### PR TITLE
Allow running emsdk_env.sh from another directory.

### DIFF
--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pushd `dirname "$_"` > /dev/null
 ./emsdk construct_env
 source ./emsdk_set_env.sh
-
+popd > /dev/null


### PR DESCRIPTION
Move into the emsdk directory before running ./emsdk. Make it possible to add `test -x $EMSCRIPTEN/emsdk_env.sh && source $EMSCRIPTEN/emsdk_env.sh` to my shell initialization script.
