### PR TITLE
Use $BASH_SOURCE to find location of emsdk_env.sh

### DIFF
--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -1,6 +1,14 @@
-#!/bin/bash
+# This script is sourced by the user and uses
+# their shell. Try not to use bashisms.
 
-pushd `dirname "$BASH_SOURCE"` > /dev/null
+SRC="$BASH_SOURCE"
+if [ "$SRC" = "" ]; then
+  SRC="$_"
+fi
+pushd `dirname "$SRC"` > /dev/null
+unset SRC
+
 ./emsdk construct_env
-source ./emsdk_set_env.sh
+. ./emsdk_set_env.sh
+
 popd > /dev/null


### PR DESCRIPTION
$_ seems to be unreliable if the first command of my shell is to source the emsdk env script.

Bash source seems to be reliable though.
