### PR TITLE
Case insensitive compare tools in Windows

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1150,6 +1150,10 @@ class Tool:
 
       # If running in embedded mode, all paths are stored dynamically relative to the emsdk root, so normalize those first.
       dot_emscripten_key = dot_emscripten[key].replace("' + emsdk_path + '", emsdk_path())
+      if WINDOWS:
+        dot_emscripten_key = dot_emscripten_key.lower()
+        value = value.lower()
+        
       if dot_emscripten_key != value:
         return False
     return True


### PR DESCRIPTION
I was having issues that sometimes invoking emsdk_env.bat did not add any activated tools to PATH or environment variables except the EMSDK. It appeared that the problem was in case sensitive comparison, e.g. after adding these two prints:

```
      # If running in embedded mode, all paths are stored dynamically relative to the emsdk root, so normalize those first.
      dot_emscripten_key = dot_emscripten[key].replace("' + emsdk_path + '", emsdk_path())
      +print('dot_emscripten_key=' + dot_emscripten_key)
      +print('value=' + value)
      if dot_emscripten_key != value:
        return False

```
I got output like:

> dot_emscripten_key='C:/sdk/emsdk/python/2.7.5.3_64bit/python.exe'
> value='c:/sdk/emsdk/python/2.7.5.3_64bit/python.exe'

Notice the different case of driver character.

A local fix for me was change command invoke from "c:\sdk\emsdk\emsdk_evn.bat" to "C:\sdk\emsdk\emsdk_evn.bat"