### PR TITLE
Fix fatal error when git shallow clone is enabled

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -489,7 +489,7 @@ def git_clone(url, dstpath):
   mkdir_p(dstpath)
   git_clone_args = []
   if GIT_CLONE_SHALLOW:
-    git_clone_args += ['--depth', '1']
+    git_clone_args += ['--depth', '1', '--no-single-branch']
   return run([GIT(), 'clone'] + git_clone_args + [url, dstpath]) == 0
 
 def git_checkout_and_pull(repo_path, branch):


### PR DESCRIPTION
Fix "error: pathspec 'incoming' did not match any file(s) known to git." error when GIT_CLONE_SHALLOW is true.

Background: http://stackoverflow.com/a/23710503/585725