### PR TITLE
Python 3 string type mismatch fix

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -189,7 +189,7 @@ def win_set_environment_variable_direct(key, value, system=True):
     win32api.RegSetValueEx(folder, key, 0, win32con.REG_EXPAND_SZ, value)
     if VERBOSE: print('Set key=' + key + ' with value ' + value + ' in registry.')
   except Exception as e:
-    if e[0] == 5 or e[2] == 'Access is denied.':
+    if e.args[0] == 5 or e.args[2] == 'Access is denied.':
       print('Error! Failed to set the environment variable \'' + key + '\'! Setting environment variables permanently requires administrator access. Please rerun this command with administrative privileges. This can be done for example by holding down the Ctrl and Shift keys while opening a command prompt in start menu.')
       sys.exit(1)
     print('Failed to write environment variable ' + key + ':', file=sys.stderr)
@@ -216,7 +216,7 @@ def win_get_environment_variable(key, system=True):
       folder = win32api.RegOpenKey(win32con.HKEY_CURRENT_USER, 'Environment')
     value = str(win32api.RegQueryValueEx(folder, key)[0])
   except Exception as e:
-    if e[0] != 2: # 'The system cannot find the file specified.'
+    if e.args[0] != 2: # 'The system cannot find the file specified.'
       print('Failed to read environment variable ' + key + ':', file=sys.stderr)
       print(str(e), file=sys.stderr)
     win32api.RegCloseKey(folder)

--- a/emsdk
+++ b/emsdk
@@ -118,14 +118,14 @@ def vswhere(version):
     # Visual Studio 2017 Express is not included in the above search, and it does not have the VC.Tools.x86.x64 tool, so do a catch-all attempt as a fallback, to detect Express version.
     if len(output) == 0:
       output = json.loads(subprocess.check_output([vswhere_path, '-latest', '-version', '[%s.0,%s.0)' % (version, version + 1), '-products', '*', '-property', 'installationPath', '-format', 'json']))
-    return output[0]['installationPath'].encode('ascii') if len(output) > 0 else ''
+    return output[0]['installationPath'] if len(output) > 0 else ''
   except Exception as e:
     return ''
 
 def vs_filewhere(installation_path, platform, file):
   try:
     vcvarsall = os.path.join(installation_path, 'VC\\Auxiliary\\Build\\vcvarsall.bat')
-    env = subprocess.check_output('cmd /c "%s" %s & where %s' % (vcvarsall, platform, file))
+    env = subprocess.check_output('cmd /c "%s" %s & where %s' % (vcvarsall, platform, file)).decode()
     paths = [path[:-len(file)] for path in env.split('\r\n') if path.endswith(file)]
     return paths[0]
   except Exception as e:
@@ -634,14 +634,14 @@ def build_env(generator):
 
   elif 'Visual Studio 15' in generator:
     path = vswhere(15)
-    build_env['VCTargetsPath'] = os.path.join(path, 'Common7\IDE\VC\VCTargets')
+    build_env['VCTargetsPath'] = str(os.path.join(path, 'Common7\IDE\VC\VCTargets'))
 
     # CMake and VS2017 cl.exe needs to have mspdb140.dll et al. in its PATH.
     vc_bin_paths = [vs_filewhere(path, 'amd64', 'cl.exe'),
                     vs_filewhere(path, 'x86', 'cl.exe')]
     for path in vc_bin_paths:
       if os.path.isdir(path):
-          build_env['PATH'] = build_env['PATH'] + ';' + path
+          build_env['PATH'] = str(build_env['PATH'] + ';' + path)
 
   elif 'Visual Studio 14' in generator or 'Visual Studio 2015' in generator:
     build_env['VCTargetsPath'] = os.path.join(os.environ['ProgramFiles(x86)'], 'MSBuild/Microsoft.Cpp/v4.0/V140')
@@ -651,7 +651,7 @@ def build_env(generator):
                     os.path.join(os.environ['ProgramFiles(x86)'], 'Microsoft Visual Studio 14.0\\VC\\bin')]
     for path in vc_bin_paths:
       if os.path.isdir(path):
-        build_env['PATH'] = build_env['PATH'] + ';' + path
+        build_env['PATH'] = str(build_env['PATH'] + ';' + path)
 
   elif 'Visual Studio 12' in generator or 'Visual Studio 2013' in generator:
     build_env['VCTargetsPath'] = os.path.join(os.environ['ProgramFiles(x86)'], 'MSBuild/Microsoft.Cpp/v4.0/V120')
@@ -706,7 +706,7 @@ def make_build(build_root, build_type, build_target_platform='x64'):
 
   if WINDOWS:
     if 'Visual Studio' in CMAKE_GENERATOR:
-      solution_name = subprocess.check_output(['dir', '/b', '*.sln'], shell=True, cwd=build_root).strip()
+      solution_name = subprocess.check_output(['dir', '/b', '*.sln'], shell=True, cwd=build_root).strip().decode()
       generator_to_use = get_generator_for_sln_file(os.path.join(build_root, solution_name))
 # Disabled for now: Don't pass /maxcpucount argument to msbuild, since it looks like when building, msbuild already automatically spawns the full amount of logical
 # cores the system has, and passing the number of logical cores here has been observed to give a quadratic N*N explosion on the number of spawned processes


### PR DESCRIPTION
Fixes `Can't mix strings and bytes in path component` error which occurs on Python 3 on Windows.