### PR TITLE
sdk-wasm-master

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -1078,9 +1078,21 @@
     "os": "win"
   },
   {
+    "version": "wasm-master",
+    "bitness": 32,
+    "uses": ["upstream-clang-master-32bit", "node-8.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-incoming-32bit", "binaryen-master-32bit"],
+    "os": "win"
+  },
+  {
     "version": "incoming",
     "bitness": 64,
     "uses": ["clang-incoming-64bit", "node-8.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
+    "os": "win"
+  },
+  {
+    "version": "wasm-master",
+    "bitness": 64,
+    "uses": ["upstream-clang-master-64bit", "node-8.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
     "os": "win"
   },
   {
@@ -1090,15 +1102,33 @@
     "os": "osx"
   },
   {
+    "version": "wasm-master",
+    "bitness": 64,
+    "uses": ["upstream-clang-master-64bit", "node-8.9.1-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
+    "os": "osx"
+  },
+  {
     "version": "incoming",
     "bitness": 32,
     "uses": ["clang-incoming-32bit", "node-8.9.1-32bit", "emscripten-incoming-32bit", "binaryen-master-32bit"],
     "os": "linux"
   },
   {
+    "version": "wasm-master",
+    "bitness": 32,
+    "uses": ["upstream-clang-master-32bit", "node-8.9.1-32bit", "emscripten-incoming-32bit", "binaryen-master-32bit"],
+    "os": "linux"
+  },
+  {
     "version": "incoming",
     "bitness": 64,
     "uses": ["clang-incoming-64bit", "node-8.9.1-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
+    "os": "linux"
+  },
+  {
+    "version": "wasm-master",
+    "bitness": 64,
+    "uses": ["upstream-clang-master-64bit", "node-8.9.1-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
     "os": "linux"
   },
   {


### PR DESCRIPTION
Add SDK definitions for upstream wasm backend enabled LLVM, "sdk-wasm-master-32/64bit".

With this, one can get going with the upstream wasm backend with

```
git clone https://github.com/emscripten-core/emsdk.git
cd emsdk
emsdk install sdk-wasm-master-64bit # Compiles llvm-mirror/llvm master branch from source
emsdk activate sdk-wasm-master-64bit
source ./emsdk_env.sh
cd emscripten/incoming
em++ tests/hello_world.c -o a.js
node a.js # runs a.wasm produced with upstream wasm backend
```

I was a bit surprised we did not have something like this already, what is the workflow that you guys have been using? @kripken @dschuff @jgravelle-google ?

Compare the above with using the traditional fastcomp based backend, which is used with:

```
git clone https://github.com/emscripten-core/emsdk.git
cd emsdk
emsdk install sdk-incoming-64bit  # Compiles emscripten-fastcomp incoming branch from source
emsdk activate sdk-incoming-64bit
source ./emsdk_env.sh
cd emscripten/incoming
em++ tests/hello_world.c -o a.js
node a.js # runs a.wasm produced with fastcomp backend
```

so the two usages work well in parallel, one can then toggle between the two by flipping `emsdk activate sdk-wasm-master-64bit` vs `emsdk activate sdk-incoming-64bit`.