### PR TITLE
Support Fish shell (emsdk_env)

### DIFF
--- a/emsdk_env.fish
+++ b/emsdk_env.fish
@@ -1,0 +1,17 @@
+#In your Fish configuration, add this line:
+#alias emsdk_setup ". /path/to/emsdk/emsdk_env.fish"
+#Now, when you want to use the SDK, run this alias first to set up
+#your environment.
+
+set -l script (status -f)
+set -l dir (dirname $script)
+
+pushd $dir > /dev/null
+
+./emsdk construct_env "$argv"
+. ./emsdk_set_env.sh
+
+set -e -l script
+set -e -l dir
+
+popd > /dev/null


### PR DESCRIPTION
Fish shell doesn't support the same syntax as most shells,
so add an emsdk_env.fish to support these users.
Instructions included in `emsdk_env.fish`.