### PR TITLE
Remove bashism in emsdk_env.sh in favor of portable alternative

### DIFF
--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -19,10 +19,11 @@ SRC="$BASH_SOURCE"
 if [ "$SRC" = "" ]; then
   SRC="$0"
 fi
-pushd `dirname "$SRC"` > /dev/null
+CURDIR=$(pwd)
+cd $(dirname "$SRC")
 unset SRC
 
 ./emsdk construct_env "$@"
 . ./emsdk_set_env.sh
 
-popd > /dev/null
+cd $CURDIR


### PR DESCRIPTION
Fixes #219 

I also replaced the backticks with `$()` because they're the modern POSIX standard and look moderately prettier. I'm fine changing it back.