### PR TITLE
Add the lkgr as a prefix to upstream downloads

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1395,7 +1395,8 @@ class Tool:
         success = git_clone_checkout_and_pull(url, self.installation_path(), self.git_branch)
       elif url.endswith('zip') or url.endswith('.tar') or url.endswith('.gz') or url.endswith('.xz') or url.endswith('.tbz2'):
         download_even_if_exists = (self.id == 'vs-tool')
-        success = download_and_unzip(url, self.installation_path(), download_even_if_exists, filename_prefix=self.zipfile_prefix if hasattr(self, 'zipfile_prefix') else '')
+        filename_prefix = self.zipfile_prefix if hasattr(self, 'zipfile_prefix') else ''
+        success = download_and_unzip(url, self.installation_path(), download_even_if_exists, filename_prefix=filename_prefix)
       else:
         dst_file = download_file(urljoin(emsdk_packages_url, self.download_url()), self.installation_path())
         if dst_file: success = True

--- a/emsdk
+++ b/emsdk
@@ -1395,7 +1395,7 @@ class Tool:
         success = git_clone_checkout_and_pull(url, self.installation_path(), self.git_branch)
       elif url.endswith('zip') or url.endswith('.tar') or url.endswith('.gz') or url.endswith('.xz') or url.endswith('.tbz2'):
         download_even_if_exists = (self.id == 'vs-tool')
-        filename_prefix = self.zipfile_prefix if hasattr(self, 'zipfile_prefix') else ''
+        filename_prefix = getattr(self, 'zipfile_prefix', '')
         success = download_and_unzip(url, self.installation_path(), download_even_if_exists=download_even_if_exists, filename_prefix=filename_prefix)
       else:
         dst_file = download_file(urljoin(emsdk_packages_url, self.download_url()), self.installation_path())

--- a/emsdk
+++ b/emsdk
@@ -1396,7 +1396,7 @@ class Tool:
       elif url.endswith('zip') or url.endswith('.tar') or url.endswith('.gz') or url.endswith('.xz') or url.endswith('.tbz2'):
         download_even_if_exists = (self.id == 'vs-tool')
         filename_prefix = self.zipfile_prefix if hasattr(self, 'zipfile_prefix') else ''
-        success = download_and_unzip(url, self.installation_path(), download_even_if_exists, filename_prefix=filename_prefix)
+        success = download_and_unzip(url, self.installation_path(), download_even_if_exists=download_even_if_exists, filename_prefix=filename_prefix)
       else:
         dst_file = download_file(urljoin(emsdk_packages_url, self.download_url()), self.installation_path())
         if dst_file: success = True

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -195,6 +195,7 @@
     "version": "upstream-%waterfall-lkgr%",
     "bitness": 64,
     "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
+    "zipfile_prefix": "%waterfall-lkgr%-",
     "install_path": "upstream/%waterfall-lkgr%",
     "activated_path": "%installation_dir%/emscripten",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT='%installation_dir%'"
@@ -204,6 +205,7 @@
     "version": "fastcomp-%waterfall-lkgr%",
     "bitness": 64,
     "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
+    "zipfile_prefix": "%waterfall-lkgr%-",
     "install_path": "fastcomp/%waterfall-lkgr%",
     "activated_path": "%installation_dir%/emscripten",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/fastcomp/bin';BINARYEN_ROOT='%installation_dir%'"


### PR DESCRIPTION
Without this, we would not download new versions, as the filename looked the same ("already downloaded"). We'd unzip those old contents to a directory with the new name, giving the impression we updated when we didn't :(