### PR TITLE
Remove sudo from travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: python
 
 services:


### PR DESCRIPTION
In theory this should speed it up a little.  I suppose it was
initially added because we use docker but it doesn't seem that is
requirement here.