### PR TITLE
Fix bug introduced in #220

### DIFF
--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -19,11 +19,11 @@ SRC="$BASH_SOURCE"
 if [ "$SRC" = "" ]; then
   SRC="$0"
 fi
-CURDIR=$(pwd)
-cd $(dirname "$SRC")
+CURDIR="$(pwd)"
+cd "$(dirname "$SRC")"
 unset SRC
 
 ./emsdk construct_env "$@"
 . ./emsdk_set_env.sh
 
-cd $CURDIR
+cd "$CURDIR"


### PR DESCRIPTION
It seems that some variables were mistakenly left unquoted, leading to paths containing spaces being treated incorrectly.

For example, the directory `/home/person/foo bar/test/` would cause `CURDIR=$(pwd)` to be expanded to `CURDIR=/home/person/foo bar/test/`. This means that the shell would attempt to run the command `bar/test/` with the environment variable `CURDIR` set to `/home/person/foo`. This is due to [word splitting](https://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html). TL;DR the result of shell expansions should probably be quoted 99% of the time to be extra safe/compatible with spaces. (I say 99% because there are rare exceptions such as `"$@"` and running the contents of a variable)