### PR TITLE
Restore lkgr.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ llvm-nightlies-64bit.txt
 llvm-tags-32bit.txt
 llvm-tags-64bit.txt
 upstream
-!upstream/lkgr.json

--- a/upstream/lkgr.json
+++ b/upstream/lkgr.json
@@ -1,0 +1,94 @@
+{
+  "repositories": {
+    "java": null, 
+    "gcc": {
+      "remote": "https://chromium.googlesource.com/chromiumos/third_party/gcc.git", 
+      "subject": "[GCC] Fix compile time error introduced by PR64111 (GCC FSF).", 
+      "hash": "b6125c702850488ac3bfb1079ae5c9db89989406", 
+      "name": "Caroline Tice", 
+      "email": "cmtice@google.com"
+    }, 
+    "llvm": {
+      "remote": "https://github.com/llvm/llvm-project.git", 
+      "subject": "[COFF] Remove finalizeContents virtual method from Chunk, NFC", 
+      "hash": "11c141eb68531eec30af8ff8f82b8159de99e555", 
+      "name": "Reid Kleckner", 
+      "email": "rnk@google.com"
+    }, 
+    "emscripten": {
+      "remote": "https://github.com/emscripten-core/emscripten.git", 
+      "subject": "Add assertions for duplicate names from parameterization (#8665)", 
+      "hash": "f6df93be62459edaecf38e3986a96118be8ace94", 
+      "name": "Guanzhong Chen", 
+      "email": "gzchen@google.com"
+    }, 
+    "nodejs": null, 
+    "llvm-test-suite": {
+      "remote": "https://llvm.googlesource.com/test-suite.git", 
+      "subject": "Document how to use the 'vs' mode in compare.py", 
+      "hash": "c79e9b9f75512e75c3241b08ec78f78d8fc710af", 
+      "name": "Amara Emerson", 
+      "email": "aemerson@apple.com"
+    }, 
+    "host-toolchain": {
+      "remote": "https://chromium.googlesource.com/v8/v8.git", 
+      "subject": "Revert \"Reland \"[torque] move class tests to unittests\"\"", 
+      "hash": "0ef1982ff57d1b5db66d4e4354193f4aee543d13", 
+      "name": "Francis McCabe", 
+      "email": "fgm@chromium.org"
+    }, 
+    "waterfall": {
+      "remote": "/b/swarming/w/ir/cache/git/chromium.googlesource.com-external-github.com-webassembly-waterfall", 
+      "subject": "Print reason for clobbering build (#528)", 
+      "hash": "02d964670cedc2e43f38151e8fbbc69a167187d8", 
+      "name": "Derek Schuff", 
+      "email": "dschuff@chromium.org"
+    }, 
+    "fastcomp-clang": {
+      "remote": "https://github.com/emscripten-core/emscripten-fastcomp-clang.git", 
+      "subject": "1.38.32", 
+      "hash": "ca75f5e8a424747b1e368ad6e94a4b4740dd28af", 
+      "name": "Alon Zakai", 
+      "email": "azakai@google.com"
+    }, 
+    "binaryen": {
+      "remote": "https://chromium.googlesource.com/external/github.com/WebAssembly/binaryen.git", 
+      "subject": "Inlining: exposed inlining thresholds as command-line parameters. (#2125)", 
+      "hash": "5644d15b87577478659d7cbeb9bb0555cc233631", 
+      "name": "Wouter van Oortmerssen", 
+      "email": "aardappel@gmail.com"
+    }, 
+    "fastcomp": {
+      "remote": "https://github.com/emscripten-core/emscripten-fastcomp.git", 
+      "subject": "1.38.32", 
+      "hash": "2be857f52bb377de8cf7369acfc42a3b36bbd94d", 
+      "name": "Alon Zakai", 
+      "email": "azakai@google.com"
+    }, 
+    "v8": {
+      "remote": "https://chromium.googlesource.com/v8/v8.git", 
+      "subject": "Revert \"Reland \"[torque] move class tests to unittests\"\"", 
+      "hash": "0ef1982ff57d1b5db66d4e4354193f4aee543d13", 
+      "name": "Francis McCabe", 
+      "email": "fgm@chromium.org"
+    }, 
+    "cmake": null, 
+    "wabt": {
+      "remote": "https://chromium.googlesource.com/external/github.com/WebAssembly/wabt.git", 
+      "subject": "[wasm-objdump] Fix crash on invalid reloc sections (#1084)", 
+      "hash": "a3a7a93f1f417c6c258e6b5d507adb004fc8b688", 
+      "name": "Sam Clegg", 
+      "email": "sbc@chromium.org"
+    }, 
+    "wasi-sysroot": {
+      "remote": "https://github.com/CraneStation/wasi-sysroot.git", 
+      "subject": "Don't declare popen and pclose.", 
+      "hash": "eee6ee7566e26f2535eb6088c8494a112ff423b9", 
+      "name": "Dan Gohman", 
+      "email": "sunfish@mozilla.com"
+    }, 
+    "gnuwin32": null
+  }, 
+  "build": "6480", 
+  "scheduler": null
+}


### PR DESCRIPTION
It was removed to try to unbreak the old buildbots. That only partially worked, but in any case at this point we are starting to get builds on the new ones, so we don't need that workaround. And restoring it avoids an annoying warning that people are seeing.