### PR TITLE
Remove waterfall integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && python -c "import os ; assert open(os.path.expanduser('~/.emscripten')).read().count('LLVM_ROOT') == 1" \
- && python -c "import os ; assert 'upstream' in open(os.path.expanduser('~/.emscripten')).read()" \
  && emcc hello_world.cpp -s WASM=0 \
  && emcc --clear-cache \
  && echo "test latest-releases-upstream" \
@@ -24,6 +22,8 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate latest-releases-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
+ && python -c "import os ; assert open(os.path.expanduser('~/.emscripten')).read().count('LLVM_ROOT') == 1" \
+ && python -c "import os ; assert 'upstream' in open(os.path.expanduser('~/.emscripten')).read()" \
  && echo "test latest-releases-fastcomp" \
  && python3 /root/emsdk/emsdk install latest-releases-fastcomp \
  && /root/emsdk/emsdk activate latest-releases-fastcomp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,8 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && echo "test upstream (waterfall)" \
- && /root/emsdk/emsdk install latest-upstream \
- && /root/emsdk/emsdk activate latest-upstream \
- && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
  && python -c "import os ; assert open(os.path.expanduser('~/.emscripten')).read().count('LLVM_ROOT') == 1" \
  && python -c "import os ; assert 'upstream' in open(os.path.expanduser('~/.emscripten')).read()" \
- && echo "test fastcomp (waterfall)" \
- && /root/emsdk/emsdk install latest-fastcomp \
- && /root/emsdk/emsdk activate latest-fastcomp \
- && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
  && emcc hello_world.cpp -s WASM=0 \
  && emcc --clear-cache \
  && echo "test latest-releases-upstream" \

--- a/emsdk
+++ b/emsdk
@@ -1687,14 +1687,6 @@ def find_latest_nightly_sdk():
     return find_latest_nightly_32bit_sdk()
 
 
-def find_latest_waterfall_sdk(which):
-  waterfall_lkgr = load_waterfall_lkgr()
-  if not waterfall_lkgr:
-    print('Failed to find an upstream lkgr')
-    sys.exit(1)
-  return 'sdk-waterfall-%s-%s-64bit' % (which, waterfall_lkgr[0])
-
-
 def find_latest_releases_sdk(which):
   releases_info = load_releases_info()
   latest = releases_info['latest']
@@ -1833,7 +1825,6 @@ def fetch_emscripten_tags():
   print('Fetching all precompiled tagged releases..')
   download_file('https://s3.amazonaws.com/mozilla-games/emscripten/packages/llvm/tag/' + os_name() + '_32bit/index.txt', 'llvm-tags-32bit.txt', download_even_if_exists=True)
   download_file('https://s3.amazonaws.com/mozilla-games/emscripten/packages/llvm/tag/' + os_name() + '_64bit/index.txt', 'llvm-tags-64bit.txt', download_even_if_exists=True)
-  download_waterfall_lkgr()
 
   if not git:
     print('Update complete, however skipped fetching the Emscripten tags, since git was not found.')
@@ -1929,23 +1920,6 @@ def load_llvm_precompiled_tags_64bit():
   return load_file_index_list('llvm-tags-64bit.txt')
 
 
-def download_waterfall_lkgr():
-  lkgr_url = 'https://storage.googleapis.com/wasm-llvm/builds/%s/lkgr.json' % os_name()
-  download_file(lkgr_url, 'upstream', download_even_if_exists=True)
-
-
-def load_waterfall_lkgr():
-  try:
-    text = open(sdk_path(os.path.join('upstream', 'lkgr.json')), 'r').read()
-    data = json.loads(text)
-    lkgr = data['build']
-    return [lkgr]
-  except Exception as e:
-    print('Error parsing lkgr.json!')
-    print(str(e))
-    return []
-
-
 # Load the json info for emscripten-releases.
 def load_releases_info():
   try:
@@ -1992,7 +1966,6 @@ def load_sdk_manifest():
   llvm_32bit_nightlies = list(reversed(load_llvm_32bit_nightlies()))
   llvm_64bit_nightlies = list(reversed(load_llvm_64bit_nightlies()))
   emscripten_nightlies = list(reversed(load_emscripten_nightlies()))
-  waterfall_lkgr = load_waterfall_lkgr()
   releases_tags = load_releases_tags()
 
   def dependencies_exist(sdk):
@@ -2064,7 +2037,6 @@ def load_sdk_manifest():
       elif '%nightly-llvm-64bit%' in t.version: expand_category_param('%nightly-llvm-64bit%', llvm_64bit_nightlies, t, is_sdk=False)
       elif '%nightly-llvm-32bit%' in t.version: expand_category_param('%nightly-llvm-32bit%', llvm_32bit_nightlies, t, is_sdk=False)
       elif '%nightly-emscripten%' in t.version: expand_category_param('%nightly-emscripten%', emscripten_nightlies, t, is_sdk=False)
-      elif '%waterfall-lkgr%' in t.version: expand_category_param('%waterfall-lkgr%', waterfall_lkgr, t, is_sdk=False)
       elif '%releases-tag%' in t.version: expand_category_param('%releases-tag%', releases_tags, t, is_sdk=False)
       else:
         add_tool(t)
@@ -2083,7 +2055,6 @@ def load_sdk_manifest():
       elif '%nightly-llvm-64bit%' in sdk.version: expand_category_param('%nightly-llvm-64bit%', llvm_64bit_nightlies, sdk, is_sdk=True)
       elif '%nightly-llvm-32bit%' in sdk.version: expand_category_param('%nightly-llvm-32bit%', llvm_32bit_nightlies, sdk, is_sdk=True)
       elif '%nightly-emscripten%' in sdk.version: expand_category_param('%nightly-emscripten%', emscripten_nightlies, sdk, is_sdk=True)
-      elif '%waterfall-lkgr%' in sdk.version: expand_category_param('%waterfall-lkgr%', waterfall_lkgr, sdk, is_sdk=True)
       elif '%releases-tag%' in sdk.version: expand_category_param('%releases-tag%', releases_tags, sdk, is_sdk=True)
       else:
         add_sdk(sdk)

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -190,26 +190,6 @@
     "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
-  {
-    "id": "waterfall",
-    "version": "upstream-%waterfall-lkgr%",
-    "bitness": 64,
-    "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
-    "zipfile_prefix": "%waterfall-lkgr%-",
-    "install_path": "upstream/%waterfall-lkgr%",
-    "activated_path": "%installation_dir%/emscripten",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT='%installation_dir%'"
-  },
-  {
-    "id": "waterfall",
-    "version": "fastcomp-%waterfall-lkgr%",
-    "bitness": 64,
-    "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
-    "zipfile_prefix": "%waterfall-lkgr%-",
-    "install_path": "fastcomp/%waterfall-lkgr%",
-    "activated_path": "%installation_dir%/emscripten",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%/fastcomp/bin';BINARYEN_ROOT='%installation_dir%'"
-  },
 
   {
     "id": "releases",
@@ -1611,18 +1591,6 @@
     "bitness": 64,
     "uses": ["clang-e1.37.1-64bit", "node-4.1.1-64bit", "python-2.7.13.1-64bit", "emscripten-1.37.1"],
     "os": "win"
-  },
-  {
-    "version": "waterfall-upstream-%waterfall-lkgr%",
-    "bitness": 64,
-    "uses": ["waterfall-upstream-%waterfall-lkgr%-64bit", "node-8.9.1-64bit"],
-    "os": "linux"
-  },
-  {
-    "version": "waterfall-fastcomp-%waterfall-lkgr%",
-    "bitness": 64,
-    "uses": ["waterfall-fastcomp-%waterfall-lkgr%-64bit", "node-8.9.1-64bit"],
-    "os": "linux"
   },
   {
     "version": "releases-upstream-%releases-tag%",


### PR DESCRIPTION
We can remove this now that we have emscripten-releases working and use it everywhere we used the emsdk's waterfall integration.

In particular this should fix the current lkgr.json errors people are seeing (by removing all the lkgr stuff), which I believe started when I refactored that code while doing the releases work - I must have gotten something wrong on non-linux OSes. But anyhow, easier to remove that unnecessary code than fix it at this point.