### PR TITLE
Add a show-activated-paths option, which prints out the activated paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ RUN cd /root/ \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
  && echo "test show-activated-paths" \
- && ./emsdk show-activated-paths | grep emscripten > a.tmp \
- && ./emsdk show-activated-paths tot-fastcomp | grep emscripten > b.tmp \
+ && /root/emsdk/emsdk show-activated-paths | grep emscripten > a.tmp \
+ && /root/emsdk/emsdk show-activated-paths tot-fastcomp | grep emscripten > b.tmp \
  && diff a.tmp b.tmp \
  && echo "test binaryen source build" \
  && /root/emsdk/emsdk install --build=Release binaryen-master-64bit

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,9 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate tot-fastcomp \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
+ && echo "test show-activated-paths" \
+ && ./emsdk show-activated-paths | grep emscripten > a.tmp \
+ && ./emsdk show-activated-paths tot-fastcomp | grep emscripten > b.tmp \
+ && diff a.tmp b.tmp \
  && echo "test binaryen source build" \
  && /root/emsdk/emsdk install --build=Release binaryen-master-64bit

--- a/emsdk
+++ b/emsdk
@@ -2182,6 +2182,23 @@ def currently_active_tools():
   return active_tools
 
 
+# Get the list of tools to activate, that includes both already active
+# as well as specified to be activated from a command in the form of
+#   emsdk [install|activate|etc.] tool1 tool2 [--optional-flag-to-ignore]
+def get_tools_to_activate():
+  tools_to_activate = currently_active_tools()
+  argv = [x for x in sys.argv if not x.startswith('--')]
+  for i in range(2, len(argv)):
+    tool = find_tool(argv[i])
+    if tool is None:
+      tool = find_sdk(argv[i])
+    if tool is None:
+      print("Error: No tool or SDK found by name '" + argv[i] + "'.")
+      sys.exit(1)
+    tools_to_activate += [tool]
+  return tools_to_activate
+
+
 # http://stackoverflow.com/questions/480214/how-do-you-remove-duplicates-from-a-list-in-python-whilst-preserving-order
 def unique_items(seq):
   seen = set()
@@ -2480,7 +2497,7 @@ def main():
   sys.argv = [x for x in sys.argv if not len(x) == 0]
 
   # Replace meta-packages with the real package names.
-  if (cmd == 'update' or cmd == 'install' or cmd == 'activate'):
+  if cmd in ('update', 'install', 'activate', 'show-activated-paths'):
     for i in range(2, len(sys.argv)):
       if sys.argv[i] == 'latest' or sys.argv[i] == 'sdk-latest':
         sys.argv[i] = str(find_latest_sdk())
@@ -2620,15 +2637,7 @@ def main():
 
     sys.argv = [x for x in sys.argv if not x.startswith('--')]
 
-    tools_to_activate = currently_active_tools()
-    for i in range(2, len(sys.argv)):
-      tool = find_tool(sys.argv[i])
-      if tool is None:
-        tool = find_sdk(sys.argv[i])
-      if tool is None:
-        print("Error: No tool or SDK found by name '" + sys.argv[i] + "'.")
-        return 1
-      tools_to_activate += [tool]
+    tools_to_activate = get_tools_to_activate()
     if len(tools_to_activate) == 0:
       print('No tools/SDKs specified to activate! Usage:\n   emsdk activate tool/sdk1 [tool/sdk2] [...]')
       return 1
@@ -2691,6 +2700,14 @@ def main():
       print("Error: Tool by name '" + sys.argv[2] + "' was not found.")
       return 1
     tool.uninstall()
+  elif cmd == 'show-activated-paths':
+    sys.argv = [x for x in sys.argv if not x.startswith('--')]
+    tools_to_activate = get_tools_to_activate()
+    tools_to_activate = process_tool_list(tools_to_activate)
+    for tool in tools_to_activate:
+      if hasattr(tool, 'activated_path'):
+        print(tool.expand_vars(tool.activated_path))
+    return 0
   else:
     print("Unknown command '" + cmd + "' given! Type 'emsdk help' to get a list of commands.")
     return 1


### PR DESCRIPTION
This came up as possibly useful for emsdk users that want to set up their own .emscripten file, so they need to know which dir the code is under. With the emscripten-releases system, currently each download gets its own directory, so it changes over time. (It's a new dir each time to make it easy to switch between builds back and forth, and also it lets us not unzip a download that was already downloaded.)

Example output:
```
$./emsdk show-activated-paths
/home/.../sdk/upstream/c7784483727437237472347/emscripten
/home/../sdk/node/../bin
```

By default the emsdk downloads node.js as well, so there are two activated tools, and so two paths.

Alternatively, perhaps we can fix this by reusing the same directory.  That might be better, come to think of it, as otherwise each update creates a new one and they aren't small, so if a user isn't careful over a year there can be a lot of disk usage that accumulates?
