### PR TITLE
Change default emsdk download location to emscripten-releases/deps

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -33,11 +33,11 @@ EMSDK_DEV = bool(os.getenv('EMSDK_DEV')) if os.getenv('EMSDK_DEV') is not None e
 
 if EMSDK_DEV:
   print('EMSDK_DEV active.')
-  emsdk_master_server = 'http://clb.demon.fi/emscripten_dev/'
+  emsdk_master_server = 'http://clb.demon.fi/emscripten_dev/packages/'
 else:
   emsdk_master_server = 'https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/'
 
-emsdk_packages_url = urljoin(emsdk_master_server, 'packages/')
+emsdk_packages_url = emsdk_master_server
 
 emscripten_git_repo = 'https://github.com/kripken/emscripten.git'
 binaryen_git_repo = 'https://github.com/WebAssembly/binaryen.git'

--- a/emsdk
+++ b/emsdk
@@ -35,7 +35,7 @@ if EMSDK_DEV:
   print('EMSDK_DEV active.')
   emsdk_master_server = 'http://clb.demon.fi/emscripten_dev/'
 else:
-  emsdk_master_server = 'https://s3.amazonaws.com/mozilla-games/emscripten/'
+  emsdk_master_server = 'https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/'
 
 emsdk_packages_url = urljoin(emsdk_master_server, 'packages/')
 

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -469,8 +469,8 @@
     "version": "8.9.1",
     "bitness": 64,
     "osx_url": "node-v8.9.1-darwin-x64.tar.gz",
-    "windows_url": "node-v8.9.1-win-x64.zip",
-    "linux_url": "node-v8.9.1-linux-x64.tar.xz",
+    "windows_url": "node-v8.9.1-win-x86.zip",
+    "linux_url": "node-v8.9.1-linux-x86.tar.xz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -468,9 +468,9 @@
     "id": "node",
     "version": "8.9.1",
     "bitness": 64,
-    "osx_url": "node-v8.9.1-darwin-x64.tar.gz",
-    "windows_url": "node-v8.9.1-win-x64.zip",
-    "linux_url": "node-v8.9.1-linux-x64.tar.xz",
+    "osx_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v8.9.1-darwin-x64.tar.gz",
+    "windows_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v8.9.1-win-x64.zip",
+    "linux_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v8.9.1-linux-x64.tar.xz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
@@ -528,28 +528,10 @@
     "id": "python",
     "version": "2.7.13.1",
     "bitness": 64,
-    "windows_url": "WinPython-64bit-2.7.13.1Zero.zip",
+    "windows_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/WinPython-64bit-2.7.13.1Zero.zip",
     "activated_path": "%installation_dir%/python-2.7.13.amd64",
     "activated_cfg": "PYTHON='%installation_dir%/python-2.7.13.amd64/python%.exe%'",
     "activated_env": "EMSDK_PYTHON=%installation_dir%/python-2.7.13.amd64/python%.exe%"
-  },
-  {
-    "id": "python",
-    "version": "3.5.4",
-    "bitness": 32,
-    "windows_url": "WinPython-32bit-3.5.4.1Zero.zip",
-    "activated_path": "%installation_dir%/python-3.5.4",
-    "activated_cfg": "PYTHON='%installation_dir%/python-3.5.4/python%.exe%'",
-    "activated_env": "EMSDK_PYTHON=%installation_dir%/python-3.5.4/python%.exe%"
-  },
-  {
-    "id": "python",
-    "version": "3.5.4",
-    "bitness": 64,
-    "windows_url": "WinPython-64bit-3.5.4.1Zero.zip",
-    "activated_path": "%installation_dir%/python-3.5.4.amd64",
-    "activated_cfg": "PYTHON='%installation_dir%/python-3.5.4.amd64/python%.exe%'",
-    "activated_env": "EMSDK_PYTHON=%installation_dir%/python-3.5.4.amd64/python%.exe%"
   },
   {
     "id": "java",
@@ -582,7 +564,7 @@
     "id": "java",
     "version": "8.152",
     "bitness": 64,
-    "windows_url": "portable_jre_8_update_152_64bit.zip",
+    "windows_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/portable_jre_8_update_152_64bit.zip",
     "activated_path": "%installation_dir%/bin",
     "activated_env": "JAVA_HOME=%installation_dir%",
     "activated_cfg": "JAVA='%installation_dir%/bin/java%.exe%'"

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -468,9 +468,9 @@
     "id": "node",
     "version": "8.9.1",
     "bitness": 64,
-    "osx_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v8.9.1-darwin-x64.tar.gz",
-    "windows_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v8.9.1-win-x64.zip",
-    "linux_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v8.9.1-linux-x64.tar.xz",
+    "osx_url": "node-v8.9.1-darwin-x64.tar.gz",
+    "windows_url": "node-v8.9.1-win-x64.zip",
+    "linux_url": "node-v8.9.1-linux-x64.tar.xz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
@@ -528,10 +528,28 @@
     "id": "python",
     "version": "2.7.13.1",
     "bitness": 64,
-    "windows_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/WinPython-64bit-2.7.13.1Zero.zip",
+    "windows_url": "WinPython-64bit-2.7.13.1Zero.zip",
     "activated_path": "%installation_dir%/python-2.7.13.amd64",
     "activated_cfg": "PYTHON='%installation_dir%/python-2.7.13.amd64/python%.exe%'",
     "activated_env": "EMSDK_PYTHON=%installation_dir%/python-2.7.13.amd64/python%.exe%"
+  },
+  {
+    "id": "python",
+    "version": "3.5.4",
+    "bitness": 32,
+    "windows_url": "WinPython-32bit-3.5.4.1Zero.zip",
+    "activated_path": "%installation_dir%/python-3.5.4",
+    "activated_cfg": "PYTHON='%installation_dir%/python-3.5.4/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python-3.5.4/python%.exe%"
+  },
+  {
+    "id": "python",
+    "version": "3.5.4",
+    "bitness": 64,
+    "windows_url": "WinPython-64bit-3.5.4.1Zero.zip",
+    "activated_path": "%installation_dir%/python-3.5.4.amd64",
+    "activated_cfg": "PYTHON='%installation_dir%/python-3.5.4.amd64/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python-3.5.4.amd64/python%.exe%"
   },
   {
     "id": "java",
@@ -564,7 +582,7 @@
     "id": "java",
     "version": "8.152",
     "bitness": 64,
-    "windows_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/portable_jre_8_update_152_64bit.zip",
+    "windows_url": "portable_jre_8_update_152_64bit.zip",
     "activated_path": "%installation_dir%/bin",
     "activated_env": "JAVA_HOME=%installation_dir%",
     "activated_cfg": "JAVA='%installation_dir%/bin/java%.exe%'"

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -469,8 +469,8 @@
     "version": "8.9.1",
     "bitness": 64,
     "osx_url": "node-v8.9.1-darwin-x64.tar.gz",
-    "windows_url": "node-v8.9.1-win-x86.zip",
-    "linux_url": "node-v8.9.1-linux-x86.tar.xz",
+    "windows_url": "node-v8.9.1-win-x64.zip",
+    "linux_url": "node-v8.9.1-linux-x64.tar.xz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -362,9 +362,9 @@
     "id": "clang",
     "version": "e%precompiled_tag64%",
     "bitness": 64,
-    "windows_url": "llvm/tag/win_64bit/emscripten-llvm-e%precompiled_tag64%.zip",
-    "osx_url": "llvm/tag/osx_64bit/emscripten-llvm-e%precompiled_tag64%.tar.gz",
-    "linux_url": "llvm/tag/linux_64bit/emscripten-llvm-e%precompiled_tag64%.tar.gz",
+    "windows_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/old/win/emscripten-llvm-e%precompiled_tag64%.zip",
+    "osx_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/old/mac/emscripten-llvm-e%precompiled_tag64%.tar.gz",
+    "linux_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/old/linux/emscripten-llvm-e%precompiled_tag64%.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
     "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen"


### PR DESCRIPTION
Instead of from mozilla S3.

This should make the core python, java, node downloads work, as we have mirrored them to the new location. I think that should be everything - if we missed something, we will get an error, and so know we need to fix something.

(The non-deps downloads still use a full url to emscripten-releases in the manifest, which is not changed here.)