### PR TITLE
Support ninja build tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /root/emsdk/
 RUN cd /root/ \
  && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
- && apt-get install -y python python3 cmake build-essential openjdk-9-jre-headless \
+ && apt-get install -y python python3 cmake ninja-build build-essential openjdk-9-jre-headless \
  && /root/emsdk/emsdk update-tags \
  && cd /root/emsdk/ \
  && bash test.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /root/emsdk/
 RUN cd /root/ \
  && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
- && apt-get install -y python python3 cmake ninja-build build-essential openjdk-9-jre-headless \
+ && apt-get install -y python python3 cmake build-essential openjdk-9-jre-headless \
  && /root/emsdk/emsdk update-tags \
  && cd /root/emsdk/ \
  && bash test.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,3 @@ RUN cd /root/ \
  && cd /root/emsdk/ \
  && bash test.sh \
  && python test.py
-

--- a/emsdk
+++ b/emsdk
@@ -176,7 +176,8 @@ def vs_filewhere(installation_path, platform, file):
     return ''
 
 
-CMAKE_GENERATOR = 'Unix Makefiles'
+# Use ninja build tool if present
+CMAKE_GENERATOR = 'Ninja' if which('ninja') is not None else 'Unix Makefiles'
 if WINDOWS:
   # Detect which CMake generator to use when building on Windows
   if '--mingw' in sys.argv: CMAKE_GENERATOR = 'MinGW Makefiles'
@@ -870,7 +871,7 @@ def make_build(build_root, build_type, build_target_platform='x64'):
     else:
       make = ['mingw32-make', '-j' + str(CPU_CORES)]
   else:
-    make = ['make', '-j' + str(CPU_CORES)]
+    make = ['cmake', '--build', '.', '--', '-j' + str(CPU_CORES)]
 
   # Build
   try:

--- a/emsdk
+++ b/emsdk
@@ -176,8 +176,7 @@ def vs_filewhere(installation_path, platform, file):
     return ''
 
 
-# Use ninja build tool if present
-CMAKE_GENERATOR = 'Ninja' if which('ninja') is not None else 'Unix Makefiles'
+CMAKE_GENERATOR = 'Unix Makefiles'
 if WINDOWS:
   # Detect which CMake generator to use when building on Windows
   if '--mingw' in sys.argv: CMAKE_GENERATOR = 'MinGW Makefiles'
@@ -197,8 +196,6 @@ if WINDOWS:
     else: CMAKE_GENERATOR = '' # No detected generator
 
 
-if VERBOSE:
-  print('CMAKE_GENERATOR: ' + CMAKE_GENERATOR)
 sys.argv = list(filter(lambda x: x not in ['--mingw', '--vs2013', '--vs2015', '--vs2017'], sys.argv))
 
 
@@ -2329,6 +2326,14 @@ def main():
                                   'Release' for LLVM master branch, and
                                   'RelWithDebInfo' for LLVM incoming branch.
 
+              --generator=<type>: Specifies the CMake Generator to be used
+                                  during the build. Possible values are the
+                                  same as what your CMake supports and whether
+                                  the generator is valid depends on the tools
+                                  you have installed. Defaults to 'Unix Makefiles'
+                                  on *nix systems. If generator name is multiple
+                                  words, enclose with single or double quotes.
+
                        --shallow: When installing tools from one of the git
                                   development branches 'master' or 'incoming',
                                   this parameter can be passed to perform a
@@ -2435,7 +2440,16 @@ def main():
 
   # Process global args
   for i in range(2, len(sys.argv)):
-    if sys.argv[i].startswith('--build='):
+    if sys.argv[i].startswith('--generator='):
+      build_generator = re.match(r'''^--generator=['"]?([^'"]+)['"]?$''', sys.argv[i])
+      if build_generator:
+        global CMAKE_GENERATOR
+        CMAKE_GENERATOR = build_generator.group(1)
+        sys.argv[i] = ''
+      else:
+        print("Cannot parse CMake generator string: " + sys.argv[i] + ". Try wrapping generator string with quotes", file=sys.stderr)
+        return 1
+    elif sys.argv[i].startswith('--build='):
       build_type = re.match(r'^--build=(.+)$', sys.argv[i])
       if build_type:
         global CMAKE_BUILD_TYPE_OVERRIDE

--- a/test.py
+++ b/test.py
@@ -134,7 +134,7 @@ check_call('./emsdk install sdk-tag-1.38.33-64bit')
 check_call('./emsdk activate sdk-tag-1.38.33-64bit')
 
 print('test binaryen source build')
-check_call('./emsdk install --build=Release binaryen-master-64bit')
+check_call('./emsdk install --build=Release --generator=Ninja binaryen-master-64bit')
 
 print('test 32-bit error')
 

--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -13,7 +14,7 @@ def listify(x):
   return [x]
 
 def check_call(cmd):
-  subprocess.check_call(cmd.split(' '))
+  subprocess.check_call(shlex.split(cmd))
 
 def checked_call_with_output(cmd, expected=None, unexpected=None, stderr=None):
   stdout = subprocess.check_output(cmd.split(' '), stderr=stderr)

--- a/test.py
+++ b/test.py
@@ -134,7 +134,7 @@ check_call('./emsdk install sdk-tag-1.38.33-64bit')
 check_call('./emsdk activate sdk-tag-1.38.33-64bit')
 
 print('test binaryen source build')
-check_call('./emsdk install --build=Release --generator=Ninja binaryen-master-64bit')
+check_call('./emsdk install --build=Release --generator="Unix Makefiles" binaryen-master-64bit')
 
 print('test 32-bit error')
 


### PR DESCRIPTION
~~Will only use `ninja` if it is on the path, otherwise uses Makefiles.~~

The user can choose which CMake generator to use by passing the `--generator` option, e.g. `--generator=Ninja` or `--generator="Unix Makefiles"` to `emsdk`.  

Default on *nix systems is `Unix Makefiles`