### PR TITLE
Refactor test code into python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cd /root/ \
  && apt-get update \
  && apt-get install -y python python3 cmake build-essential openjdk-9-jre-headless \
  && /root/emsdk/emsdk update-tags \
- && echo "test the standard workflow a user would do" \
+ && echo "test the standard workflow (as close as possible to how a user would do it, in the shell)" \
  && /root/emsdk/emsdk install latest \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,43 +10,14 @@ RUN cd /root/ \
  && apt-get update \
  && apt-get install -y python python3 cmake build-essential openjdk-9-jre-headless \
  && /root/emsdk/emsdk update-tags \
- && echo "test latest" \
+ && echo "test the standard workflow a user would do" \
  && /root/emsdk/emsdk install latest \
  && /root/emsdk/emsdk activate latest \
- && python -c "import os ; assert 'fastcomp' in open(os.path.expanduser('~/.emscripten')).read()" \
- && python -c "import os ; assert 'upstream' not in open(os.path.expanduser('~/.emscripten')).read()" \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
  && emcc hello_world.cpp -s WASM=0 \
  && emcc --clear-cache \
- && echo "test latest-releases-upstream" \
- && python2 /root/emsdk/emsdk install latest-upstream \
- && /root/emsdk/emsdk activate latest-upstream \
- && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
- && python -c "import os ; assert open(os.path.expanduser('~/.emscripten')).read().count('LLVM_ROOT') == 1" \
- && python -c "import os ; assert 'upstream' in open(os.path.expanduser('~/.emscripten')).read()" \
- && python -c "import os ; assert 'fastcomp' not in open(os.path.expanduser('~/.emscripten')).read()" \
- && echo "test tot-upstream" \
- && /root/emsdk/emsdk install tot-upstream \
- && /root/emsdk/emsdk activate tot-upstream \
- && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
- && echo "test tot-fastcomp" \
- && /root/emsdk/emsdk install tot-fastcomp \
- && /root/emsdk/emsdk activate tot-fastcomp \
- && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
- && echo "test specific release (old)" \
- && /root/emsdk/emsdk install sdk-1.38.31-64bit \
- && /root/emsdk/emsdk activate tot-fastcomp \
- && echo "test specific release (new, short name)" \
- && /root/emsdk/emsdk install 1.38.33 \
- && /root/emsdk/emsdk activate tot-fastcomp \
- && python -c "import os ; assert 'fastcomp' in open(os.path.expanduser('~/.emscripten')).read()" \
- && python -c "import os ; assert 'upstream' not in open(os.path.expanduser('~/.emscripten')).read()" \
- && echo "test specific release (new, full name)" \
- && /root/emsdk/emsdk install sdk-1.38.33-upstream-64bit \
- && /root/emsdk/emsdk activate sdk-1.38.33-upstream-64bit \
- && echo "test binaryen source build" \
- && /root/emsdk/emsdk install --build=Release binaryen-master-64bit
+ && echo "run addition tests in python" \
+ && cd /root/emsdk/ \
+ && python test.py
+

--- a/test.py
+++ b/test.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+
+# Utilities
+
+def check_call(cmd):
+  subprocess.check_call(cmd.split(' '))
+
+# Set up
+
+open('hello_world.cpp', 'w').write('int main() {}')
+
+# Tests
+
+print('update')
+check_call('./emsdk update-tags')
+
+print('test latest')
+assert 'fastcomp' in open(os.path.expanduser('~/.emscripten')).read()
+assert 'upstream' not in open(os.path.expanduser('~/.emscripten')).read()
+
+print('test latest-releases-upstream')
+check_call('python2 ./emsdk install latest-upstream')
+check_call('./emsdk activate latest-upstream')
+check_call('upstream/emscripten/emcc hello_world.cpp')
+assert open(os.path.expanduser('~/.emscripten')).read().count('LLVM_ROOT') == 1
+assert 'upstream' in open(os.path.expanduser('~/.emscripten')).read()
+assert 'fastcomp' not in open(os.path.expanduser('~/.emscripten')).read()
+
+print('test tot-upstream')
+check_call('./emsdk install tot-upstream')
+check_call('./emsdk activate tot-upstream')
+check_call('upstream/emscripten/emcc hello_world.cpp')
+
+print('test tot-fastcomp')
+check_call('./emsdk install tot-fastcomp')
+check_call('./emsdk activate tot-fastcomp')
+check_call('fastcomp/emscripten/emcc hello_world.cpp')
+
+print('test specific release (old)')
+check_call('./emsdk install sdk-1.38.31-64bit')
+check_call('./emsdk activate tot-fastcomp')
+
+print('test specific release (new, short name)')
+check_call('./emsdk install 1.38.33')
+check_call('./emsdk activate tot-fastcomp')
+assert 'fastcomp' in open(os.path.expanduser('~/.emscripten')).read()
+assert 'upstream' not in open(os.path.expanduser('~/.emscripten')).read()
+
+print('test specific release (new, full name)')
+check_call('./emsdk install sdk-1.38.33-upstream-64bit')
+check_call('./emsdk activate sdk-1.38.33-upstream-64bit')
+
+print('test binaryen source build')
+check_call('./emsdk install --build=Release binaryen-master-64bit')
+

--- a/test.py
+++ b/test.py
@@ -53,4 +53,3 @@ check_call('./emsdk activate sdk-1.38.33-upstream-64bit')
 
 print('test binaryen source build')
 check_call('./emsdk install --build=Release binaryen-master-64bit')
-


### PR DESCRIPTION
Keep the basic workflow test (checking what a user would do to get started) in bash, but otherwise it's more convenient for most tests to be in python.