### PR TITLE
Error on downloading a 64-bit package on a non-64-bit OS

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1485,12 +1485,16 @@ class Tool(object):
   # If this tool can be installed on this system, this function returns True.
   # Otherwise, this function returns a string that describes the reason why this tool is not available.
   def can_be_installed(self):
+    if hasattr(self, 'bitness'):
+      if self.bitness == 64 and not is_os_64bit():
+        return "this tool is only provided for 64-bit OSes"
+
     if self.id == 'vs-tool':
       msbuild_dir = find_msbuild_dir()
       if len(msbuild_dir) > 0:
         return True
       else:
-        return "Visual Studio 2010 was not found!"
+        return "Visual Studio 2010 was not found"
     else:
       return True
 
@@ -1509,7 +1513,7 @@ class Tool(object):
       return None
 
   def install(self):
-    if not self.can_be_installed():
+    if self.can_be_installed() is not True:
       print("The tool '" + str(self) + "' is not available due to the reason: " + self.can_be_installed())
       return False
 
@@ -2435,7 +2439,7 @@ def main():
         for tool in t:
           if tool.is_old and not arg_old:
             continue
-          if tool.can_be_installed():
+          if tool.can_be_installed() is True:
             installed = '\tINSTALLED' if tool.is_installed() else ''
           else:
             installed = '\tNot available: ' + tool.can_be_installed()

--- a/test.py
+++ b/test.py
@@ -1,10 +1,25 @@
 import os
 import subprocess
+import sys
 
 # Utilities
 
 def check_call(cmd):
   subprocess.check_call(cmd.split(' '))
+
+def failing_call_with_output(cmd, expected):
+  proc = subprocess.Popen(cmd.split(' '), stdout=subprocess.PIPE)
+  stdout, stderr = proc.communicate()
+  assert proc.returncode, 'call must have failed'
+  assert expected in stdout, 'call did not have the right output'
+
+def hack_emsdk(marker, replacement):
+  src = open('emsdk').read()
+  assert marker in src
+  src = src.replace(marker, replacement)
+  name = '__test_emsdk'
+  open(name, 'w').write(src)
+  return name
 
 # Set up
 
@@ -53,3 +68,8 @@ check_call('./emsdk activate sdk-1.38.33-upstream-64bit')
 
 print('test binaryen source build')
 check_call('./emsdk install --build=Release binaryen-master-64bit')
+
+print('test 32-bit error')
+
+failing_call_with_output('python %s install latest' % hack_emsdk('not is_os_64bit()', 'True'), 'this tool is only provided for 64-bit OSes')
+


### PR DESCRIPTION
Also fix the `can_be_installed` which was always broken it seems - it returns True for success or a string for error, but didn't check if the output `is True`.

Includes a test, which hacks up emsdk to make it think it's on 32-bit, and verifies the error and message.