### PR TITLE
Support sdk-tag-X.Y.Z-64bit

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -2414,7 +2414,7 @@ def main():
         elif '-fastcomp' in arg:
           arg = arg.replace('-fastcomp', '')
           upstream = False
-        arg = arg.replace('sdk-', '').replace('-64bit', '')
+        arg = arg.replace('sdk-', '').replace('-64bit', '').replace('tag-', '')
         release_hash = releases_info.get(arg, None) or releases_info.get('sdk-' + arg + '-64bit')
         if release_hash:
           sys.argv[i] = 'sdk-releases-%s-%s-64bit' % ('upstream' if upstream else 'fastcomp', release_hash)

--- a/test.py
+++ b/test.py
@@ -51,5 +51,9 @@ print('test specific release (new, full name)')
 check_call('./emsdk install sdk-1.38.33-upstream-64bit')
 check_call('./emsdk activate sdk-1.38.33-upstream-64bit')
 
+print('test specific release (new, full name)')
+check_call('./emsdk install sdk-tag-1.38.33-64bit')
+check_call('./emsdk activate sdk-tag-1.38.33-64bit')
+
 print('test binaryen source build')
 check_call('./emsdk install --build=Release binaryen-master-64bit')


### PR DESCRIPTION
(we supported it without -tag-, but that did work before, so fix it for existing users)