### PR TITLE
List emscripten-releases versions in ./emsdk list

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1880,6 +1880,12 @@ def load_releases_tags():
   return tags
 
 
+def load_releases_versions():
+  info = load_releases_info()
+  versions = list(info['releases'].keys())
+  return versions
+
+
 def is_string(s):
   if sys.version_info[0] >= 3:
     return isinstance(s, str)
@@ -2423,10 +2429,22 @@ def main():
     print('')
 
     print('The *recommended* precompiled SDK download is %s (%s).' % (find_latest_releases_version(), find_latest_releases_hash()))
+    print()
     print('To install/activate it, use one of:')
     print('         latest                  [default (fastcomp) backend]')
     print('         latest-upstream         [upstream LLVM wasm backend]')
     print('')
+    print('Those are equivalent to installing/activating the following:')
+    print('         %s' % find_latest_releases_version())
+    print('         %s-upstream' % find_latest_releases_version())
+    print('')
+    print('All recent (non-legacy) installable versions are:')
+    releases_versions = sorted(load_releases_versions())
+    releases_versions.reverse()
+    for ver in releases_versions:
+      print('         %s' % ver)
+      print('         %s-upstream' % ver)
+    print()
 
     has_partially_active_tools = [False] # Use array to work around the lack of being able to mutate from enclosing function.
 
@@ -2451,6 +2469,7 @@ def main():
         print('')
       print('The additional following precompiled SDKs are also available for download:')
       print_sdks(find_sdks(False))
+
       print('The following SDKs can be compiled from source:')
       print_sdks(find_sdks(True))
 


### PR DESCRIPTION
The output now looks like
```
The *recommended* precompiled SDK download is 1.38.34 (048cf9424790cc525a7ea6da340820aae226f3b9).

To install/activate it, use one of:
         latest                  [default (fastcomp) backend]
         latest-upstream         [upstream LLVM wasm backend]

Those are equivalent to installing/activating the following:
         1.38.34
         1.38.34-upstream

All recent (non-legacy) installable versions are:
         1.38.34
         1.38.34-upstream
         1.38.33
         1.38.33-upstream
```
and after that is the detailed output with the older builds etc.
