### PR TITLE
Fix ./emsdk update of a *non*-git install

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -45,6 +45,8 @@ emscripten_releases_repo = 'https://chromium.googlesource.com/emscripten-release
 
 emscripten_releases_download_url_template = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/%s/%s/wasm-binaries.%s"
 
+emsdk_zip_download_url = 'https://github.com/emscripten-core/emsdk/archive/master.zip'
+
 zips_subdir = 'zips/'
 
 # Enable this to do very verbose printing about the different steps that are being run. Useful for debugging.
@@ -1790,14 +1792,7 @@ def update_emsdk():
     print('You seem to have bootstrapped Emscripten SDK by cloning from GitHub. In this case, use "git pull" instead of "emsdk update" to update emsdk. (Not doing that automatically in case you have local changes)', file=sys.stderr)
     print('Alternatively, use "emsdk update-tags" to refresh the latest list of tags from the different Git repositories.', file=sys.stderr)
     sys.exit(1)
-  if WINDOWS:
-    download_and_unzip(urljoin(emsdk_packages_url, 'emsdk_windows_update.zip'), emsdk_path(), download_even_if_exists=True)
-    rmfile('zips/emsdk_windows_update.zip')
-  elif OSX or LINUX:
-    download_and_unzip(urljoin(emsdk_packages_url, 'emsdk_unix_update.tar.gz'), emsdk_path(), download_even_if_exists=True)
-    rmfile('zips/emsdk_unix_update.tar.gz')
-  else:
-    print('Unsupported OS, cannot update!')
+  download_and_unzip(emsdk_zip_download_url, emsdk_path(), download_even_if_exists=True)
   fetch_emscripten_tags()
 
 

--- a/test.py
+++ b/test.py
@@ -1,6 +1,8 @@
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 
 # Utilities
 
@@ -76,4 +78,16 @@ check_call('./emsdk install --build=Release binaryen-master-64bit')
 print('test 32-bit error')
 
 failing_call_with_output('python %s install latest' % hack_emsdk('not is_os_64bit()', 'True'), 'this tool is only provided for 64-bit OSes')
+
+print('test non-git update')
+
+temp_dir = tempfile.mkdtemp()
+
+for filename in os.listdir('.'):
+  if not filename.startswith('.') and not os.path.isdir(filename):
+    shutil.copyfile(filename, os.path.join(temp_dir, filename))
+
+os.chdir(temp_dir)
+
+check_call('python ./emsdk update')
 


### PR DESCRIPTION
The non-git case was not well documented and not tested, and it was broken since we switched the build infrastructure.

In the git case, an update is to do a git pull. In the non-git case, it downloads a zip and unpacks it. The old build infra apparently had builds created for this; instead, I made it download it directly from github. Perhaps we should consider creating builds for this as well eventually?

Also add a test for this, so we never break it again.