### PR TITLE
Default Python 3 for running emsdk

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/emsdk
+++ b/emsdk
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/bin/sh
+# Following line is responsible for selecting the best python for current host
+# This script can be called directly: `./emsdk` or indirectly: `python ./emsdk` `sh ./emsdk` or `bash ./emsdk`
+"exec" "`dirname $0`/python_selector" "$0" "$@"
 
 from __future__ import print_function
 

--- a/python_selector
+++ b/python_selector
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+"""Provides a way to run a script on the preferred Python version"""
+
+import os
+import subprocess
+import sys
+
+
+def which(program):
+  for path in [""] + os.environ.get("PATH", "").split(os.pathsep):
+    exe_file = os.path.join(path, program)
+    if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
+      return exe_file
+  return None
+
+# Look for the best choice for python, favours Python3 over Python2
+# In case of Windows it uses always python that was used for this script
+if sys.platform in ["linux", "linux2", "darwin"]:
+  python = which("python3") or which("python") or sys.executable
+else:
+  python = sys.executable
+
+sys.exit(subprocess.call([python] + sys.argv[1:]))


### PR DESCRIPTION
On macOS it's pretty common to hit a problem
```
Error downloading URL 'https://github.com/kripken/emscripten/archive/1.38.25.tar.gz': <urlopen error [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:590)>
```
When an installation is started. I.e. `./emsdk install sdk-1.38.25-64bit` - this is caused in majority of cases by some problem of openssl and python2 - (some other https downloads work just fine, not sure why GitHub is special)

So this Pull Request will default Python to Python 3, for running `emsdk`