### PR TITLE
python_selector checks if found python command is valid

### DIFF
--- a/python_selector
+++ b/python_selector
@@ -16,7 +16,12 @@ def which(program):
   for path in [""] + os.environ.get("PATH", "").split(os.pathsep):
     exe_file = os.path.join(path, program)
     if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-      return exe_file
+      # in case of pyenv we might have `python3` command available, but it's just a stub
+      # https://github.com/emscripten-core/emscripten/issues/8792
+      p = subprocess.Popen([exe_file, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      p.communicate()
+      if p.returncode == 0:
+        return exe_file
   return None
 
 # Look for the best choice for python, favours Python3 over Python2


### PR DESCRIPTION
Addresses https://github.com/emscripten-core/emscripten/issues/8792

I've found what's the reason of the strange behaviour of last changes (https://github.com/emscripten-core/emsdk/pull/273). 

In order to reproduce this problem it's needed:
* To don't have python3 installed in system
* To have `pyenv` with installed at least one version from each family, like:
```
pyenv install 3.7.0
pyenv install 2.7.15
```
* To activate a version from python2
```
pyenv local 2.7.15
```

Then we have a strange situation that `python3` is available as a command, but it's just a mock for `pyenv`:
```bash
➜ pyenv versions
  system
* 2.7.15 (set by /home/trzeci/Projects/emsdk/.python-version)
  3.7.0

➜ which python3
~/.pyenv/shims/python3

➜ python3 --version
pyenv: python3: command not found

The `python3' command exists in these Python versions:
  3.7.0

➜ ./emsdk --help        
pyenv: python3: command not found

The `python3' command exists in these Python versions:
  3.7.0

```

As you see in an example above I didn't even call `emsdk` script, just tried to execute `python3 --version` and I've got exactly the same error. The problem of pyenv is that even if python3 isn't active it's available in the system PATH. 
Calling `./emsdk --help` get's the same error, as `python3` was used.

At the moment this entirely breaks logic in `python_selector` and in pyenv working command is indistinguishable from stub python command.

@kripken: A couple of ways to go from here:
* revert logic of python_selector and advertise mac users to use python3
* keep logic and advertise pyenv users to use python3
* This PR: extend logic of `python_selector` by checking if found python command is valid (for the instance by calling `python --version`), this will filter out false positive matches that coming from `pyenv`


After patch:
```bash
➜ pyenv versions        
  system
* 2.7.15 (set by /home/trzeci/Projects/emsdk/.python-version)
  3.7.0

➜ which python3 
~/.pyenv/shims/python3

➜ python3 --version
pyenv: python3: command not found

The `python3' command exists in these Python versions:
  3.7.0


➜ ./emsdk --help
 emsdk: Available commands:

   emsdk list [--old] [--uses]  - Lists all available SDKs and tools and their
                                  current installation status. With the --old
   ....

```
As you can see `python3 --version` command fails as it was, but that's expected behaviour. What's important is that `./emsdk --help` gets executed as `python_selector` recognizes a stub.