### PR TITLE
Use shutil.move instead of os.rename as it has more portable behavior

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -492,7 +492,7 @@ def unzip(source_filename, dest_dir, unpack_even_if_exists=False):
             parent_dir = os.path.dirname(fix_potentially_long_windows_pathname(final_dst_filename))
             if parent_dir and not os.path.exists(parent_dir):
               os.makedirs(parent_dir)
-            os.rename(fix_potentially_long_windows_pathname(tmp_dst_filename), fix_potentially_long_windows_pathname(final_dst_filename))
+            shutil.move(fix_potentially_long_windows_pathname(tmp_dst_filename), fix_potentially_long_windows_pathname(final_dst_filename))
 
       if common_subdir:
         try:


### PR DESCRIPTION
In particular, reportedly it fails on windows if the target already exists, see https://github.com/emscripten-core/emscripten/issues/5713#issuecomment-502468703

Note that there is already a test for updating the emsdk a second time (which downloads the same zip again) so this already has test coverage.