### PR TITLE
Fix 'SendMessage' hanging on Windows

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -260,7 +260,7 @@ def win_set_environment_variable_direct(key, value, system=True):
 
   win32api.RegCloseKey(folder)
   os.environ['PATH'] = prev_path
-  win32api.SendMessage(win32con.HWND_BROADCAST, win32con.WM_SETTINGCHANGE, 0, 'Environment')
+  win32api.PostMessage(win32con.HWND_BROADCAST, win32con.WM_SETTINGCHANGE, 0, 'Environment')
 
 
 def win_get_environment_variable(key, system=True):


### PR DESCRIPTION
Fixes https://github.com/emscripten-core/emsdk/issues/138

As I got from my research and [StackOverflow](https://stackoverflow.com/questions/1951658/sendmessagehwnd-broadcast-hangs), WinAPI `SendMessage` function doesn't return until all receivers have processed the message. So it might hang sometimes, this happens on my machine and some other users report such problem.

We can use `PostMessage` instead of `SendMessage`. Another solution is to use [SendMessageTImout](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendmessagetimeouta), but I am not sure what constant timeout value we should pass.