### PR TITLE
Fix issue with windows install

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -82,7 +82,7 @@ if not OSX and (platform.system() == 'Linux' or os.name == 'posix'):
 UNIX = (OSX or LINUX)
 
 ARCH = 'unknown'
-machine = platform.machine()
+machine = platform.machine().lower() #amd64 was not being recognised when returned as AMD64
 if machine.startswith('x64') or machine.startswith('amd64') or machine.startswith('x86_64'):
   ARCH = 'x86_64'
 elif machine.endswith('86'):


### PR DESCRIPTION
Windows version of python 3 returns platform.machine() in upper case for AMD64 which wasn't being checked for so added .lower().

Doesn't affect Linux python3 which already worked.