### PR TITLE
Compare against lower-case platform string

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -83,7 +83,7 @@ UNIX = (OSX or LINUX)
 
 ARCH = 'unknown'
 machine = platform.machine()
-if machine.startswith('x64') or machine.startswith('amd64') or machine.startswith('x86_64'):
+if machine.startswith('x64') or machine.lower().startswith('amd64') or machine.startswith('x86_64'):
   ARCH = 'x86_64'
 elif machine.endswith('86'):
   ARCH = 'x86'


### PR DESCRIPTION
At least on some platforms (my windows e.g.)

```
import platform
print(platform.machine())
```

returns `AMD64` with uppercase letters. This will then fail the platform check and the installation fails.

See https://github.com/emscripten-core/emsdk/issues/312