### PR TITLE
List all archive suffixes properly, so we clean up all downloaded archives

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -141,6 +141,8 @@ if os.path.exists(os.path.join(emsdk_path(), '.emscripten')):
 
 EMSDK_SET_ENV = 'emsdk_set_env.ps1' if POWERSHELL else 'emsdk_set_env.bat' if (WINDOWS and not MSYS) else 'emsdk_set_env.sh'
 
+ARCHIVE_SUFFIXES = ('zip', '.tar', '.gz', '.xz', '.tbz2', '.bz2')
+
 
 # Finds the given executable 'program' in PATH. Operates like the Unix tool 'which'.
 def which(program):
@@ -1580,7 +1582,7 @@ class Tool(object):
         success = build_llvm_tool(self)
       elif hasattr(self, 'git_branch'):
         success = git_clone_checkout_and_pull(url, self.installation_path(), self.git_branch)
-      elif url.endswith('zip') or url.endswith('.tar') or url.endswith('.gz') or url.endswith('.xz') or url.endswith('.tbz2'):
+      elif url.endswith(ARCHIVE_SUFFIXES):
         download_even_if_exists = (self.id == 'vs-tool')
         filename_prefix = getattr(self, 'zipfile_prefix', '')
         success = download_and_unzip(url, self.installation_path(), download_even_if_exists=download_even_if_exists, filename_prefix=filename_prefix)
@@ -1619,7 +1621,7 @@ class Tool(object):
 
   def cleanup_temp_install_files(self):
     url = self.download_url()
-    if url.endswith('zip') or url.endswith('.tar') or url.endswith('.gz'):
+    if url.endswith(ARCHIVE_SUFFIXES):
       file_name = url.split('/')[-1]
       tempzipfile = os.path.join('zips/', file_name)
       if VERBOSE: print("Deleting temporary zip file " + tempzipfile)


### PR DESCRIPTION
Implements what @juj suggested here: https://github.com/emscripten-core/emsdk/pull/274#issuecomment-502447670

After this, the behavior should consistently be: archives are downloaded, unpacked, then deleted immediately. Another install of the same thing will re-download.