### PR TITLE
Properly clean up downloaded zips

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1624,9 +1624,9 @@ class Tool(object):
     url = self.download_url()
     if url.endswith(ARCHIVE_SUFFIXES):
       file_name = url.split('/')[-1]
-      tempzipfile = os.path.join('zips/', file_name)
-      if VERBOSE: print("Deleting temporary zip file " + tempzipfile)
-      rmfile(tempzipfile)
+      download_target = get_download_target(url, zips_subdir, getattr(self, 'zipfile_prefix', ''))
+      if VERBOSE: print("Deleting temporary zip file " + download_target)
+      rmfile(download_target)
 
   def uninstall(self):
     if not self.is_installed():

--- a/test.py
+++ b/test.py
@@ -122,6 +122,8 @@ check_call('./emsdk activate sdk-1.38.31-64bit')
 
 print('test specific release (new, short name)')
 check_call('./emsdk install 1.38.33')
+print('another install must re-download')
+checked_call_with_output('./emsdk install 1.38.33', expected='Downloading:', unexpected='already exist in destination')
 check_call('./emsdk activate 1.38.33')
 assert 'fastcomp' in open(os.path.expanduser('~/.emscripten')).read()
 assert 'upstream' not in open(os.path.expanduser('~/.emscripten')).read()


### PR DESCRIPTION
We got this wrong because we were not using `get_download_target`, so we were trying to delete the wrong file.

Also add a test.

Fixes #320 
