### PR TITLE
Always download archives, since we delete them after use anyhow.

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1584,7 +1584,13 @@ class Tool(object):
       elif hasattr(self, 'git_branch'):
         success = git_clone_checkout_and_pull(url, self.installation_path(), self.git_branch)
       elif url.endswith(ARCHIVE_SUFFIXES):
+        # TODO: explain the vs-tool special-casing
         download_even_if_exists = (self.id == 'vs-tool')
+        # if we are downloading a zip, we will unpack and delete it after immediately anyhow,
+        # so there is no need to look for an existing one (which may have been left behind
+        # due to an error in the past)
+        if url.endswith(ARCHIVE_SUFFIXES):
+          download_even_if_exists = True
         filename_prefix = getattr(self, 'zipfile_prefix', '')
         success = download_and_unzip(url, self.installation_path(), download_even_if_exists=download_even_if_exists, filename_prefix=filename_prefix)
       else:


### PR DESCRIPTION
This prevents using archives left behind by mistake in the past.

Fixes #323 