### PR TITLE
Fix file permissions when extracting zip files

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -503,6 +503,10 @@ def unzip(source_filename, dest_dir, unpack_even_if_exists=False):
       # Now do the actual decompress.
       for member in zf.infolist():
         zf.extract(member, fix_potentially_long_windows_pathname(unzip_to_dir))
+        unix_attributes = member.external_attr >> 16
+        if unix_attributes:
+          target = os.path.join(unzip_to_dir, member.filename)
+          os.chmod(target, unix_attributes)
 
         # Move the extracted file to its final location without the base directory name, if we are stripping that away.
         if common_subdir:

--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import json
 import os
 import shlex
@@ -151,9 +152,9 @@ for filename in os.listdir('.'):
 
 os.chdir(temp_dir)
 
-check_call('python ./emsdk update')
+check_call('./emsdk update')
 print('second time')
-check_call('python ./emsdk update')
+check_call('./emsdk update')
 
 print('verify downloads exist for all OSes')
 latest_hash = TAGS['releases'][TAGS['latest']]

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 echo "test the standard workflow (as close as possible to how a user would do it, in the shell)"
 ./emsdk install latest
 ./emsdk activate latest


### PR DESCRIPTION
This means that `./emsdk` works on UNIX system after emsdk self-updates
from a zip file.  Without this one would need to run `python ./emsdk`
which seems to be why the tests were doing it this way.