### PR TITLE
Remove extraneous arguments to construct_env

### DIFF
--- a/emsdk_env.fish
+++ b/emsdk_env.fish
@@ -8,7 +8,7 @@ set -l dir (dirname $script)
 
 pushd $dir > /dev/null
 
-./emsdk construct_env "$argv"
+./emsdk construct_env
 . ./emsdk_set_env.sh
 
 set -e -l script

--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -23,7 +23,7 @@ cd "$(dirname "$SRC")"
 unset SRC
 
 tmpfile=`mktemp` || exit 1
-./emsdk construct_env "$@" $tmpfile
+./emsdk construct_env $tmpfile
 . $tmpfile
 rm -f $tmpfile
 


### PR DESCRIPTION
The code for construct_env expects the output file to be at `argv[2]`,
but it is actually invoked in emsdk_env.{sh,fish} with $@ there
instead. Usually this is not a problem because the emdsk_env.{sh,fish}
is `sourced` directly from the user's shell and $@ is empty, but this
can break in scripted environments.

The $@ was added two years ago in 3b6c6b86 for no discernible reason,
but it was entirely ignored in the code until last month when #307
added a meaningful argument to construct_env but incorrectly kept the
$@.