### PR TITLE
Set EMSCRIPTEN_ROOT in releases builds

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -177,7 +177,7 @@
     "zipfile_prefix": "%releases-tag%-",
     "install_path": "upstream",
     "activated_path": "%installation_dir%/emscripten",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT='%installation_dir%'",
+    "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT='%installation_dir%';EMSCRIPTEN_ROOT='%installation_dir%/emscripten'",
     "emscripten_releases_hash": "%releases-tag%",
     "pregenerated_cache": "wasm-obj"
   },
@@ -192,7 +192,7 @@
     "zipfile_prefix": "%releases-tag%-",
     "install_path": "fastcomp",
     "activated_path": "%installation_dir%/emscripten",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%/fastcomp/bin';BINARYEN_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/bin/optimizer%.exe%'",
+    "activated_cfg": "LLVM_ROOT='%installation_dir%/fastcomp/bin';BINARYEN_ROOT='%installation_dir%';EMSCRIPTEN_ROOT='%installation_dir%/emscripten';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/bin/optimizer%.exe%'",
     "emscripten_releases_hash": "%releases-tag%",
     "pregenerated_cache": "asmjs"
   },


### PR DESCRIPTION
Without setting this, if a non-releases build was previously activated, it will keep affecting EMSCRIPTEN_ROOT in the emitted config file.

Helps with #326