### PR TITLE
Update node version to 12.9.1

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -520,42 +520,42 @@
   },
   {
     "id": "node",
-    "version": "10.16.3",
+    "version": "12.9.1",
     "bitness": 32,
     "arch": "x86",
-    "windows_url": "node-v10.16.3-win-x86.zip",
+    "windows_url": "node-v12.9.1-win-x86.zip",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
   {
     "id": "node",
-    "version": "10.16.3",
+    "version": "12.9.1",
     "arch": "arm",
     "bitness": 32,
-    "linux_url": "node-v10.16.3-linux-armv7l.tar.xz",
+    "linux_url": "node-v12.9.1-linux-armv7l.tar.xz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
   {
     "id": "node",
-    "version": "10.16.3",
+    "version": "12.9.1",
     "bitness": 64,
     "arch": "x86_64",
-    "osx_url": "node-v10.16.3-darwin-x64.tar.gz",
-    "windows_url": "node-v10.16.3-win-x64.zip",
-    "linux_url": "node-v10.16.3-linux-x64.tar.xz",
+    "osx_url": "node-v12.9.1-darwin-x64.tar.gz",
+    "windows_url": "node-v12.9.1-win-x64.zip",
+    "linux_url": "node-v12.9.1-linux-x64.tar.xz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
   {
     "id": "node",
-    "version": "10.16.3",
+    "version": "12.9.1",
     "arch": "aarch64",
     "bitness": 64,
-    "linux_url": "node-v10.16.3-linux-arm64.tar.xz",
+    "linux_url": "node-v12.9.1-linux-arm64.tar.xz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
@@ -1186,61 +1186,61 @@
   {
     "version": "incoming",
     "bitness": 32,
-    "uses": ["clang-incoming-32bit", "node-10.16.3-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-incoming-32bit", "binaryen-master-32bit"],
+    "uses": ["clang-incoming-32bit", "node-12.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-incoming-32bit", "binaryen-master-32bit"],
     "os": "win"
   },
   {
     "version": "incoming",
     "bitness": 64,
-    "uses": ["clang-incoming-64bit", "node-10.16.3-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
+    "uses": ["clang-incoming-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
     "os": "win"
   },
   {
     "version": "incoming",
     "bitness": 64,
-    "uses": ["clang-incoming-64bit", "node-10.16.3-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
+    "uses": ["clang-incoming-64bit", "node-12.9.1-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
     "os": "osx"
   },
   {
     "version": "incoming",
     "bitness": 32,
-    "uses": ["clang-incoming-32bit", "node-10.16.3-32bit", "emscripten-incoming-32bit", "binaryen-master-32bit"],
+    "uses": ["clang-incoming-32bit", "node-12.9.1-32bit", "emscripten-incoming-32bit", "binaryen-master-32bit"],
     "os": "linux"
   },
   {
     "version": "incoming",
     "bitness": 64,
-    "uses": ["clang-incoming-64bit", "node-10.16.3-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
+    "uses": ["clang-incoming-64bit", "node-12.9.1-64bit", "emscripten-incoming-64bit", "binaryen-master-64bit"],
     "os": "linux"
   },
   {
     "version": "master",
     "bitness": 32,
-    "uses": ["clang-master-32bit", "node-10.16.3-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
+    "uses": ["clang-master-32bit", "node-12.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
     "os": "win"
   },
   {
     "version": "master",
     "bitness": 64,
-    "uses": ["clang-master-64bit", "node-10.16.3-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["clang-master-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "win"
   },
   {
     "version": "master",
     "bitness": 64,
-    "uses": ["clang-master-64bit", "node-10.16.3-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["clang-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "osx"
   },
   {
     "version": "master",
     "bitness": 32,
-    "uses": ["clang-master-32bit", "node-10.16.3-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
+    "uses": ["clang-master-32bit", "node-12.9.1-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
     "os": "linux"
   },
   {
     "version": "master",
     "bitness": 64,
-    "uses": ["clang-master-64bit", "node-10.16.3-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["clang-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "linux"
   },
   {
@@ -1667,37 +1667,37 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-10.16.3-64bit"],
+    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit"],
     "os": "linux"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-10.16.3-64bit"],
+    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit"],
     "os": "osx"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-10.16.3-64bit"],
+    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit"],
     "os": "win"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-10.16.3-64bit"],
+    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-12.9.1-64bit"],
     "os": "linux"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-10.16.3-64bit"],
+    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-12.9.1-64bit"],
     "os": "osx"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-10.16.3-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit"],
+    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit"],
     "os": "win"
   },
   {


### PR DESCRIPTION
Turns out 10.16.3 has issues running some emscripten tests due to a
v8 bug: https://bugs.chromium.org/p/v8/issues/detail?id=8347.