### PR TITLE
Modified the code and added user notification about Python certificat…

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -664,7 +664,9 @@ def download_file(url, dstpath, download_even_if_exists=False, filename_prefix='
         print(']')
         sys.stdout.flush()
   except Exception as e:
-    print("Error downloading URL '" + url + "': " + str(e))
+    print("Error: Downloading URL '" + url + "': " + str(e))
+    if "SSL: CERTIFICATE_VERIFY_FAILED" in str(e) or "urlopen error unknown url type: https" in str(e):
+      print("Warning: Possibly SSL/TLS issue. Update or install Python SSL root certificates (2048-bit or greater) supplied in Python folder or https://pypi.org/project/certifi/ and try again.")
     rmfile(file_name)
     return None
   except KeyboardInterrupt:


### PR DESCRIPTION
Modified the code and added user notification about Python certificates issue to reduce the number of future git issues being raised about the Python ... urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate  ... exception. This issue has resulted in continuous stream of issues with common  problems in: #133 #136 #140 #176 #6275 #6548 #6723 #9036 ...

A notification during installation would help the user resolve the issue without raising a new issue request.