### PR TITLE
Do not attempt to reinstall python if it already exists

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1712,6 +1712,9 @@ class Tool(object):
       # We should not force reinstallation of python if it already exists, since that very python
       # may be interpreting the current emsdk.py script we are executing. On Windows this would
       # lead to a failure to uncompress the python zip file as the python executable files are in use.
+      # TODO: Refactor codebase to avoid needing this kind of special case check by being more
+      # careful about reinstallation, see https://github.com/emscripten-core/emsdk/pull/394#issuecomment-559386468
+      # for a scheme that would work.
       if self.id == 'python' and self.is_installed():
         print("Skipped installing " + self.name + ", already installed.")
         return True

--- a/emsdk.py
+++ b/emsdk.py
@@ -1709,6 +1709,12 @@ class Tool(object):
       print("Done installing SDK '" + str(self) + "'.")
       return True
     else:
+      # We should not force reinstallation of python if it already exists, since that very python
+      # may be interpreting the current emsdk.py script we are executing. On Windows this would
+      # lead to a failure to uncompress the python zip file as the python executable files are in use.
+      if self.id == 'python' and self.is_installed():
+        print("Skipped installing " + self.name + ", already installed.")
+        return True
       print("Installing tool '" + str(self) + "'..")
       url = self.download_url()
 


### PR DESCRIPTION
Do not attempt to reinstall python if it already exists, since that python may be interpreting the current emsdk.py script that is being executed to do the installation.

At some point in the past the installation model changed to always redownload+unzip over tools that already have installed. That broke emsdk on Windows, as it would attempt to re-unzip python over to the directory where python was actively being executed, resulting in error

```
Downloading: C:/code/emsdk/zips/WinPython-64bit-2.7.13.1Zero.zip from https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/WinPython-64bit-2.7.13.1Zero.zip, 41285159 Bytes
Unpacking 'C:/code/emsdk/zips/WinPython-64bit-2.7.13.1Zero.zip' to 'C:/code/emsdk/python/2.7.13.1_64bit'
Unzipping file 'C:/code/emsdk/zips/WinPython-64bit-2.7.13.1Zero.zip' failed due to reason: [Error 5] Access is denied: '\\\\?\\C:\\code\\emsdk\\python\\2.7.13.1_64bit\\python-2.7.13.amd64\\DLLs\\_ctypes.pyd'
Installation failed!
```

Not sure of another way to resolve except to skip python from the "always re-download" behavior. (could check if the current python interpreter actually is the one that is being installed, but that might be a bit overkill and lead to odd discrepancies for users)