### PR TITLE
Build wasm master

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ You can use this target for example to bootstrap developing patches to LLVM,
 Binaryen or Emscripten. (After initial installation, use `git remote add`
 in the cloned tree to add your own fork to push changes as patches)
 
+If you only intend to contribute to Emscripten repository, and not to LLVM
+or Binaryen, you can also use precompiled versions of them, and only git
+clone the Emscripten repository. For more details, see
+
+https://emscripten.org/docs/contributing/developers_guide.html?highlight=developer#setting-up
+
 ### When working on git branches compiled from source, how do I update to a newer compiler version?
 
 Unlike tags and precompiled versions, a few of the SDK packages are based on

--- a/README.md
+++ b/README.md
@@ -118,11 +118,31 @@ Emsdk contains a history of old compiler versions that you can use to maintain
 your migration path. Type `emsdk list --old` to get a list of archived tool and
 SDK versions, and `emsdk install <name_of_tool>` to install it.
 
+### I want to build from source/I want to download a precompiled build!
+
+Some Emsdk Tool and SDK targets refer to packages that are precompiled, and
+no compilation is needed when installing them. Other Emsdk Tools and SDK
+targets come "from source", meaning that they will fetch the source repositories
+using git, and compile the package on demand.
+
+When you run `emsdk list`, it will group the Tools and SDKs under these two
+categories.
+
+To obtain and build latest upstream wasm SDK from source, run
+
+```
+emsdk install sdk-upstream-incoming-64bit
+```
+
+You can use this target for example to bootstrap developing patches to LLVM,
+Binaryen or Emscripten. (After initial installation, use `git remote add`
+in the cloned tree to add your own fork to push changes as patches)
+
 ### When working on git branches compiled from source, how do I update to a newer compiler version?
 
 Unlike tags and precompiled versions, a few of the SDK packages are based on
-"moving" git branches and compiled from source (sdk-incoming, sdk-master,
-emscripten-incoming, emscripten-master, binaryen-master). Because of that, the
+"moving" git branches and compiled from source (e.g. sdk-upstream-incoming,
+sdk-incoming, emscripten-incoming, binaryen-master). Because of that, the
 compiled versions will eventually go out of date as new commits are introduced
 to the development branches. To update an old compiled installation of one of
 this branches, simply reissue the "emsdk install" command on that tool/SDK. This

--- a/emsdk.py
+++ b/emsdk.py
@@ -1808,7 +1808,7 @@ class Tool(object):
         if hasattr(self, 'custom_install_script'):
           if self.custom_install_script == 'build_optimizer':
             success = build_optimizer_tool(self)
-          elif self.custom_install_script in ('build_fastcomp' , 'build_llvm_monorepo'):
+          elif self.custom_install_script in ('build_fastcomp', 'build_llvm_monorepo'):
             # 'build_fastcomp' is a special one that does the download on its
             # own, others do the download manually.
             pass

--- a/emsdk.py
+++ b/emsdk.py
@@ -1052,8 +1052,8 @@ def xcode_sdk_version():
     return subprocess.checkplatform.mac_ver()[0].split('.')
 
 
-def build_llvm_tool(tool):
-  debug_print('build_llvm_tool(' + str(tool) + ')')
+def build_llvm_fastcomp(tool):
+  debug_print('build_llvm_fastcomp(' + str(tool) + ')')
   fastcomp_root = tool.installation_path()
   fastcomp_src_root = os.path.join(fastcomp_root, 'src')
   # Does this tool want to be git cloned from github?
@@ -1782,7 +1782,7 @@ class Tool(object):
       url = self.download_url()
 
       if hasattr(self, 'custom_install_script') and self.custom_install_script == 'build_fastcomp':
-        success = build_llvm_tool(self)
+        success = build_llvm_fastcomp(self)
       elif hasattr(self, 'custom_install_script') and self.custom_install_script == 'build_llvm_monorepo':
         success = build_llvm_monorepo(self)
       elif hasattr(self, 'git_branch'):

--- a/emsdk.py
+++ b/emsdk.py
@@ -1808,7 +1808,7 @@ class Tool(object):
         if hasattr(self, 'custom_install_script'):
           if self.custom_install_script == 'build_optimizer':
             success = build_optimizer_tool(self)
-          elif self.custom_install_script == 'build_fastcomp' or self.custom_install_script == 'build_llvm_monorepo':
+          elif self.custom_install_script in ('build_fastcomp' , 'build_llvm_monorepo'):
             # 'build_fastcomp' is a special one that does the download on its
             # own, others do the download manually.
             pass

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -1,6 +1,35 @@
 {
   "tools": [
   {
+    "id": "llvm-git",
+    "version": "master",
+    "bitness": 32,
+    "install_path": "llvm/git",
+    "git_branch": "master",
+    "url": "https://github.com/llvm/llvm-project.git",
+    "custom_install_script": "build_llvm_monorepo",
+    "only_supports_wasm": true,
+    "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
+    "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%;EMCC_WASM_BACKEND=1",
+    "cmake_build_type": "Release"
+  },
+  {
+    "id": "llvm-git",
+    "version": "master",
+    "bitness": 64,
+    "install_path": "llvm/git",
+    "git_branch": "master",
+    "url": "https://github.com/llvm/llvm-project.git",
+    "custom_install_script": "build_llvm_monorepo",
+    "only_supports_wasm": true,
+    "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
+    "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%;EMCC_WASM_BACKEND=1",
+    "cmake_build_type": "Release"
+  },
+
+  {
     "id": "clang",
     "version": "tag-e%tag%",
     "bitness": 32,
@@ -540,6 +569,12 @@
   ],
 
   "sdks": [
+  {
+    "version": "wasm-git-master",
+    "bitness": 64,
+    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "emscripten-incoming-64bit"],
+    "os": "win"
+  },
   {
     "version": "fastcomp-incoming",
     "bitness": 32,

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -570,7 +570,7 @@
 
   "sdks": [
   {
-    "version": "wasm-git-master",
+    "version": "upstream-incoming",
     "bitness": 64,
     "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "emscripten-incoming-64bit"],
     "os": "win"

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -41,7 +41,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%;EMCC_WASM_BACKEND=0",
     "cmake_build_type": "Release"
   },
   {
@@ -56,7 +56,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%;EMCC_WASM_BACKEND=0",
     "cmake_build_type": "Release"
   },
   {
@@ -70,7 +70,7 @@
     "linux_url": "llvm/nightly/linux_64bit/emscripten-llvm-e%nightly-llvm-64bit%.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMCC_WASM_BACKEND=0"
   },
   {
     "id": "fastcomp-clang",
@@ -83,7 +83,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%;EMCC_WASM_BACKEND=0",
     "cmake_build_type": "Release"
   },
   {
@@ -97,7 +97,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%;EMCC_WASM_BACKEND=0",
     "cmake_build_type": "Release"
   },
   {
@@ -111,7 +111,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%;EMCC_WASM_BACKEND=0",
     "cmake_build_type": "Release"
   },
   {
@@ -125,7 +125,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%;EMCC_WASM_BACKEND=0",
     "cmake_build_type": "Release"
   },
 
@@ -170,7 +170,7 @@
     "linux_url": "llvm/tag/linux_64bit/emscripten-llvm-e%precompiled_tag32%.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
-    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen;EMCC_WASM_BACKEND=0"
   },
   {
     "id": "fastcomp-clang",
@@ -182,7 +182,7 @@
     "linux_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/old/linux/emscripten-llvm-e%precompiled_tag64%.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
-    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen;EMCC_WASM_BACKEND=0"
   },
   {
     "id": "node",


### PR DESCRIPTION
It looks like at some point the support for building wasm upstream backend from LLVM source was deleted from emsdk. This PR looks to introduce that support back.

Although when I work on this, I get all sorts of Windows build failures.

First is that Clang-fuzzer does not really build but gets build errors in LLVM trunk. After that it looks like handling of `-DLLVM_ENABLE_PROJECTS="clang"` is broken and one must duplicate it to `-DLLVM_ENABLE_PROJECTS="clang;clang"` for it to work. Trying to build targets libcxx, libcxxabi, libunwind, compiler-rt or polly do not work but they attempt to write to C:\Program Files as an unprivileged user and get access denied. And finally I don't get `wasm-ld.exe` generated, even if I add `lld` target into the build.

This is a bit surprising, I feel like I am missing something really specific since I see so many failures. I tried to look for Emscripten's .circleci config to see how LLVM monorepo + wasm backend is now being built from upstream, but it does not look like it is built from there at least. Do we have instructions somewhere on how to build from source for Windows?