### PR TITLE
Add Closure compiler to emsdk.

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1446,6 +1446,8 @@ class Tool(object):
     if '%generator_prefix%' in str:
       str = str.replace('%generator_prefix%', cmake_generator_prefix())
     str = str.replace('%.exe%', '.exe' if WINDOWS else '')
+    str = str.replace('%.cmd%', '.cmd' if WINDOWS else '')
+    str = str.replace('%.bat%', '.bat' if WINDOWS else '')
     if '%fastcomp_build_dir%' in str:
       str = str.replace('%fastcomp_build_dir%', fastcomp_build_dir(self))
     if '%fastcomp_build_bin_dir%' in str:

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -344,6 +344,15 @@
     "activated_cfg": "JAVA='%installation_dir%/bin/java%.exe%'"
   },
   {
+    "id": "closure-compiler",
+    "version": "20191111",
+    "bitness": 64,
+    "url": "google-closure-compiler-20191111.zip",
+    "activated_path": "%installation_dir%/.bin",
+    "activated_cfg": "CLOSURE_COMPILER='%installation_dir%/.bin/google-closure-compiler%.cmd%'",
+    "activated_env": "NODE_PATH=%installation_dir%"
+  },
+  {
     "id": "emscripten",
     "version": "tag-%tag%",
     "bitness": 32,
@@ -729,19 +738,19 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit"],
+    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit", "closure-compiler-20191111"],
     "os": "linux"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit"],
+    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit", "closure-compiler-20191111"],
     "os": "osx"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit"],
+    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "closure-compiler-20191111"],
     "os": "win"
   },
   {


### PR DESCRIPTION
Also drop Java.

To land this, please upload http://clb.confined.space/dump/google-closure-compiler-20191111.zip to Google emsdk hosting. The zip was generated via instructions by @dcodeIO at https://github.com/emscripten-core/emscripten/pull/9962#issuecomment-562328316 . 