### PR TITLE
Add npm install step as post-build to Emscripten

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1267,7 +1267,7 @@ def emscripten_npm_install(tool, directory):
   npm = os.path.join(node_path, 'npm' + ('.cmd' if WINDOWS else ''))
   env = os.environ.copy()
   env["PATH"] = node_path + os.pathsep + env["PATH"]
-  subprocess.check_call([npm, 'install'], cwd=directory, env=env)
+  subprocess.check_call([npm, 'install', '--production'], cwd=directory, env=env)
   return True
 
 

--- a/emsdk.py
+++ b/emsdk.py
@@ -1263,8 +1263,11 @@ def emscripten_npm_install(tool, directory):
     print('Failed to run "npm install" in installed Emscripten root directory ' + tool.installation_path() + '! Please install node.js first!')
     return False
 
-  npm = os.path.join(node_tool.installation_path(), 'bin', 'npm' + ('.cmd' if WINDOWS else ''))
-  subprocess.check_call([npm, 'install'], cwd=directory)
+  node_path = os.path.join(node_tool.installation_path(), 'bin')
+  npm = os.path.join(node_path, 'npm' + ('.cmd' if WINDOWS else ''))
+  env = os.environ.copy()
+  env["PATH"] = node_path + os.pathsep + env["PATH"]
+  subprocess.check_call([npm, 'install'], cwd=directory, env=env)
   return True
 
 

--- a/emsdk.py
+++ b/emsdk.py
@@ -1247,7 +1247,6 @@ def is_optimizer_installed(tool):
 
 # Finds newest tool of given name that is active, or if none are active, finds the newest one that is installed.
 def find_latest_active_or_installed_tool(name):
-  global tools
   for t in reversed(tools):
     if t.id == name and t.is_active():
       return t
@@ -1257,8 +1256,8 @@ def find_latest_active_or_installed_tool(name):
       return t
 
 
-def build_optimizer_and_npm(tool):
-  debug_print('build_optimizer_and_npm(' + str(tool) + ')')
+def emscripten_post_install(tool):
+  debug_print('emscripten_post_install(' + str(tool) + ')')
   src_root = os.path.join(tool.installation_path(), 'tools', 'optimizer')
   build_root = optimizer_build_root(tool)
   build_type = decide_cmake_build_type(tool)
@@ -1289,11 +1288,11 @@ def build_optimizer_and_npm(tool):
   if not node_tool:
     print('Failed to run "npm install" in installed Emscripten root directory ' + tool.installation_path() + '! Please install node.js first!')
     return False
-  else:
-    npm = os.path.join(node_tool.installation_path(), 'npm' + ('.cmd' if WINDOWS else ''))
-    npm_ret = subprocess.check_call([npm, 'install'], cwd=tool.installation_path())
-    if npm_ret != 0:
-      return False
+
+  npm = os.path.join(node_tool.installation_path(), 'npm' + ('.cmd' if WINDOWS else ''))
+  npm_ret = subprocess.check_call([npm, 'install'], cwd=tool.installation_path())
+  if npm_ret != 0:
+    return False
 
   return True
 
@@ -1872,7 +1871,7 @@ class Tool(object):
 
       if success:
         if hasattr(self, 'custom_install_script'):
-          if self.custom_install_script == 'build_optimizer_and_npm':
+          if self.custom_install_script == 'emscripten_post_install':
             success = build_optimizer_tool(self)
           elif self.custom_install_script in ('build_fastcomp', 'build_llvm_monorepo'):
             # 'build_fastcomp' is a special one that does the download on its

--- a/emsdk.py
+++ b/emsdk.py
@@ -1263,7 +1263,7 @@ def emscripten_npm_install(tool, directory):
     print('Failed to run "npm install" in installed Emscripten root directory ' + tool.installation_path() + '! Please install node.js first!')
     return False
 
-  npm = os.path.join(node_tool.installation_path(), 'npm' + ('.cmd' if WINDOWS else ''))
+  npm = os.path.join(node_tool.installation_path(), 'bin', 'npm' + ('.cmd' if WINDOWS else ''))
   subprocess.check_call([npm, 'install'], cwd=directory)
   return True
 

--- a/emsdk.py
+++ b/emsdk.py
@@ -1837,7 +1837,7 @@ class Tool(object):
         success = tool.install()
         if not success:
           return False
-      if hasattr(self, 'custom_install_script') and self.custom_install_script == 'emscripten_npm_install':
+      if getattr(self, 'custom_install_script', None) == 'emscripten_npm_install':
         # upstream tools have hardcoded paths that are not stored in emsdk_manifest.json registry
         install_path = 'upstream' if 'releases-upstream' in self.version else 'fastcomp'
         success = emscripten_npm_install(self, os.path.join(emsdk_path(), install_path, 'emscripten'))

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -384,7 +384,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer",
+    "custom_install_script": "build_optimizer_and_npm",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -399,7 +399,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer",
+    "custom_install_script": "build_optimizer_and_npm",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -464,7 +464,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer",
+    "custom_install_script": "build_optimizer_and_npm",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -479,7 +479,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer",
+    "custom_install_script": "build_optimizer_and_npm",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -494,7 +494,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer",
+    "custom_install_script": "build_optimizer_and_npm",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -509,7 +509,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer",
+    "custom_install_script": "build_optimizer_and_npm",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -384,7 +384,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer_and_npm",
+    "custom_install_script": "emscripten_post_install",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -399,7 +399,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer_and_npm",
+    "custom_install_script": "emscripten_post_install",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -464,7 +464,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer_and_npm",
+    "custom_install_script": "emscripten_post_install",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -479,7 +479,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer_and_npm",
+    "custom_install_script": "emscripten_post_install",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -494,7 +494,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer_and_npm",
+    "custom_install_script": "emscripten_post_install",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },
@@ -509,7 +509,7 @@
     "activated_path": "%installation_dir%",
     "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
-    "custom_install_script": "build_optimizer_and_npm",
+    "custom_install_script": "emscripten_post_install",
     "custom_is_installed_script": "is_optimizer_installed",
     "custom_uninstall_script": "uninstall_optimizer"
   },

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -776,38 +776,44 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit"],
-    "os": "linux"
+    "uses": ["node-12.9.1-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "os": "linux",
+    "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit"],
-    "os": "osx"
+    "uses": ["node-12.9.1-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "os": "osx",
+    "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-upstream-%releases-tag%-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit"],
-    "os": "win"
+    "uses": ["node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "os": "win",
+    "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-12.9.1-64bit"],
-    "os": "linux"
+    "uses": ["node-12.9.1-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "os": "linux",
+    "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-12.9.1-64bit"],
-    "os": "osx"
+    "uses": ["node-12.9.1-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "os": "osx",
+    "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["releases-fastcomp-%releases-tag%-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit"],
-    "os": "win"
+    "uses": ["node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "os": "win",
+    "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "fastcomp-%precompiled_tag32%",


### PR DESCRIPTION
Automatically run `npm install` in Emscripten root directory after installing an Emscripten tool.