### PR TITLE
Migrate upstream Emscripten packages to Python 3.5.4

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -514,7 +514,7 @@
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "emscripten-master-64bit"],
+    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "python-3.5.4-64bit", "emscripten-master-64bit"],
     "os": "win"
   },
   {
@@ -702,7 +702,7 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-12.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-12.9.1-64bit", "python-3.5.4-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   },


### PR DESCRIPTION
Migrate upstream Emscripten packages to Python 3.5.4 from old Python 2.7.13.1