### PR TITLE
Re-add binaryen dep to upstream-master SDK builds

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -514,19 +514,19 @@
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "emscripten-master-64bit"],
+    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "python-2.7.13.1-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "win"
   },
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit"],
+    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "osx"
   },
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit"],
+    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "linux"
   },
   {


### PR DESCRIPTION
This should ensure that BINARYEN_PATH is added to the resulting
~/.emscripten file when building from source:

https://github.com/emscripten-core/emsdk/issues/434

Tested briefly on macOS with `emsdk install sdk-upstream-master-64bit`.