### PR TITLE
Make installation errors fatal

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1397,7 +1397,8 @@ def get_required_path(active_tools):
   path_add = [to_native_path(emsdk_path())]
   for tool in active_tools:
     if hasattr(tool, 'activated_path'):
-      path_add += [to_native_path(tool.expand_vars(tool.activated_path))]
+      path = to_native_path(tool.expand_vars(tool.activated_path))
+      path_add.append(path)
   return path_add
 
 
@@ -1685,13 +1686,13 @@ class Tool(object):
     # clang-master-64bit, clang-master-32bit and clang-master-64bit each
     # share the same git repo), require that in addition to the installation
     # directory, each item in the activated PATH must exist.
-    activated_path = self.expand_vars(self.activated_path).split(';') if hasattr(self, 'activated_path') else [self.installation_path()]
+    if hasattr(self, 'activated_path'):
+      activated_path = self.expand_vars(self.activated_path).split(';')
+    else:
+      activated_path = [self.installation_path()]
 
     def each_path_exists(pathlist):
-      for path in pathlist:
-        if not os.path.exists(path):
-          return False
-      return True
+      return all(os.path.exists(p) for p in pathlist)
 
     content_exists = os.path.exists(self.installation_path()) and each_path_exists(activated_path) and (os.path.isfile(self.installation_path()) or num_files_in_directory(self.installation_path()) > 0)
 
@@ -1919,7 +1920,9 @@ class Tool(object):
       with open(version_file_path, 'w') as version_file:
         version_file.write(version_id)
     else:
-      print("Warning: The installation of '" + str(self) + "' seems to have failed, but no error was detected. Either something went wrong with the installation, or this may indicate an internal emsdk error.")
+      print("Installation of '" + str(self) + "' failed, but no error was detected. Either something went wrong with the installation, or this may indicate an internal emsdk error.")
+      return False
+
     return True
 
   def cleanup_temp_install_files(self):
@@ -2567,22 +2570,24 @@ def adjusted_path(tools_to_activate, log_additions=False, system_path_only=False
     existing_path = os.environ['PATH'].split(ENVPATH_SEPARATOR)
   emsdk_root_path = to_unix_path(emsdk_path())
 
-  existing_emsdk_tools = [item for item in existing_path if to_unix_path(item).startswith(emsdk_root_path)]
-  new_emsdk_tools = [item for item in path_add if not normalized_contains(existing_emsdk_tools, item)]
+  existing_emsdk_tools = [i for i in existing_path if to_unix_path(i).startswith(emsdk_root_path)]
+  new_emsdk_tools = [i for i in path_add if not normalized_contains(existing_emsdk_tools, i)]
 
   # Existing non-emsdk tools
-  existing_path = [item for item in existing_path if not to_unix_path(item).startswith(emsdk_root_path)]
-  new_path = [item for item in path_add if not normalized_contains(existing_path, item)]
+  existing_path = [i for i in existing_path if not to_unix_path(i).startswith(emsdk_root_path)]
+
+  new_path = [i for i in path_add if not normalized_contains(existing_path, i)]
   whole_path = unique_items(new_path + existing_path)
   if MSYS:
     # XXX Hack: If running native Windows Python in MSYS prompt where PATH
     # entries look like "/c/Windows/System32", os.environ['PATH']
     # in Python will transform to show them as "C:\\Windows\\System32", so need
     # to reconvert path delimiter back to forward slashes.
-    whole_path = list(map(to_msys_path, whole_path))
-    new_emsdk_tools = list(map(to_msys_path, new_emsdk_tools))
+    whole_path = [to_msys_path(p) for p in whole_path]
+    new_emsdk_tools = [to_msys_path(p) for p in new_emsdk_tools]
 
-  return ((':' if MSYS else ENVPATH_SEPARATOR).join(whole_path), new_emsdk_tools)
+  separator = ':' if MSYS else ENVPATH_SEPARATOR
+  return (separator.join(whole_path), new_emsdk_tools)
 
 
 def construct_env(tools_to_activate, permanent):

--- a/emsdk.py
+++ b/emsdk.py
@@ -2575,7 +2575,6 @@ def adjusted_path(tools_to_activate, log_additions=False, system_path_only=False
 
   # Existing non-emsdk tools
   existing_path = [i for i in existing_path if not to_unix_path(i).startswith(emsdk_root_path)]
-
   new_path = [i for i in path_add if not normalized_contains(existing_path, i)]
   whole_path = unique_items(new_path + existing_path)
   if MSYS:


### PR DESCRIPTION
If `is_installed` doesn't return true after install than something
serious went wrong so make this into a warning.

Also, clean up couple of places to make the python code more
readable.