### PR TITLE
Python needs to be present before llvm-git-master

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -514,7 +514,7 @@
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "python-3.7.4-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["python-3.7.4-64bit", "llvm-git-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "win"
   },
   {


### PR DESCRIPTION
Python needs to be present before llvm-git-master so that -DPYTHON_EXECUTABLE= is passed properly when building llvm-git-master.