### PR TITLE
Avoid re-downloading files that are already downloaded

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1885,11 +1885,11 @@ class Tool(object):
       print("Skipped installing " + self.name + ", already installed.")
       return True
 
-    version_hash = self.name
+    version_id = self.name
     version_file_path = os.path.join(self.installation_path(), '.emsdk_version')
     if os.path.isfile(version_file_path):
       with open(version_file_path, 'r') as version_file:
-        if version_hash == version_file.read():
+        if version_id == version_file.read():
           print("Skipped installing " + self.name + ", already installed.")
           return True
 
@@ -1954,7 +1954,7 @@ class Tool(object):
     if self.is_installed():
       self.cleanup_temp_install_files()
       with open(version_file_path, 'w') as version_file:
-        version_file.write(version_hash)
+        version_file.write(version_id)
     else:
       print("Warning: The installation of '" + str(self) + "' seems to have failed, but no error was detected. Either something went wrong with the installation, or this may indicate an internal emsdk error.")
     return True

--- a/emsdk.py
+++ b/emsdk.py
@@ -1886,13 +1886,12 @@ class Tool(object):
       return True
 
     version_hash = self.name
-    try:
-      with open(os.path.join(self.installation_path(), '.emsdk_version'), 'r') as version_file:
+    version_file_path = os.path.join(self.installation_path(), '.emsdk_version')
+    if os.path.isfile(version_file_path):
+      with open(version_file_path, 'r') as version_file:
         if version_hash == version_file.read():
           print("Skipped installing " + self.name + ", already installed.")
           return True
-    except FileNotFoundError:
-      pass
 
     print("Installing tool '" + str(self) + "'..")
     url = self.download_url()
@@ -1954,8 +1953,8 @@ class Tool(object):
     # leftover installation files.
     if self.is_installed():
       self.cleanup_temp_install_files()
-      with open(os.path.join(self.installation_path(), '.emsdk_version'), 'w') as version_file:
-        version_file.write(self.name)
+      with open(version_file_path, 'w') as version_file:
+        version_file.write(version_hash)
     else:
       print("Warning: The installation of '" + str(self) + "' seems to have failed, but no error was detected. Either something went wrong with the installation, or this may indicate an internal emsdk error.")
     return True

--- a/emsdk.py
+++ b/emsdk.py
@@ -1885,6 +1885,15 @@ class Tool(object):
       print("Skipped installing " + self.name + ", already installed.")
       return True
 
+    version_hash = self.name
+    try:
+      with open(os.path.join(self.installation_path(), '.emsdk_version'), 'r') as version_file:
+        if version_hash == version_file.read():
+          print("Skipped installing " + self.name + ", already installed.")
+          return True
+    except FileNotFoundError:
+      pass
+
     print("Installing tool '" + str(self) + "'..")
     url = self.download_url()
 
@@ -1945,6 +1954,8 @@ class Tool(object):
     # leftover installation files.
     if self.is_installed():
       self.cleanup_temp_install_files()
+      with open(os.path.join(self.installation_path(), '.emsdk_version'), 'w') as version_file:
+        version_file.write(self.name)
     else:
       print("Warning: The installation of '" + str(self) + "' seems to have failed, but no error was detected. Either something went wrong with the installation, or this may indicate an internal emsdk error.")
     return True

--- a/test.py
+++ b/test.py
@@ -6,6 +6,19 @@ import subprocess
 import sys
 import tempfile
 
+WINDOWS = sys.platform.startswith('win')
+MACOS = sys.platform == 'darwin'
+
+upstream_emcc = os.path.join('upstream', 'emscripten', 'emcc')
+fastcomp_emcc = os.path.join('fastcomp', 'emscripten', 'emcc')
+emsdk = './emsdk'
+if WINDOWS:
+  upstream_emcc += '.bat'
+  fastcomp_emcc += '.bat'
+  emsdk = 'emsdk.bat'
+else:
+  emsdk = './emsdk'
+
 # Utilities
 
 
@@ -102,20 +115,6 @@ def run_emsdk(cmd):
   if type(cmd) != list:
     cmd = cmd.split()
   check_call([emsdk] + cmd)
-
-
-WINDOWS = sys.platform.startswith('win')
-MACOS = sys.platform == 'darwin'
-
-upstream_emcc = os.path.join('upstream', 'emscripten', 'emcc')
-fastcomp_emcc = os.path.join('fastcomp', 'emscripten', 'emcc')
-emsdk = './emsdk'
-if WINDOWS:
-  upstream_emcc += '.bat'
-  fastcomp_emcc += '.bat'
-  emsdk = 'emsdk.bat'
-else:
-  emsdk = './emsdk'
 
 test_lib_building(upstream_emcc, use_asmjs_optimizer=True)
 

--- a/test.py
+++ b/test.py
@@ -116,6 +116,7 @@ def run_emsdk(cmd):
     cmd = cmd.split()
   check_call([emsdk] + cmd)
 
+
 test_lib_building(upstream_emcc, use_asmjs_optimizer=True)
 
 print('update')

--- a/test.py
+++ b/test.py
@@ -64,6 +64,9 @@ print('test .emscripten contents (latest was installed/activated in test.sh)')
 assert 'fastcomp' not in open(os.path.expanduser('~/.emscripten')).read()
 assert 'upstream' in open(os.path.expanduser('~/.emscripten')).read()
 
+# Test we don't re-download unnecessarily
+checked_call_with_output(emsdk + ' install latest', expected='already installed', unexpected='Downloading:')
+
 print('building proper system libraries')
 
 


### PR DESCRIPTION
- Writes a `.emsdk_version` file to output directories using the name (which contains a version number and/or hash) once all installation steps have completed successfully
- If that file exists, skip downloading/installation hooks.

My primary use case for this is running `emsdk.py install latest` as part of another repository's setup steps - and I want to avoid developers needlessly downloading the same large tarballs every time they run it.