### PR TITLE
Set user environment variables by default when giving `--global` in Windows

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2584,7 +2584,7 @@ def to_msys_path(p):
 
 # Looks at the current PATH and adds and removes entries so that the PATH reflects
 # the set of given active tools.
-def adjusted_path(tools_to_activate, log_additions=False, system=False):
+def adjusted_path(tools_to_activate, system=False):
   # These directories should be added to PATH
   path_add = get_required_path(tools_to_activate)
   # These already exist.


### PR DESCRIPTION
Fixes #467

This makes `./emsdk activate --global` to set user environment variables by default instead of previous system-wide-only activation.

Also removes some magic that implicitly nukes user envvars when system ones are shadowed, as a system admin should understand what's going on when setting envvars. Thus fixes #189 and closes #192.