### PR TITLE
Remove reference of old clang binary.

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -680,12 +680,6 @@
     "os": "unix"
   },
   {
-    "version": "1.37.1",
-    "bitness": 64,
-    "uses": ["clang-e1.37.1-64bit", "node-4.1.1-64bit", "python-2.7.13.1-64bit", "emscripten-1.37.1"],
-    "os": "win"
-  },
-  {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
     "uses": ["node-12.9.1-64bit", "releases-upstream-%releases-tag%-64bit"],


### PR DESCRIPTION
I think this should have been part of #395.

Fixes: https://github.com/emscripten-core/emscripten/issues/10904