### PR TITLE
Re-enable building master from source for linux 32-bit

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -530,6 +530,12 @@
     "os": "linux"
   },
   {
+    "version": "upstream-master",
+    "bitness": 32,
+    "uses": ["llvm-git-master-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
+    "os": "linux"
+  },
+  {
     "version": "fastcomp-master",
     "bitness": 32,
     "uses": ["fastcomp-clang-master-32bit", "node-12.9.1-32bit", "python-3.7.4-32bit", "java-8.152-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],


### PR DESCRIPTION
Doing this for windows is trickier as we would also need to provide
the python binaries for win32.

Fixes: #470