### PR TITLE
test.py should require that the SDK be activated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: test.py
           command: |
             source emsdk_env.sh
-            python scripts/test.py
+            scripts/test.py
   test-windows:
     executor:
       name: win/vs2019
@@ -88,7 +88,7 @@ jobs:
           name: test.py
           command: |
             source emsdk_env.sh
-            scripts/test.py
+            python scripts/test.py
 
 workflows:
   flake8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,11 @@ jobs:
           name: Install debian packages
           command: apt-get update -q && apt-get install -q -y cmake build-essential openjdk-8-jre-headless
       - run: scripts/test.sh
-      - run: scripts/test.py
+      - run:
+          name: test.py
+          command: |
+            source emsdk_env.sh
+            scripts/test.py
   test-mac:
     macos:
       xcode: "9.0"
@@ -54,7 +58,11 @@ jobs:
           name: Install python 3
           command: brew install python3
       - run: scripts/test.sh
-      - run: scripts/test.py
+      - run:
+          name: test.py
+          command: |
+            source emsdk_env.sh
+            scripts/test.py
   test-windows:
     executor:
       name: win/vs2019
@@ -76,7 +84,11 @@ jobs:
           name: Install latest
           shell: cmd.exe
           command: scripts\test.bat
-      - run: python scripts/test.py
+      - run:
+          name: test.py
+          command: |
+            source emsdk_env.sh
+            scripts/test.py
 
 workflows:
   flake8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: test.py
           command: |
             source emsdk_env.sh
-            scripts/test.py
+            python scripts/test.py
   test-windows:
     executor:
       name: win/vs2019

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -9,6 +9,9 @@ import tempfile
 WINDOWS = sys.platform.startswith('win')
 MACOS = sys.platform == 'darwin'
 
+assert 'EM_CONFIG' in os.environ, "emsdk should be activated before running this script"
+
+emconfig = os.environ['EM_CONFIG']
 upstream_emcc = os.path.join('upstream', 'emscripten', 'emcc')
 fastcomp_emcc = os.path.join('fastcomp', 'emscripten', 'emcc')
 emsdk = './emsdk'
@@ -77,13 +80,14 @@ int main() {
 
 TAGS = json.loads(open('emscripten-releases-tags.txt').read())
 
-LIBC = os.path.expanduser('~/.emscripten_cache/wasm/libc.a')
+DEFAULT_CACHE = os.path.expanduser('~/.emscripten_cache')
+LIBC = os.environ.get('EM_CACHE', DEFAULT_CACHE) + '/wasm/libc.a'
 
 # Tests
 
 print('test .emscripten contents (latest was installed/activated in test.sh)')
-assert 'fastcomp' not in open(os.path.expanduser('~/.emscripten')).read()
-assert 'upstream' in open(os.path.expanduser('~/.emscripten')).read()
+assert 'fastcomp' not in open(emconfig).read()
+assert 'upstream' in open(emconfig).read()
 
 # Test we don't re-download unnecessarily
 checked_call_with_output(emsdk + ' install latest', expected='already installed', unexpected='Downloading:')
@@ -135,9 +139,9 @@ run_emsdk('install latest-fastcomp')
 run_emsdk('activate latest-fastcomp')
 
 test_lib_building(fastcomp_emcc, use_asmjs_optimizer=False)
-assert open(os.path.expanduser('~/.emscripten')).read().count('LLVM_ROOT') == 1
-assert 'upstream' not in open(os.path.expanduser('~/.emscripten')).read()
-assert 'fastcomp' in open(os.path.expanduser('~/.emscripten')).read()
+assert open(emconfig).read().count('LLVM_ROOT') == 1
+assert 'upstream' not in open(emconfig).read()
+assert 'fastcomp' in open(emconfig).read()
 
 print('verify version')
 checked_call_with_output(fastcomp_emcc + ' -v', TAGS['latest'], stderr=subprocess.STDOUT)
@@ -155,9 +159,9 @@ checked_call_with_output(emsdk + ' install node-12.9.1-64bit', unexpected='Downl
 print('test tot-upstream')
 run_emsdk('install tot-upstream')
 assert not os.path.exists(LIBC)
-old_config = open(os.path.expanduser('~/.emscripten')).read()
+old_config = open(emconfig).read()
 run_emsdk('activate tot-upstream')
-assert old_config == open(os.path.expanduser('~/.emscripten.old')).read()
+assert old_config == open(emconfig + '.old').read()
 # TODO; test on latest as well
 assert os.path.exists(LIBC), 'activation supplies prebuilt libc'
 check_call(upstream_emcc + ' hello_world.c')
@@ -176,8 +180,8 @@ run_emsdk('install 1.38.33')
 print('another install, but no need for re-download')
 checked_call_with_output(emsdk + ' install 1.38.33', expected='Skipped', unexpected='Downloading:')
 run_emsdk('activate 1.38.33')
-assert 'upstream' not in open(os.path.expanduser('~/.emscripten')).read()
-assert 'fastcomp' in open(os.path.expanduser('~/.emscripten')).read()
+assert 'upstream' not in open(emconfig).read()
+assert 'fastcomp' in open(emconfig).read()
 
 print('test specific release (new, full name)')
 run_emsdk('install sdk-1.38.33-upstream-64bit')


### PR DESCRIPTION
It was working previously by accident because the tests were
using the defaults such as $HOME/.emscripten.  However usage of the
emsdk should really only happen in the emsdk environment where
EM_CONFIG dictates the config location (not just using the default).

This change is needed as precursor to making `--embedded` the default
(in this case the config doesn't live in `$HOME/.emscripten`).