### PR TITLE
Allow EMCC_BASH to force bash during construct_env

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -79,8 +79,11 @@ UNIX = (OSX or LINUX)
 # Pick which shell of 4 shells to use
 POWERSHELL = bool(os.getenv('EMSDK_POWERSHELL'))
 CSH = bool(os.getenv('EMSDK_CSH'))
-BASH = bool(os.getenv('EMSDK_BASH'))
 CMD = bool(os.getenv('EMSDK_CMD'))
+BASH = bool(os.getenv('EMSDK_BASH'))
+if WINDOWS and BASH:
+  MSYS = True
+
 if not CSH and not POWERSHELL and not BASH and not CMD:
   # Fall back to default of `cmd` on windows and `bash` otherwise
   if WINDOWS and not MSYS:
@@ -88,7 +91,7 @@ if not CSH and not POWERSHELL and not BASH and not CMD:
   else:
     BASH = True
 
-if CMD:
+if WINDOWS and not MSYS:
   ENVPATH_SEPARATOR = ';'
 else:
   ENVPATH_SEPARATOR = ':'

--- a/emsdk.py
+++ b/emsdk.py
@@ -91,7 +91,7 @@ if not CSH and not POWERSHELL and not BASH and not CMD:
   else:
     BASH = True
 
-if WINDOWS and not MSYS:
+if WINDOWS:
   ENVPATH_SEPARATOR = ';'
 else:
   ENVPATH_SEPARATOR = ':'
@@ -171,7 +171,7 @@ if os.path.exists(os.path.join(emsdk_path(), '.emscripten')):
   emscripten_config_directory = emsdk_path()
 
 EMSDK_SET_ENV = 'emsdk_set_env.ps1' if POWERSHELL \
-    else 'emsdk_set_env.bat' if CMD \
+    else 'emsdk_set_env.bat' if (WINDOWS and not MSYS) \
     else 'emsdk_set_env.csh' if CSH \
     else 'emsdk_set_env.sh'
 
@@ -1385,7 +1385,7 @@ def download_and_unzip(zipfile, dest_dir, download_even_if_exists=False,
 
 
 def to_native_path(p):
-  if WINDOWS and CMD:
+  if WINDOWS and not MSYS:
     return to_unix_path(p).replace('/', '\\')
   else:
     return to_unix_path(p)
@@ -2581,7 +2581,7 @@ def adjusted_path(tools_to_activate, log_additions=False, system_path_only=False
     whole_path = list(map(to_msys_path, whole_path))
     new_emsdk_tools = list(map(to_msys_path, new_emsdk_tools))
 
-  return (ENVPATH_SEPARATOR.join(whole_path), new_emsdk_tools)
+  return ((':' if MSYS else ENVPATH_SEPARATOR).join(whole_path), new_emsdk_tools)
 
 
 def construct_env(tools_to_activate, permanent):

--- a/emsdk.py
+++ b/emsdk.py
@@ -2575,7 +2575,7 @@ def adjusted_path(tools_to_activate, log_additions=False, system_path_only=False
     whole_path = list(map(to_msys_path, whole_path))
     new_emsdk_tools = list(map(to_msys_path, new_emsdk_tools))
 
-  return ENVPATH_SEPARATOR.join(whole_path), new_emsdk_tools)
+  return (ENVPATH_SEPARATOR.join(whole_path), new_emsdk_tools)
 
 
 def construct_env(tools_to_activate, permanent):

--- a/emsdk.py
+++ b/emsdk.py
@@ -51,7 +51,6 @@ TTY_OUTPUT = not os.getenv('EMSDK_NOTTY', not sys.stdout.isatty())
 WINDOWS = False
 if os.name == 'nt' or (os.getenv('SYSTEMROOT') is not None and 'windows' in os.getenv('SYSTEMROOT').lower()) or (os.getenv('COMSPEC') is not None and 'windows' in os.getenv('COMSPEC').lower()):
   WINDOWS = True
-  ENVPATH_SEPARATOR = ';'
 
 MINGW = False
 MSYS = False
@@ -69,12 +68,10 @@ if os.getenv('MSYSTEM'):
 OSX = False
 if platform.mac_ver()[0] != '':
   OSX = True
-  ENVPATH_SEPARATOR = ':'
 
 LINUX = False
 if not OSX and (platform.system() == 'Linux' or os.name == 'posix'):
   LINUX = True
-  ENVPATH_SEPARATOR = ':'
 
 UNIX = (OSX or LINUX)
 
@@ -88,8 +85,10 @@ if not CSH and not POWERSHELL and not BASH and not CMD:
   # Fall back to default of `cmd` on windows and `bash` otherwise
   if WINDOWS and not MSYS:
     CMD = True
+    ENVPATH_SEPARATOR = ';'
   else:
     BASH = True
+    ENVPATH_SEPARATOR = ':'
 
 
 ARCH = 'unknown'
@@ -1380,7 +1379,7 @@ def download_and_unzip(zipfile, dest_dir, download_even_if_exists=False,
 
 
 def to_native_path(p):
-  if WINDOWS and not MSYS:
+  if WINDOWS and CMD:
     return to_unix_path(p).replace('/', '\\')
   else:
     return to_unix_path(p)
@@ -2576,7 +2575,7 @@ def adjusted_path(tools_to_activate, log_additions=False, system_path_only=False
     whole_path = list(map(to_msys_path, whole_path))
     new_emsdk_tools = list(map(to_msys_path, new_emsdk_tools))
 
-  return ((':' if MSYS else ENVPATH_SEPARATOR).join(whole_path), new_emsdk_tools)
+  return ENVPATH_SEPARATOR.join(whole_path), new_emsdk_tools)
 
 
 def construct_env(tools_to_activate, permanent):

--- a/emsdk.py
+++ b/emsdk.py
@@ -85,10 +85,13 @@ if not CSH and not POWERSHELL and not BASH and not CMD:
   # Fall back to default of `cmd` on windows and `bash` otherwise
   if WINDOWS and not MSYS:
     CMD = True
-    ENVPATH_SEPARATOR = ';'
   else:
     BASH = True
-    ENVPATH_SEPARATOR = ':'
+
+if CMD:
+  ENVPATH_SEPARATOR = ';'
+else:
+  ENVPATH_SEPARATOR = ':'
 
 
 ARCH = 'unknown'

--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This script is sourced by the user and uses
 # their shell. Try not to use bashisms.
 
@@ -23,7 +24,8 @@ cd "$(dirname "$SRC")"
 unset SRC
 
 tmpfile=`mktemp` || exit 1
-./emsdk construct_env $tmpfile
+# Force emsdk to use bash syntax so that this works in windows + bash too
+EMSDK_BASH=1 ./emsdk construct_env $tmpfile
 . $tmpfile
 rm -f $tmpfile
 


### PR DESCRIPTION
This allows emsdk_env.sh to work under bash for windows. Without
this emsdk will default to cmd.exe syntax when running on windows
and `source emsdk_env.sh` will not work.