### PR TITLE
Fix for parsing existing config in --embedded mode after #495

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1736,8 +1736,9 @@ class Tool(object):
         debug_print(str(self) + ' is not active, because key="' + key + '" does not exist in .emscripten')
         return False
 
-      # If running in embedded mode, all paths are stored dynamically relative to the emsdk root, so normalize those first.
-      dot_emscripten_key = dot_emscripten[key].replace("' + emsdk_path + '", emsdk_path())
+      # If running in embedded mode, all paths are stored dynamically relative
+      # to the emsdk root, so normalize those first.
+      dot_emscripten_key = dot_emscripten[key].replace("emsdk_path + '", "'" + emsdk_path())
       if dot_emscripten_key != value:
         debug_print(str(self) + ' is not active, because key="' + key + '" has value "' + dot_emscripten_key + '" but should have value "' + value + '"')
         return False


### PR DESCRIPTION
Ooops, I guess even the most innocent-seeming change can have
unintended consequences. Switching to embedded by default will at
least make this path more tested in the future.

Fixed #497