### PR TITLE
Remove legacy builds

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2176,11 +2176,11 @@ def remove_suffix(s, suffix):
     return s
 
 
-# filename should be one of: 'llvm-nightlies-32bit.txt', 'llvm-nightlies-64bit.txt', 'llvm-precompiled-tags-32bit.txt', 'llvm-precompiled-tags-64bit.txt', 'emscripten-nightlies.txt'
+# filename should be one of: 'llvm-precompiled-tags-32bit.txt', 'llvm-precompiled-tags-64bit.txt'
 def load_file_index_list(filename):
   try:
     items = open(sdk_path(filename), 'r').read().split('\n')
-    items = map(lambda x: remove_suffix(remove_suffix(remove_prefix(remove_prefix(x, 'emscripten-llvm-e'), 'emscripten-nightly-'), '.tar.gz'), '.zip').strip(), items)
+    items = map(lambda x: remove_suffix(remove_suffix(remove_prefix(x, 'emscripten-llvm-e'), '.tar.gz'), '.zip').strip(), items)
     items = filter(lambda x: 'latest' not in x and len(x) > 0, items)
 
     # Sort versions from oldest to newest (the default sort would be lexicographic, i.e. '1.37.1 < 1.37.10 < 1.37.2')
@@ -2189,18 +2189,6 @@ def load_file_index_list(filename):
     return items
   except:
     return []
-
-
-def load_llvm_32bit_nightlies():
-  return load_file_index_list('llvm-nightlies-32bit.txt')
-
-
-def load_llvm_64bit_nightlies():
-  return load_file_index_list('llvm-nightlies-64bit.txt')
-
-
-def load_emscripten_nightlies():
-  return load_file_index_list('emscripten-nightlies.txt')
 
 
 def load_llvm_precompiled_tags_32bit():
@@ -2264,9 +2252,6 @@ def load_sdk_manifest():
   llvm_precompiled_tags_64bit = list(reversed(load_llvm_precompiled_tags_64bit()))
   llvm_precompiled_tags = llvm_precompiled_tags_32bit + llvm_precompiled_tags_64bit
   binaryen_tags = load_legacy_binaryen_tags()
-  llvm_32bit_nightlies = list(reversed(load_llvm_32bit_nightlies()))
-  llvm_64bit_nightlies = list(reversed(load_llvm_64bit_nightlies()))
-  emscripten_nightlies = list(reversed(load_emscripten_nightlies()))
   releases_tags = load_releases_tags()
 
   def dependencies_exist(sdk):
@@ -2298,7 +2283,7 @@ def load_sdk_manifest():
     return True
 
   # A 'category parameter' is a %foo%-encoded identifier that specifies
-  # a class of tools instead of just one tool, e.g. %tag% or %nightly..%
+  # a class of tools instead of just one tool, e.g. %tag%
   def expand_category_param(param, category_list, t, is_sdk):
     for i, ver in enumerate(category_list):
       if not ver.strip():
@@ -2339,7 +2324,7 @@ def load_sdk_manifest():
       if not hasattr(t, 'is_old'):
         t.is_old = False
 
-      # Expand the metapackages that refer to tags or nightlies.
+      # Expand the metapackages that refer to tags
       if '%tag%' in t.version:
         expand_category_param('%tag%', emscripten_tags, t, is_sdk=False)
       elif '%precompiled_tag%' in t.version:
@@ -2350,12 +2335,6 @@ def load_sdk_manifest():
         expand_category_param('%precompiled_tag64%', llvm_precompiled_tags_64bit, t, is_sdk=False)
       elif '%binaryen_tag%' in t.version:
         expand_category_param('%binaryen_tag%', binaryen_tags, t, is_sdk=False)
-      elif '%nightly-llvm-64bit%' in t.version:
-        expand_category_param('%nightly-llvm-64bit%', llvm_64bit_nightlies, t, is_sdk=False)
-      elif '%nightly-llvm-32bit%' in t.version:
-        expand_category_param('%nightly-llvm-32bit%', llvm_32bit_nightlies, t, is_sdk=False)
-      elif '%nightly-emscripten%' in t.version:
-        expand_category_param('%nightly-emscripten%', emscripten_nightlies, t, is_sdk=False)
       elif '%releases-tag%' in t.version:
         expand_category_param('%releases-tag%', releases_tags, t, is_sdk=False)
       else:
@@ -2376,12 +2355,6 @@ def load_sdk_manifest():
         expand_category_param('%precompiled_tag32%', llvm_precompiled_tags_32bit, sdk, is_sdk=True)
       elif '%precompiled_tag64%' in sdk.version:
         expand_category_param('%precompiled_tag64%', llvm_precompiled_tags_64bit, sdk, is_sdk=True)
-      elif '%nightly-llvm-64bit%' in sdk.version:
-        expand_category_param('%nightly-llvm-64bit%', llvm_64bit_nightlies, sdk, is_sdk=True)
-      elif '%nightly-llvm-32bit%' in sdk.version:
-        expand_category_param('%nightly-llvm-32bit%', llvm_32bit_nightlies, sdk, is_sdk=True)
-      elif '%nightly-emscripten%' in sdk.version:
-        expand_category_param('%nightly-emscripten%', emscripten_nightlies, sdk, is_sdk=True)
       elif '%releases-tag%' in sdk.version:
         expand_category_param('%releases-tag%', releases_tags, sdk, is_sdk=True)
       else:

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -61,19 +61,6 @@
   },
   {
     "id": "fastcomp-clang",
-    "version": "nightly-e%nightly-llvm-64bit%",
-    "bitness": 64,
-    "arch": "x86_64",
-    "append_bitness": false,
-    "windows_url": "llvm/nightly/win_64bit/emscripten-llvm-e%nightly-llvm-64bit%.zip",
-    "osx_url": "llvm/nightly/osx_64bit/emscripten-llvm-e%nightly-llvm-64bit%.tar.gz",
-    "linux_url": "llvm/nightly/linux_64bit/emscripten-llvm-e%nightly-llvm-64bit%.tar.gz",
-    "activated_path": "%installation_dir%",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%;EMCC_WASM_BACKEND=0"
-  },
-  {
-    "id": "fastcomp-clang",
     "version": "master",
     "bitness": 32,
     "install_path": "clang/fastcomp",
@@ -155,49 +142,6 @@
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
     "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen;EMCC_WASM_BACKEND=0"
-  },
-  {
-    "id": "node",
-    "version": "4.1.1",
-    "bitness": 32,
-    "arch": "x86",
-    "windows_url": "node_4.1.1_32bit.zip",
-    "linux_url": "node-v4.1.1-linux-x86.tar.gz",
-    "activated_path": "%installation_dir%/bin",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
-    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
-  },
-  {
-    "id": "node",
-    "version": "4.1.1",
-    "bitness": 32,
-    "arch": "arm",
-    "linux_url": "https://nodejs.org/download/release/v4.1.1/node-v4.1.1-linux-armv7l.tar.xz",
-    "activated_path": "%installation_dir%/bin",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
-    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
-  },
-  {
-    "id": "node",
-    "version": "4.1.1",
-    "bitness": 64,
-    "arch": "x86_64",
-    "osx_url": "node-v4.1.1-darwin-x64.tar.gz",
-    "windows_url": "node_4.1.1_64bit.zip",
-    "linux_url": "node-v4.1.1-linux-x64.tar.gz",
-    "activated_path": "%installation_dir%/bin",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
-    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
-  },
-  {
-    "id": "node",
-    "version": "4.1.1",
-    "bitness": 64,
-    "arch": "aarch64",
-    "linux_url": "https://nodejs.org/download/release/v4.1.1/node-v4.1.1-linux-arm64.tar.gz",
-    "activated_path": "%installation_dir%/bin",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
-    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
   {
     "id": "node",
@@ -438,15 +382,6 @@
   },
   {
     "id": "emscripten",
-    "version": "nightly-%nightly-emscripten%",
-    "windows_url": "emscripten/nightly/win/emscripten-nightly-%nightly-emscripten%.zip",
-    "unix_url": "emscripten/nightly/linux/emscripten-nightly-%nightly-emscripten%.tar.gz",
-    "activated_cfg": "EMSCRIPTEN_ROOT='%installation_dir%'",
-    "activated_path": "%installation_dir%",
-    "activated_env": "EMSCRIPTEN=%installation_dir%"
-  },
-  {
-    "id": "emscripten",
     "version": "master",
     "bitness": 32,
     "append_bitness": false,
@@ -588,42 +523,6 @@
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 32,
-    "uses": ["fastcomp-clang-tag-e%tag%-32bit", "node-4.1.1-32bit", "python-2.7.13.1-32bit", "java-7.45-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
-    "os": "win",
-    "version_filter": [
-      ["%tag%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-tag-%tag%",
-    "bitness": 64,
-    "uses": ["fastcomp-clang-tag-e%tag%-64bit", "node-4.1.1-64bit", "python-2.7.13.1-64bit", "java-7.45-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
-    "os": "win",
-    "version_filter": [
-      ["%tag%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-tag-%tag%",
-    "bitness": 32,
-    "uses": ["fastcomp-clang-tag-e%tag%-32bit", "node-4.1.1-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
-    "os": "linux",
-    "version_filter": [
-      ["%tag%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-tag-%tag%",
-    "bitness": 64,
-    "uses": ["fastcomp-clang-tag-e%tag%-64bit", "node-4.1.1-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
-    "os": "unix",
-    "version_filter": [
-      ["%tag%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-tag-%tag%",
-    "bitness": 32,
     "uses": ["fastcomp-clang-tag-e%tag%-32bit", "node-8.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
     "os": "win",
     "version_filter": [
@@ -657,54 +556,6 @@
       ["%tag%", ">", "1.37.22"]
     ]
   },  
-  {
-    "version": "fastcomp-nightly-%nightly-llvm-32bit%",
-    "bitness": 32,
-    "uses": ["fastcomp-clang-nightly-e%nightly-llvm-32bit%-32bit", "node-4.1.1-32bit", "python-2.7.13.1-32bit", "java-7.45-32bit", "emscripten-nightly-%nightly-llvm-32bit%"],
-    "os": "win",
-    "version_filter": [
-      ["%nightly-llvm-32bit%", "<=", "1.37.22-2017_11_05"]
-    ]
-  },
-  {
-    "version": "fastcomp-nightly-%nightly-llvm-64bit%",
-    "bitness": 64,
-    "uses": ["fastcomp-clang-nightly-e%nightly-llvm-64bit%-64bit", "node-4.1.1-64bit", "python-2.7.13.1-64bit", "java-7.45-64bit", "emscripten-nightly-%nightly-llvm-64bit%"],
-    "os": "win",
-    "version_filter": [
-      ["%nightly-llvm-64bit%", "<=", "1.37.22-2017_11_05"]
-    ]
-  },
-  {
-    "version": "fastcomp-nightly-%nightly-llvm-32bit%",
-    "bitness": 32,
-    "uses": ["fastcomp-clang-nightly-e%nightly-llvm-32bit%-32bit", "node-4.1.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-nightly-%nightly-llvm-32bit%"],
-    "os": "win",
-    "version_filter": [
-      ["%nightly-llvm-32bit%", ">", "1.37.22-2017_11_05"]
-    ]
-  },
-  {
-    "version": "fastcomp-nightly-%nightly-llvm-64bit%",
-    "bitness": 64,
-    "uses": ["fastcomp-clang-nightly-e%nightly-llvm-64bit%-64bit", "node-4.1.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-nightly-%nightly-llvm-64bit%"],
-    "os": "win",
-    "version_filter": [
-      ["%nightly-llvm-64bit%", ">", "1.37.22-2017_11_05"]
-    ]
-  },
-  {
-    "version": "fastcomp-nightly-%nightly-llvm-32bit%",
-    "bitness": 32,
-    "uses": ["fastcomp-clang-nightly-e%nightly-llvm-32bit%-32bit", "node-4.1.1-64bit", "emscripten-nightly-%nightly-llvm-32bit%"],
-    "os": "unix"
-  },
-  {
-    "version": "fastcomp-nightly-%nightly-llvm-64bit%",
-    "bitness": 64,
-    "uses": ["fastcomp-clang-nightly-e%nightly-llvm-64bit%-64bit", "node-4.1.1-64bit", "emscripten-nightly-%nightly-llvm-64bit%"],
-    "os": "unix"
-  },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
@@ -746,60 +597,6 @@
     "uses": ["node-12.9.1-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
-  },
-  {
-    "version": "fastcomp-%precompiled_tag32%",
-    "bitness": 32,
-    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-4.1.1-32bit", "python-2.7.13.1-32bit", "java-7.45-32bit", "emscripten-%precompiled_tag32%"],
-    "os": "win",
-    "version_filter": [
-      ["%precompiled_tag32%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-%precompiled_tag64%",
-    "bitness": 64,
-    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-4.1.1-64bit", "python-2.7.13.1-64bit", "java-7.45-64bit", "emscripten-%precompiled_tag64%"],
-    "os": "win",
-    "version_filter": [
-      ["%precompiled_tag64%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-%precompiled_tag32%",
-    "bitness": 32,
-    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-4.1.1-32bit", "emscripten-%precompiled_tag32%"],
-    "os": "linux",
-    "version_filter": [
-      ["%precompiled_tag32%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-%precompiled_tag64%",
-    "bitness": 64,
-    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-4.1.1-64bit", "emscripten-%precompiled_tag64%"],
-    "os": "linux",
-    "version_filter": [
-      ["%precompiled_tag64%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-%precompiled_tag32%",
-    "bitness": 32,
-    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-4.1.1-32bit", "emscripten-%precompiled_tag32%"],
-    "os": "osx",
-    "version_filter": [
-      ["%precompiled_tag32%", "<=", "1.37.22"]
-    ]
-  },
-  {
-    "version": "fastcomp-%precompiled_tag64%",
-    "bitness": 64,
-    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-4.1.1-64bit", "emscripten-%precompiled_tag64%"],
-    "os": "osx",
-    "version_filter": [
-      ["%precompiled_tag64%", "<=", "1.37.22"]
-    ]
   },
   {
     "version": "fastcomp-%precompiled_tag32%",


### PR DESCRIPTION
"Legacy" here meaning anything using only < 1.38.0, and anything
using 'nightly' mozilla builds (which have not been done for years).

This also lets us remove node 4.1.1 (but not 8.9.1).