### PR TITLE
Update default emscripten cache directory

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2433,6 +2433,7 @@ def copy_pregenerated_cache(tools_to_activate):
       em_cache_dir = os.path.join(config['EMSCRIPTEN_ROOT'], 'cache')
       break
   else:
+    debug_print('Not copying pregenerated libaries (no EMSCRIPTEN_ROOT found)')
     return
 
   # If we found an EMSCRIPTEN_ROOT look for any tools that include

--- a/emsdk.py
+++ b/emsdk.py
@@ -1455,7 +1455,6 @@ def generate_dot_emscripten(active_tools):
   if embedded:
     cfg += 'import os\n'
     cfg += "emsdk_path = os.path.dirname(os.environ.get('EM_CONFIG')).replace('\\\\', '/')\n"
-    cfg += "CACHE = '%s'\n" % sdk_path('.emscripten_cache')
 
   # Different tools may provide the same activated configs; the latest to be
   # activated is the relevant one.
@@ -1490,11 +1489,9 @@ JS_ENGINES = [NODE_JS]
   with open(dot_emscripten_path(), "w") as text_file:
     text_file.write(cfg)
 
-  # Clear old cached emscripten content.
+  # Clear old emscripten content.
   try:
-    remove_tree(os.path.join(emscripten_config_directory, ".emscripten_cache"))
     os.remove(os.path.join(emscripten_config_directory, ".emscripten_sanity"))
-    os.remove(os.path.join(emscripten_config_directory, ".emscripten_cache__last_clear"))
   except:
     pass
 
@@ -2420,13 +2417,26 @@ def run_emcc(tools_to_activate):
         return
 
 
-def emscripten_cache_directory():
-  return os.path.join(emscripten_config_directory, ".emscripten_cache")
-
-
 # Copy over any emscripten cache contents that were pregenerated. This avoids
 # the user needing to immediately build libc etc. on first run.
+# This only applies to legacy SDK versions.  Anything built after
+# https://github.com/WebAssembly/waterfall/pull/644 already has the libraries
+# in the correct location.
+# TODO(sbc): Remove this code.
 def copy_pregenerated_cache(tools_to_activate):
+  em_cache_dir = None
+
+  # First look through all the tools to find the EMSCRIPTEN_ROOT
+  for tool in tools_to_activate:
+    config = tool.activated_config()
+    if 'EMSCRIPTEN_ROOT' in config:
+      em_cache_dir = os.path.join(config['EMSCRIPTEN_ROOT'], 'cache')
+      break
+  else:
+    return
+
+  # If we found an EMSCRIPTEN_ROOT look for any tools that include
+  # "pregenerated_cache" and copy those items into the cache.
   for tool in tools_to_activate:
     pregenerated_cache = getattr(tool, 'pregenerated_cache', None)
     if not pregenerated_cache:
@@ -2437,8 +2447,9 @@ def copy_pregenerated_cache(tools_to_activate):
       in_cache = os.path.join(install_path, 'lib', cache_dir)
       if not os.path.exists(in_cache):
         continue
-      out_cache = os.path.join(emscripten_cache_directory(), cache_dir)
-      os.makedirs(out_cache)
+      out_cache = os.path.join(em_cache_dir, cache_dir)
+      if not os.path.exists(out_cache):
+        os.makedirs(out_cache)
       for filename in os.listdir(in_cache):
         debug_print('Copying %s to cache: %s' % (filename, out_cache))
         shutil.copy2(os.path.join(in_cache, filename),
@@ -2600,15 +2611,14 @@ def construct_env(tools_to_activate, permanent):
   em_config_path = os.path.normpath(dot_emscripten_path())
   if to_unix_path(os.environ.get('EM_CONFIG', '')) != to_unix_path(em_config_path):
     env_vars_to_add += [('EM_CONFIG', em_config_path)]
-  if emscripten_config_directory == emsdk_path():
-    # Remove this once emscripten support CACHE in the config file:
-    # https://github.com/emscripten-core/emscripten/pull/11091
-    em_cache_dir = sdk_path('.emscripten_cache')
-    if to_unix_path(os.environ.get('EM_CACHE', '')) != to_unix_path(em_cache_dir):
-      env_vars_to_add += [('EM_CACHE', em_cache_dir)]
-    mkdir_p(em_cache_dir)
 
   for tool in tools_to_activate:
+    config = tool.activated_config()
+    if 'EMSCRIPTEN_ROOT' in config:
+      # For older emscripten versions that don't use this default we export
+      # EM_CACHE.
+      em_cache_dir = os.path.join(config['EMSCRIPTEN_ROOT'], 'cache')
+      env_vars_to_add += [('EM_CACHE', em_cache_dir)]
     envs = tool.activated_environment()
     for env in envs:
       key, value = parse_key_value(env)

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -101,7 +101,7 @@
     "activated_path": "%installation_dir%/emscripten",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT='%installation_dir%';EMSCRIPTEN_ROOT='%installation_dir%/emscripten'",
     "emscripten_releases_hash": "%releases-tag%",
-    "pregenerated_cache": ["wasm", "wasm-obj", "wasm-bc"]
+    "pregenerated_cache": ["asmjs", "wasm", "wasm-obj", "wasm-bc"]
   },
   {
     "id": "releases",
@@ -116,7 +116,7 @@
     "activated_path": "%installation_dir%/emscripten",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/fastcomp/bin';BINARYEN_ROOT='%installation_dir%';EMSCRIPTEN_ROOT='%installation_dir%/emscripten';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/bin/optimizer%.exe%'",
     "emscripten_releases_hash": "%releases-tag%",
-    "pregenerated_cache": ["asmjs"]
+    "pregenerated_cache": ["asmjs", "wasm", "wasm-obj", "wasm-bc"]
   },
 
   {

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -157,12 +157,10 @@ checked_call_with_output(emsdk + ' install node-12.9.1-64bit', unexpected='Downl
 
 print('test tot-upstream')
 run_emsdk('install tot-upstream')
-assert not os.path.exists(LIBC)
 old_config = open(emconfig).read()
 run_emsdk('activate tot-upstream')
 assert old_config == open(emconfig + '.old').read()
 # TODO; test on latest as well
-assert os.path.exists(LIBC), 'activation supplies prebuilt libc'
 check_call(upstream_emcc + ' hello_world.c')
 
 print('test tot-fastcomp')

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -80,8 +80,7 @@ int main() {
 
 TAGS = json.loads(open('emscripten-releases-tags.txt').read())
 
-DEFAULT_CACHE = os.path.expanduser('~/.emscripten_cache')
-LIBC = os.environ.get('EM_CACHE', DEFAULT_CACHE) + '/wasm/libc.a'
+LIBC = os.environ['EM_CACHE'] + '/wasm/libc.a'
 
 # Tests
 


### PR DESCRIPTION
Now that emscripten uses an in-tree cache directory there is no
need to copy the pre-built libraries around.
    
See: https://github.com/WebAssembly/waterfall/pull/644
    
Also for the sake of older versions of emscripten explictly set
EM_CACHE environment variable to point to the in-tree cache
directory.
