### PR TITLE
Add a .gitattributes file that forces unix shell scripts to have unix file endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Shell scripts should be converted to native line endings on checkout
+/emsdk                text eol=lf
+/emsdk_env.sh         text eol=lf


### PR DESCRIPTION
Errors running files for [quickstart](https://webassembly.org/getting-started/developers-guide/) on unix before this fix:
```bash
aatif@PC6353:~/lab/emsdk$ ./emsdk
: not found ./emsdk: 
: not found ./emsdk: 
: not found: ./emsdk: 
./emsdk: 19: ./emsdk: Syntax error: end of file unexpected (expecting "then")
```
I recommend a once-and-for-all overhaul of text files to use LF, and a .gitattributes that sets text files to `text=auto`, but this change gets the repository newbie-friendly faster.
