### PR TITLE
Properly report what is installed in "emsdk list"

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1677,7 +1677,7 @@ class Tool(object):
     return False
 
   def update_installed_version(self):
-    with open(self.get_version_file_path(), 'wr') as version_file:
+    with open(self.get_version_file_path(), 'w') as version_file:
       version_file.write(self.name)
     return None
 
@@ -2088,6 +2088,10 @@ def get_emscripten_releases_tot():
       continue
     return release
   return ''
+
+
+def get_release_hash(arg, releases_info):
+  return releases_info.get(arg, None) or releases_info.get('sdk-' + arg + '-64bit')
 
 
 # Finds the best-matching python tool for use.
@@ -2887,7 +2891,7 @@ def main():
           arg = arg.replace('-fastcomp', '')
           backend = 'fastcomp'
         arg = arg.replace('sdk-', '').replace('-64bit', '').replace('tag-', '')
-        release_hash = releases_info.get(arg, None) or releases_info.get('sdk-' + arg + '-64bit')
+        release_hash = get_release_hash(arg, releases_info)
         if release_hash:
           if backend is None:
             if version_key(arg) >= (1, 39, 0):
@@ -2899,6 +2903,9 @@ def main():
   if cmd == 'list':
     print('')
 
+    def installed_sdk_text(name):
+      return '\tINSTALLED' if find_sdk(name).is_installed() else ''
+
     if (LINUX or OSX or WINDOWS) and (ARCH == 'x86' or ARCH == 'x86_64'):
       print('The *recommended* precompiled SDK download is %s (%s).' % (find_latest_releases_version(), find_latest_releases_hash()))
       print()
@@ -2907,8 +2914,8 @@ def main():
       print('         latest-fastcomp         [legacy (fastcomp) backend]')
       print('')
       print('Those are equivalent to installing/activating the following:')
-      print('         %s' % find_latest_releases_version())
-      print('         %s-fastcomp' % find_latest_releases_version())
+      print('         %s            %s' % (find_latest_releases_version(), installed_sdk_text(find_latest_releases_sdk('upstream'))))
+      print('         %s-fastcomp   %s' % (find_latest_releases_version(), installed_sdk_text(find_latest_releases_sdk('fastcomp'))))
       print('')
     else:
       print('Warning: your platform does not have precompiled SDKs available.')
@@ -2919,7 +2926,7 @@ def main():
     releases_versions = sorted(load_releases_versions())
     releases_versions.reverse()
     for ver in releases_versions:
-      print('         %s' % ver)
+      print('         %s  %s' % (ver, installed_sdk_text('sdk-releases-upstream-%s-64bit' % get_release_hash(ver, releases_info))))
     print()
 
     # Use array to work around the lack of being able to mutate from enclosing

--- a/emsdk.py
+++ b/emsdk.py
@@ -2904,7 +2904,7 @@ def main():
     print('')
 
     def installed_sdk_text(name):
-      return '\tINSTALLED' if find_sdk(name).is_installed() else ''
+      return 'INSTALLED' if find_sdk(name).is_installed() else ''
 
     if (LINUX or OSX or WINDOWS) and (ARCH == 'x86' or ARCH == 'x86_64'):
       print('The *recommended* precompiled SDK download is %s (%s).' % (find_latest_releases_version(), find_latest_releases_hash()))
@@ -2914,8 +2914,8 @@ def main():
       print('         latest-fastcomp         [legacy (fastcomp) backend]')
       print('')
       print('Those are equivalent to installing/activating the following:')
-      print('         %s            %s' % (find_latest_releases_version(), installed_sdk_text(find_latest_releases_sdk('upstream'))))
-      print('         %s-fastcomp   %s' % (find_latest_releases_version(), installed_sdk_text(find_latest_releases_sdk('fastcomp'))))
+      print('         %s             %s' % (find_latest_releases_version(), installed_sdk_text(find_latest_releases_sdk('upstream'))))
+      print('         %s-fastcomp    %s' % (find_latest_releases_version(), installed_sdk_text(find_latest_releases_sdk('fastcomp'))))
       print('')
     else:
       print('Warning: your platform does not have precompiled SDKs available.')
@@ -2926,7 +2926,7 @@ def main():
     releases_versions = sorted(load_releases_versions())
     releases_versions.reverse()
     for ver in releases_versions:
-      print('         %s  %s' % (ver, installed_sdk_text('sdk-releases-upstream-%s-64bit' % get_release_hash(ver, releases_info))))
+      print('         %s    %s' % (ver, installed_sdk_text('sdk-releases-upstream-%s-64bit' % get_release_hash(ver, releases_info))))
     print()
 
     # Use array to work around the lack of being able to mutate from enclosing

--- a/emsdk.py
+++ b/emsdk.py
@@ -1662,11 +1662,6 @@ class Tool(object):
     return hasattr(self, 'url')
 
   def is_installed(self):
-    if self.id.startswith(('releases', 'sdk-releases')):
-      # The main SDK releases should never be marked "installed" since they
-      # are not cached.
-      return False
-
     # If this tool/sdk depends on other tools, require that all dependencies are
     # installed for this tool to count as being installed.
     if hasattr(self, 'uses'):
@@ -1795,6 +1790,16 @@ class Tool(object):
         return "Visual Studio was not found!"
     else:
       return True
+
+  def can_report_installed(self):
+    # The main SDK releases should never be marked "installed" since they
+    # are not cached. We do not keep old versions since they can accumulate;
+    # instead we overwrite in the same directory when we update.
+    # FIXME https://github.com/emscripten-core/emsdk/issues/477
+    return not self.name.startswith(('releases-', 'sdk-releases-'))
+
+  def report_installed(self):
+    return self.can_report_installed() and self.is_installed()
 
   def download_url(self):
     if WINDOWS and hasattr(self, 'windows_url'):
@@ -2932,7 +2937,7 @@ def main():
 
       def print_sdks(s):
         for sdk in s:
-          installed = '\tINSTALLED' if sdk.is_installed() else ''
+          installed = '\tINSTALLED' if sdk.report_installed() else ''
           active = '*' if sdk.is_active() else ' '
           print('    ' + active + '    {0: <25}'.format(str(sdk)) + installed)
           if arg_uses:
@@ -2959,6 +2964,8 @@ def main():
       def print_tools(t):
         for tool in t:
           if tool.is_old and not arg_old:
+            continue
+          if not tool.can_report_installed():
             continue
           if tool.can_be_installed() is True:
             installed = '\tINSTALLED' if tool.is_installed() else ''

--- a/emsdk.py
+++ b/emsdk.py
@@ -1662,6 +1662,11 @@ class Tool(object):
     return hasattr(self, 'url')
 
   def is_installed(self):
+    if self.id.startswith(('releases', 'sdk-releases')):
+      # The main SDK releases should never be marked "installed" since they
+      # are not cached.
+      return False
+
     # If this tool/sdk depends on other tools, require that all dependencies are
     # installed for this tool to count as being installed.
     if hasattr(self, 'uses'):

--- a/emsdk.py
+++ b/emsdk.py
@@ -1681,7 +1681,7 @@ class Tool(object):
       version_file.write(self.name)
     return None
 
-  def is_installed(self, assume_is_installed_version=False):
+  def is_installed(self, skip_version_check=False):
     # If this tool/sdk depends on other tools, require that all dependencies are
     # installed for this tool to count as being installed.
     if hasattr(self, 'uses'):
@@ -1727,7 +1727,7 @@ class Tool(object):
       else:
         raise Exception('Unknown custom_is_installed_script directive "' + self.custom_is_installed_script + '"!')
 
-    return content_exists and (assume_is_installed_version or self.is_installed_version())
+    return content_exists and (skip_version_check or self.is_installed_version())
 
   def is_active(self):
     if not self.is_installed():
@@ -1918,7 +1918,7 @@ class Tool(object):
 
     # Sanity check that the installation succeeded, and if so, remove unneeded
     # leftover installation files.
-    if self.is_installed(assume_is_installed_version=True):
+    if self.is_installed(skip_version_check=True):
       self.cleanup_temp_install_files()
       self.update_installed_version()
     else:

--- a/emsdk.py
+++ b/emsdk.py
@@ -1791,16 +1791,6 @@ class Tool(object):
     else:
       return True
 
-  def can_report_installed(self):
-    # The main SDK releases should never be marked "installed" since they
-    # are not cached. We do not keep old versions since they can accumulate;
-    # instead we overwrite in the same directory when we update.
-    # FIXME https://github.com/emscripten-core/emsdk/issues/477
-    return not self.name.startswith(('releases-', 'sdk-releases-'))
-
-  def report_installed(self):
-    return self.can_report_installed() and self.is_installed()
-
   def download_url(self):
     if WINDOWS and hasattr(self, 'windows_url'):
       return self.windows_url
@@ -2937,7 +2927,7 @@ def main():
 
       def print_sdks(s):
         for sdk in s:
-          installed = '\tINSTALLED' if sdk.report_installed() else ''
+          installed = '\tINSTALLED' if sdk.is_installed() else ''
           active = '*' if sdk.is_active() else ' '
           print('    ' + active + '    {0: <25}'.format(str(sdk)) + installed)
           if arg_uses:
@@ -2964,8 +2954,6 @@ def main():
       def print_tools(t):
         for tool in t:
           if tool.is_old and not arg_old:
-            continue
-          if not tool.can_report_installed():
             continue
           if tool.can_be_installed() is True:
             installed = '\tINSTALLED' if tool.is_installed() else ''

--- a/emsdk.py
+++ b/emsdk.py
@@ -1856,13 +1856,7 @@ class Tool(object):
     return True
 
   def install_tool(self):
-    # We should not force reinstallation of python if it already exists, since that very python
-    # may be interpreting the current emsdk.py script we are executing. On Windows this would
-    # lead to a failure to uncompress the python zip file as the python executable files are in use.
-    # TODO: Refactor codebase to avoid needing this kind of special case check by being more
-    # careful about reinstallation, see https://github.com/emscripten-core/emsdk/pull/394#issuecomment-559386468
-    # for a scheme that would work.
-    if self.id == 'python' and self.is_installed():
+    if self.is_installed():
       print("Skipped installing " + self.name + ", already installed.")
       return True
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -97,6 +97,10 @@ assert 'upstream' in open(emconfig).read()
 # Test we don't re-download unnecessarily
 checked_call_with_output(emsdk + ' install latest', expected='already installed', unexpected='Downloading:')
 
+# Test we report installed tools properly. The latest version should be
+# installed, but not some random old one.
+checked_call_with_output(emsdk + ' list', expected=TAGS['latest'] + '    INSTALLED', unexpected='1.39.15    INSTALLED:')
+
 print('building proper system libraries')
 
 


### PR DESCRIPTION
This expands on #460 which added a file in each install dir
with the version, that lets us know not to re-download it. That
didn't integrate with `is_installed`, so it wasn't reported properly,
which this PR fixes.

With this we can remove a hack for python, as we can simply
not install anything if it's already installed (see line 1859).

Also add the "INSTALLED" indicators on the main listings in
"emsdk list". The output can now look like this:
```
To install/activate it, use one of:
         latest                  [default (llvm) backend]
         latest-fastcomp         [legacy (fastcomp) backend]

Those are equivalent to installing/activating the following:
         1.39.16             INSTALLED
         1.39.16-fastcomp    

All recent (non-legacy) installable versions are:
         1.39.9    
         1.39.8    
         1.39.7    
         1.39.6    
         1.39.5    
         1.39.4    
         1.39.3    
         1.39.2    
         1.39.16    INSTALLED
         1.39.15    
         1.39.14    
         1.39.13    
         1.39.12    
         1.39.11    
         1.39.10    
         1.39.1    
```

Bug was reported in https://github.com/emscripten-core/emsdk/issues/477#issuecomment-631152317