### PR TITLE
Properly sort versions in "emsdk list"

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2917,8 +2917,11 @@ def main():
       print('')
 
     print('All recent (non-legacy) installable versions are:')
-    releases_versions = sorted(load_releases_versions())
-    releases_versions.reverse()
+    releases_versions = sorted(
+      load_releases_versions(),
+      key=lambda x: [int(v) if v.isdigit() else -1 for v in x.split('.')],
+      reverse=True,
+    )
     for ver in releases_versions:
       print('         %s    %s' % (ver, installed_sdk_text('sdk-releases-upstream-%s-64bit' % get_release_hash(ver, releases_info))))
     print()


### PR DESCRIPTION
This uses LooseVersion from distutils, here is the doc:
> Version numbering for anarchists and software realists. Implements the
> standard interface for version number classes as described above. A
> version number consists of a series of numbers, separated by either
> periods or strings of letters. When comparing version numbers, the
> numeric components will be compared numerically, and the alphabetic
> components lexically.
> ...
> In fact, there is no such thing as an invalid version number under
> this scheme; the rules for comparison are simple and predictable, but
> may not always give the results you want (for some definition of
> "want").

I believe that this should be available in all possible configurations of python, I checked with python2 & 3 on linux. If not, an easy workaround is to catch `ImportError` and set `LooseVersion=None`.

```
Comparison:
    Before   |   After
    1.39.9       1.39.16
    1.39.8       1.39.15
    1.39.7       1.39.14
    1.39.6       1.39.13
    1.39.5       1.39.12
    1.39.4       1.39.11
    1.39.3       1.39.10
    1.39.2       1.39.9
    1.39.16      1.39.8
    1.39.15      1.39.7
    1.39.14      1.39.6
    1.39.13      1.39.5
    1.39.12      1.39.4
    1.39.11      1.39.3
    1.39.10      1.39.2
    1.39.1       1.39.1
    1.39.0       1.39.0
    1.38.48      1.38.48
    1.38.47      1.38.47
    1.38.46      1.38.46
    1.38.45      1.38.45
    1.38.44      1.38.44
    1.38.43      1.38.43
    1.38.42      1.38.42
    1.38.41      1.38.41
    1.38.40      1.38.40
    1.38.39      1.38.39
    1.38.38      1.38.38
    1.38.37      1.38.37
    1.38.36      1.38.36
    1.38.35      1.38.35
    1.38.34      1.38.34
    1.38.33      1.38.33
```