### PR TITLE
Build docker image on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,15 @@ jobs:
             source emsdk_env.sh
             python scripts/test.py
 
+  build-docker-image:
+    machine: true
+    steps:
+      - checkout
+      - run: cd docker && make version=${CIRCLE_TAG}-upstream
+      - run: |
+          docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+          docker push emscripten/emsdk:${CIRCLE_TAG}-upstream
+
 workflows:
   flake8:
     jobs:
@@ -103,3 +112,11 @@ workflows:
   test-windows:
     jobs:
       - test-windows
+  build-docker-image:
+    jobs:
+      - build-docker-image:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/


### PR DESCRIPTION
As per https://github.com/emscripten-core/emscripten/issues/11078 and https://github.com/emscripten-core/emsdk/issues/372.

@trzecieu @sbc100 
Very very rough draft for building the docker image on Circle CI.

**TODO**
 - [x] Build docker image
 - [x] Properly specify the tag(s) for docker hub
 - [x] Trigger build only on ~~`emscripten-releases-tags.txt` changes.~~ tags
    - [x] Double check that this is _really_ just triggering on tags.
 - [x] What's the process of getting the docker hub deploy key? They should be specified through secret variables in Circle CI and probably could be done as a final step by one of the project maintainers.
 - ~~Build various variations of the image? (i.e. I remember emscripten-slim and a ubuntu based version in trzeci's original images.)~~