### PR TITLE
Add host network for building image

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,7 +11,7 @@ ifndef version
 endif
 
 build: .TEST
-	docker build --build-arg=EMSCRIPTEN_VERSION=${version} --tag emscripten/emsdk:${version} .
+	docker build --network host --build-arg=EMSCRIPTEN_VERSION=${version} --tag emscripten/emsdk:${version} .
 
 push: .TEST
 	docker push emscripten/emsdk:${version}

--- a/docker/README.md
+++ b/docker/README.md
@@ -59,6 +59,7 @@ This step will build Dockerfile as given tag on local machine
 ```bash
 # using docker
 docker build \
+    --network host \
     --build-arg=EMSCRIPTEN_VERSION=1.38.43-upstream \
     --tag emscripten/emsdk:1.38.43-upstream \
     .


### PR DESCRIPTION
Without `--network host` It's impossible to build images (might be some recent addition for docker engine, as I don't recall it was a case before) 