### PR TITLE
Updated tagging schema for docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,10 +94,12 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: cd docker && make version=${CIRCLE_TAG}-upstream
+      - run: docker build --network host --build-arg=EMSCRIPTEN_VERSION=${CIRCLE_TAG}-upstream --tag emscripten/emsdk:${CIRCLE_TAG} ./docker
+      - run: docker tag emscripten/emsdk:${CIRCLE_TAG} emscripten/emsdk:latest
       - run: |
           docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-          docker push emscripten/emsdk:${CIRCLE_TAG}-upstream
+          docker push emscripten/emsdk:${CIRCLE_TAG}
+          docker push emscripten/emsdk:latest
 
 workflows:
   flake8:


### PR DESCRIPTION
This change will: 
* Push all future docker images as `emscripten/emsdk:X.YY.ZZ` instead of  `emscripten/emsdk:X.YY.ZZ-upstream`
* Set created tag as `latest`