### PR TITLE
Download and install mac (homebrew) version of python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,6 @@ jobs:
       - run:
           name: Install cmake
           command: brew install cmake
-      - run:
-          name: Install python 3
-          command: brew install python3
       - run: scripts/test.sh
       - run:
           name: test.py

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -486,7 +486,7 @@
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-master-64bit", "node-12.9.1-64bit", "python-3.7.7-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "osx"
   },
   {
@@ -516,7 +516,7 @@
   {
     "version": "fastcomp-master",
     "bitness": 64,
-    "uses": ["fastcomp-clang-master-64bit", "node-12.9.1-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["fastcomp-clang-master-64bit", "node-12.9.1-64bit", "python-3.7.7-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "osx"
   },
   {
@@ -598,7 +598,7 @@
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-12.9.1-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "uses": ["node-12.9.1-64bit", "python-3.7.7-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "osx",
     "custom_install_script": "emscripten_npm_install"
   },
@@ -648,7 +648,7 @@
   {
     "version": "fastcomp-%precompiled_tag32%",
     "bitness": 32,
-    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "emscripten-%precompiled_tag32%"],
+    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-3.7.7-64bit", "emscripten-%precompiled_tag32%"],
     "os": "osx",
     "version_filter": [
       ["%precompiled_tag32%", ">", "1.37.22"]
@@ -657,7 +657,7 @@
   {
     "version": "fastcomp-%precompiled_tag64%",
     "bitness": 64,
-    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "emscripten-%precompiled_tag64%"],
+    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-3.7.7-64bit", "emscripten-%precompiled_tag64%"],
     "os": "osx",
     "version_filter": [
       ["%precompiled_tag64%", ">", "1.37.22"]

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -289,6 +289,17 @@
     "activated_env": "EMSDK_PYTHON=%installation_dir%/python.exe"
   },
   {
+    "id": "python",
+    "version": "3.7.7",
+    "bitness": 64,
+    "strip": 2,
+    "arch": "x86_64",
+    "osx_url": "python-3.7.7.high_sierra.bottle.tar.gz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "PYTHON='%installation_dir%/bin/python3",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/bin/python3"
+  },
+  {
     "id": "java",
     "version": "8.152",
     "bitness": 32,

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -577,7 +577,7 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-12.9.1-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-12.9.1-64bit", "python-3.7.7-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "osx",
     "custom_install_script": "emscripten_npm_install"
   },

--- a/scripts/update_python.py
+++ b/scripts/update_python.py
@@ -4,7 +4,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-"""Updates the python binaries that we cache store at
+"""Updates the windows python binaries that we cache store at
 http://storage.google.com/webassembly.
 
 Currently this is windows only and we rely on the system python on other
@@ -16,6 +16,12 @@ recipe:
   2. Remove .pth file to work around https://bugs.python.org/issue34841
   3. Download and install pywin32 in the `site-packages` directory
   4. Re-zip and upload to storage.google.com
+
+
+Note: The mac version of python was downloaded from the homebrew archive:
+  https://bintray.com/homebrew/bottles/python/3.7.7#files
+With the sha265 checked against the formula:
+  https://github.com/Homebrew/homebrew-core/blob/master/Formula/python.rb
 """
 
 import urllib.request


### PR DESCRIPTION
This means we no longer depend on system python, except to
run emsdk itself for the initial download.