### PR TITLE
Updated make file for docker building to perform extra sanity tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,12 +98,13 @@ jobs:
           name: install docker
           command: apt-get update -q && apt-get install -q -y docker.io
       - setup_remote_docker
+      # build and test the latest released version of EMSDK
       - run:
           name: build
-          command: make -C ./docker version=${CIRCLE_TAG} build
+          command: make -C ./docker version=$(git describe --tags --abbrev=0) build
       - run:
           name: test
-          command: make -C ./docker version=${CIRCLE_TAG} test
+          command: make -C ./docker version=$(git describe --tags --abbrev=0) test
 
   publish-docker-image:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,10 @@ jobs:
       - setup_remote_docker
       - run:
           name: build
-          command: docker build --network host ./docker
+          command: make -C ./docker version=${CIRCLE_TAG} build
+      - run:
+          name: test
+          command: make -C ./docker version=${CIRCLE_TAG} test
 
   publish-docker-image:
     executor: bionic
@@ -112,16 +115,15 @@ jobs:
       - setup_remote_docker
       - run:
           name: build
-          command: docker build --network host --build-arg EMSCRIPTEN_VERSION=${CIRCLE_TAG} --tag emscripten/emsdk:${CIRCLE_TAG} ./docker
+          command: make -C ./docker version=${CIRCLE_TAG} build
       - run:
-          name: tag image
-          command: docker tag emscripten/emsdk:${CIRCLE_TAG} emscripten/emsdk:latest
+          name: test
+          command: make -C ./docker version=${CIRCLE_TAG} test
       - run:
           name: push image
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            docker push emscripten/emsdk:${CIRCLE_TAG}
-            docker push emscripten/emsdk:latest
+            make -C ./docker version=${CIRCLE_TAG} alias=latest push
 
 workflows:
   flake8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,13 +91,9 @@ jobs:
             python scripts/test.py
 
   build-docker-image:
-    executor: bionic
+    machine: true # required for testing files permissions
     steps:
       - checkout
-      - run:
-          name: install docker
-          command: apt-get update -q && apt-get install -q -y docker.io
-      - setup_remote_docker
       # build and test the latest released version of EMSDK
       - run:
           name: build

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env make
 
 # Emscripten version to build: Should match the version that has been already released.
-# i.e.:  1.38.45, 1.38.45-upstream
+# i.e.:  1.39.18
 version =
 alias =
 
@@ -11,21 +11,32 @@ ifndef version
 endif
 
 build: .TEST
-	docker build --network host --build-arg=EMSCRIPTEN_VERSION=${version}-upstream --tag emscripten/emsdk:${version} .
+	docker build --network host --build-arg=EMSCRIPTEN_VERSION=${version} --tag emscripten/emsdk:${version} .
 
 test: .TEST
-	# compilation without root
-	docker run --rm -u 1000:1000 -v `pwd`:/src -w /src emscripten/emsdk:${version} emcc -c main.c -o main
+	# compilation as non-root
+	docker run --rm -u `id -u`:`id -g` -v `pwd`:/src -w /src emscripten/emsdk:${version} \
+		bash -c "\
+			mkdir -p .test \
+			&& echo 'int main() { return 0; }' > .test/main.c \
+			&& emcc -c .test/main.c -o .test/main\
+		"
 	# artifact should be removable from host by non-root
-	rm -fr main
+	rm -fr .test
 
 	# running as non-root and forcing downloading ports
-	docker run --rm -u 1000:1000 --net=host emscripten/emsdk:${version} embuilder build zlib
+	docker run --rm -u `id -u`:`id -g` --net=host emscripten/emsdk:${version} embuilder build zlib
 
 	# compilation without entrypoint
-	docker run --rm -e /bin/bash -v `pwd`:/src -w /src emscripten/emsdk:${version} emcc -c main.c -o main
+	docker run --rm -e /bin/bash -v `pwd`:/src -w /src emscripten/emsdk:${version} \
+		bash -c "\
+			mkdir -p .test \
+			&& echo 'int main() { return 0; }' > .test/main.c \
+			&& emcc -c .test/main.c -o .test/main\
+		"
+
 	# artifact should be removable from host by non-root
-	rm -fr main
+	rm -fr .test
 
 push: .TEST
 	docker push emscripten/emsdk:${version}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,7 +11,21 @@ ifndef version
 endif
 
 build: .TEST
-	docker build --network host --build-arg=EMSCRIPTEN_VERSION=${version} --tag emscripten/emsdk:${version} .
+	docker build --network host --build-arg=EMSCRIPTEN_VERSION=${version}-upstream --tag emscripten/emsdk:${version} .
+
+test: .TEST
+	# compilation without root
+	docker run --rm -u 1000:1000 -v `pwd`:/src -w /src emscripten/emsdk:${version} emcc -c main.c -o main
+	# artifact should be removable from host by non-root
+	rm -fr main
+
+	# running as non-root and forcing downloading ports
+	docker run --rm -u 1000:1000 --net=host emscripten/emsdk:${version} embuilder build zlib
+
+	# compilation without entrypoint
+	docker run --rm -e /bin/bash -v `pwd`:/src -w /src emscripten/emsdk:${version} emcc -c main.c -o main
+	# artifact should be removable from host by non-root
+	rm -fr main
 
 push: .TEST
 	docker push emscripten/emsdk:${version}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@ build: .TEST
 
 test: .TEST
 	# compilation as non-root
-	docker run --rm -u `id -u`:`id -g` -v `pwd`:/src -w /src emscripten/emsdk:${version} \
+	docker run --rm -u `id -u`:`id -g` -e HOME=/tmp -v `pwd`:/src -w /src emscripten/emsdk:${version} \
 		bash -c "\
 			mkdir -p .test \
 			&& echo 'int main() { return 0; }' > .test/main.c \
@@ -25,7 +25,7 @@ test: .TEST
 	rm -fr .test
 
 	# running as non-root and forcing downloading ports
-	docker run --rm -u `id -u`:`id -g` --net=host emscripten/emsdk:${version} embuilder build zlib
+	docker run --rm -u `id -u`:`id -g` -e HOME=/tmp --net=host emscripten/emsdk:${version} embuilder build zlib
 
 	# compilation without entrypoint
 	docker run --rm -e /bin/bash -v `pwd`:/src -w /src emscripten/emsdk:${version} \

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,7 +51,7 @@ This image requires to specify following build arguments:
 
 | arg | description |
 | --- | --- |
-| `EMSCRIPTEN_VERSION` | One of released version of Emscripten. For example `1.38.45`<br/> Can be used with `-upstream` variant like: `1.38.45-upstream`<br /> Minimal supported version is **1.38.40**|
+| `EMSCRIPTEN_VERSION` | One of released version of Emscripten. For example `1.39.17`<br/> Can be used with `-upstream` variant like: `1.39.17-upstream`<br /> Minimal supported version is **1.39.0**|
 
 **Building**
 
@@ -60,13 +60,13 @@ This step will build Dockerfile as given tag on local machine
 # using docker
 docker build \
     --network host \
-    --build-arg=EMSCRIPTEN_VERSION=1.38.43-upstream \
-    --tag emscripten/emsdk:1.38.43-upstream \
+    --build-arg=EMSCRIPTEN_VERSION=1.39.17-upstream \
+    --tag emscripten/emsdk:1.39.17-upstream \
     .
 ```
 ```bash
 # using predefined make target
-make version=1.38.43-upstream build
+make version=1.39.17 build test
 ```
 
 **Tagging**
@@ -79,34 +79,23 @@ This step will take local image and push to default docker registry. You need to
 
 ```bash
 # using docker
-docker push emscripten/emsdk:1.38.43-upstream
+docker push emscripten/emsdk:1.39.17
 ```
 ```bash
 # using predefined make target
-make version=1.38.43-upstream push
+make version=1.39.17 push
 ```
 
-In case of pushing the most recent version, this version should be also tagged as `latest` or `latest-upstream` and pushed.
+In case of pushing the most recent version, this version should be also tagged as `latest` and pushed.
 ```bash
 # using docker cli
-
-# in case of fastcomp variant (default backend)
-docker tag emscripten/emsdk:1.38.43 emscripten/emsdk:latest
+docker tag emscripten/emsdk:1.39.17 emscripten/emsdk:latest
 docker push emscripten/emsdk:latest
 
-# in case of upstream variant
-docker tag emscripten/emsdk:1.38.43-upstream emscripten/emsdk:latest-upstream
-docker push emscripten/emsdk:latest-upstream
-
-```
-
 ```bash
-# using predefined make target
-
-make version=1.38.43-upstream alias=latest-upstream push
-
+# using make
+make version=1.39.17 alias=latest push
 ```
-
 
 ### Extending
 
@@ -117,20 +106,20 @@ If your project uses packages that this image doesn't provide you might want to:
 1. create own Dockerfile that holds:
     ```dockerfile
     # Point at any base image that you find suitable to extend.
-    FROM emscripten/emsdk:1.38.25
+    FROM emscripten/emsdk:1.39.17
 
     # Install required tools that are useful for your project i.e. ninja-build
     RUN apt update && apt install -y ninja-build
 
     ```
 2. build it
-    ```shell
+    ```bash
     docker build -t extended_emscripten .
     ```
 
 3. test
-    ```shell
+    ```bash
     docker run --rm extended_emscripten ninja --version
-    # Python 2.7.16
+    # 1.10.0
     ```
 

--- a/docker/main.c
+++ b/docker/main.c
@@ -1,1 +1,0 @@
-int main() { return 0; }

--- a/docker/main.c
+++ b/docker/main.c
@@ -1,0 +1,1 @@
+int main() { return 0; }


### PR DESCRIPTION
Reapply #526

This change:
* Adds extra sanity tests for Makefile, so that it will be easier to maintain the image
* Switches to `make` commands for CircleCI, and adds `test` step
* Adds small changes to RADME.md to better reflect how to build image locally

To be merged after: https://github.com/emscripten-core/emsdk/pull/530 