### PR TITLE
Cleanup emsdk_env scripts

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2489,6 +2489,9 @@ def set_active_tools(tools_to_activate, permanently_activate):
   copy_pregenerated_cache(tools_to_activate)
 
   # Construct a .bat script that will be invoked to set env. vars and PATH
+  # We only do this on windows since emsdk.bat is able to modify the
+  # calling shell environment.  On other platform `source emsdk_env.sh` is
+  # required.
   if WINDOWS:
     env_string = construct_env(tools_to_activate)
     open(EMSDK_SET_ENV, 'w').write(env_string)
@@ -2611,11 +2614,11 @@ def construct_env(tools_to_activate):
       print('')
 
   # A core variable EMSDK points to the root of Emscripten SDK directory.
-  env_vars_to_add = [('EMSDK', to_unix_path(emsdk_path()))]
+  env_vars = [('EMSDK', to_unix_path(emsdk_path()))]
 
   em_config_path = os.path.normpath(dot_emscripten_path())
   if to_unix_path(os.environ.get('EM_CONFIG', '')) != to_unix_path(em_config_path):
-    env_vars_to_add += [('EM_CONFIG', em_config_path)]
+    env_vars += [('EM_CONFIG', em_config_path)]
 
   for tool in tools_to_activate:
     config = tool.activated_config()
@@ -2623,14 +2626,18 @@ def construct_env(tools_to_activate):
       # For older emscripten versions that don't use this default we export
       # EM_CACHE.
       em_cache_dir = os.path.join(config['EMSCRIPTEN_ROOT'], 'cache')
-      env_vars_to_add += [('EM_CACHE', em_cache_dir)]
+      env_vars += [('EM_CACHE', em_cache_dir)]
     envs = tool.activated_environment()
     for env in envs:
       key, value = parse_key_value(env)
       value = to_native_path(tool.expand_vars(value))
-      # Don't set env vars which are already set to the correct value.
-      if key not in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value):
-        env_vars_to_add += [(key, value)]
+      env_vars += [(key, value)]
+
+  # Don't set env vars which are already set to the correct value.
+  env_vars_to_add = []
+  for key, value in env_vars:
+    if key not in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value):
+      env_vars_to_add.append((key, value))
 
   if env_vars_to_add:
     print('Setting environment variables:')
@@ -3005,19 +3012,15 @@ def main():
 
     return 0
   elif cmd == 'construct_env':
-    if len(sys.argv) == 2:
-      outfile = EMSDK_SET_ENV
-      # Clean up old temp file up front, in case of failure later before we get
-      # to write out the new one.
-      silentremove(EMSDK_SET_ENV)
-    else:
-      outfile = sys.argv[2]
+    # Clean up old temp file up front, in case of failure later before we get
+    # to write out the new one.
+    silentremove(EMSDK_SET_ENV)
     tools_to_activate = currently_active_tools()
     tools_to_activate = process_tool_list(tools_to_activate, log_errors=True)
     env_string = construct_env(tools_to_activate)
-    open(outfile, 'w').write(env_string)
+    open(EMSDK_SET_ENV, 'w').write(env_string)
     if UNIX:
-      os.chmod(outfile, 0o755)
+      os.chmod(EMSDK_SET_ENV, 0o755)
     return 0
   elif cmd == 'update':
     update_emsdk()

--- a/emsdk_env.bat
+++ b/emsdk_env.bat
@@ -1,1 +1,1 @@
-@call "%~dp0emsdk" construct_env %*
+@call "%~dp0emsdk" construct_env

--- a/emsdk_env.csh
+++ b/emsdk_env.csh
@@ -21,16 +21,13 @@ else
   set SRC="$SRC[2]"
 endif
 set CURDIR=`pwd`
-cd `dirname "$SRC"`
+set DIR=`dirname "$SRC"`
 unset SRC
 
 setenv EMSDK_CSH 1
 
-set tmpfile=`mktemp` || exit 1
-./emsdk construct_env $tmpfile
-source $tmpfile
-rm -f $tmpfile
+$DIR/emsdk construct_env
+source $DIR/emsdk_set_env.csh
+unset DIR
 
 unsetenv EMSDK_CSH
-
-cd "$CURDIR"

--- a/emsdk_env.fish
+++ b/emsdk_env.fish
@@ -6,12 +6,8 @@
 set -l script (status -f)
 set -l dir (dirname $script)
 
-pushd $dir > /dev/null
-
-./emsdk construct_env
-. ./emsdk_set_env.sh
+$dir/emsdk construct_env
+. $dir/emsdk_set_env.sh
 
 set -e -l script
 set -e -l dir
-
-popd > /dev/null

--- a/emsdk_env.ps1
+++ b/emsdk_env.ps1
@@ -1,2 +1,2 @@
 $ScriptDirectory = Split-Path -parent $PSCommandPath
-& "$ScriptDirectory/emsdk.ps1" construct_env $args
+& "$ScriptDirectory/emsdk.ps1" construct_env

--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script is sourced by the user and uses
 # their shell. Try not to use bashisms.
 
@@ -15,18 +15,13 @@
 #     ./emsdk_env.sh
 #
 # which won't have any effect.
-SRC="$BASH_SOURCE"
-if [ "$SRC" = "" ]; then
-  SRC="$0"
+DIR="$BASH_SOURCE"
+if [ "$DIR" = "" ]; then
+  DIR="$0"
 fi
-CURDIR="$(pwd)"
-cd "$(dirname "$SRC")"
-unset SRC
+DIR="$(dirname "$DIR")"
 
-tmpfile=`mktemp` || exit 1
 # Force emsdk to use bash syntax so that this works in windows + bash too
-EMSDK_BASH=1 ./emsdk construct_env $tmpfile
-. $tmpfile
-rm -f $tmpfile
-
-cd "$CURDIR"
+EMSDK_BASH=1 $DIR/emsdk construct_env
+. $DIR/emsdk_set_env.sh
+unset DIR


### PR DESCRIPTION
Remove the optional argument to contruct_env.  It simple if we
always construct the env in the same place.  Avoid using temp files,
and avoid changing directory.