### PR TITLE
Fix fatal exception in "emsdk list" on unsupported platforms

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2907,7 +2907,8 @@ def main():
     print('')
 
     def installed_sdk_text(name):
-      return 'INSTALLED' if find_sdk(name).is_installed() else ''
+      sdk = find_sdk(name)
+      return 'INSTALLED' if sdk and sdk.is_installed() else ''
 
     if (LINUX or OSX or WINDOWS) and (ARCH == 'x86' or ARCH == 'x86_64'):
       print('The *recommended* precompiled SDK download is %s (%s).' % (find_latest_releases_version(), find_latest_releases_hash()))


### PR DESCRIPTION
On platforms with no supported binary SDKs to download, find_sdk
can return None which caused a check in the "list" command to fail.
Checking for the return value before making method calls fixes this,
and allows Linux/ARM64 to run "emsdk list" and then build an SDK
from source.

Fixes https://github.com/emscripten-core/emsdk/issues/548