### PR TITLE
Remove error duplication around missing git executable

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2104,11 +2104,10 @@ def update_emsdk():
     sys.exit(1)
 
   # attempt to run fetch_emscripten_tags if git is available.
-  git = GIT(must_succeed=False)
-  if not git:
+  if GIT(must_succeed=False):
+    fetch_emscripten_tags()
+  else:
     print('Update complete, however skipped fetching the Emscripten tags, since git was not found, which is necessary for update-tags.', file=sys.stderr)
-    return
-  fetch_emscripten_tags()
 
 
 # Lists all legacy (pre-emscripten-releases) tagged versions directly in the Git


### PR DESCRIPTION
Make git a requirement for fetch_emscripten_tags but in the case
when we run it from "emsdk update" we can check for git first.

This cleans up fetch_emscripten_tags and removed the duplication
of the git-missing error messages.

Also, remove check for 'llvm-tags-64bit.txt' which always exists these days
because it is checked-in.