### PR TITLE
Pre-bundle requests module with macOS bundles python

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -290,10 +290,10 @@
   },
   {
     "id": "python",
-    "version": "3.7.4",
+    "version": "3.7.4-2",
     "bitness": 64,
     "arch": "x86_64",
-    "macos_url": "python-3.7.4-macos.tar.gz",
+    "macos_url": "python-3.7.4-2-macos.tar.gz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "PYTHON='%installation_dir%/bin/python3'",
     "activated_env": "EMSDK_PYTHON=%installation_dir%/bin/python3"
@@ -485,7 +485,7 @@
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-12.18.1-64bit", "python-3.7.4-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-master-64bit", "node-12.18.1-64bit", "python-3.7.4-2-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "macos"
   },
   {
@@ -515,7 +515,7 @@
   {
     "version": "fastcomp-master",
     "bitness": 64,
-    "uses": ["fastcomp-clang-master-64bit", "node-12.18.1-64bit", "python-3.7.4-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["fastcomp-clang-master-64bit", "node-12.18.1-64bit", "python-3.7.4-2-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "macos"
   },
   {
@@ -576,7 +576,7 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-12.18.1-64bit", "python-3.7.4-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-12.18.1-64bit", "python-3.7.4-2-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "macos",
     "custom_install_script": "emscripten_npm_install"
   },
@@ -597,7 +597,7 @@
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-12.18.1-64bit", "python-3.7.4-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "uses": ["node-12.18.1-64bit", "python-3.7.4-2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "macos",
     "custom_install_script": "emscripten_npm_install"
   },
@@ -647,7 +647,7 @@
   {
     "version": "fastcomp-%precompiled_tag32%",
     "bitness": 32,
-    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-3.7.4-64bit", "emscripten-%precompiled_tag32%"],
+    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag32%"],
     "os": "macos",
     "version_filter": [
       ["%precompiled_tag32%", ">", "1.37.22"]
@@ -656,7 +656,7 @@
   {
     "version": "fastcomp-%precompiled_tag64%",
     "bitness": 64,
-    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-3.7.4-64bit", "emscripten-%precompiled_tag64%"],
+    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag64%"],
     "os": "macos",
     "version_filter": [
       ["%precompiled_tag64%", ">", "1.37.22"]


### PR DESCRIPTION
The problem is that python can have trouble finding the default
certifcate set on macOS.  The actual bundle is installed by the certifi
package which the requests module uses under the hood.

Fixes #588