### PR TITLE
Error on trying to get latest-fastcomp

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2636,12 +2636,13 @@ def error_on_missing_tool(name):
   return 1
 
 
+def exit_with_fastcomp_error(details):
+    exit_with_error(details + ' Please use the upstream llvm backend or use an older version than 2.0.0 (such as 1.40.1).')
+
+
 def expand_sdk_name(name):
   if name in ('latest-fastcomp', 'latest-releases-fastcomp'):
-    # Since we no longer support fastcomp in ToT emscripten, the latest
-    # fastcomp release is fixed at 1.40.1.
-    name = 'sdk-fastcomp-1.40.1'
-
+    exit_with_fastcomp_error('The fastcomp backend is not getting new builds.')
   if name in ('latest', 'sdk-latest', 'latest-64bit', 'sdk-latest-64bit'):
     # This is effectly the default SDK
     return str(find_latest_releases_sdk('upstream'))
@@ -2652,8 +2653,7 @@ def expand_sdk_name(name):
   elif name == 'tot-upstream':
     return str(find_tot_sdk('upstream'))
   elif name in ('tot-fastcomp', 'sdk-nightly-latest'):
-    print('error: The fastcomp compiler is not available tot/nightly builds. Please use the upstream llvm backend or use an older version than 2.0.0.')
-    sys.exit(1)
+    exit_with_fastcomp_error('The fastcomp backend is not getting tot/nightly builds.')
   else:
     # check if it's a release handled by an emscripten-releases version,
     # and if so use that by using the right hash. we support a few notations,
@@ -2670,8 +2670,7 @@ def expand_sdk_name(name):
       backend = 'fastcomp'
     fullname = fullname.replace('sdk-', '').replace('-64bit', '').replace('tag-', '')
     if backend == 'fastcomp' and version_key(fullname) >= (2, 0, 0):
-      print('error: The fastcomp compiler is not available in 2.0.0+. Please use the upstream llvm backend or use an older version than 2.0.0.')
-      sys.exit(1)
+      exit_with_fastcomp_error('The fastcomp backend is not supported in 2.0.0+.')
     releases_info = load_releases_info()['releases']
     release_hash = get_release_hash(fullname, releases_info)
     if release_hash:

--- a/emsdk.py
+++ b/emsdk.py
@@ -2636,13 +2636,13 @@ def error_on_missing_tool(name):
   return 1
 
 
-def exit_with_fastcomp_error(details):
-    exit_with_error(details + ' Please use the upstream llvm backend or use an older version than 2.0.0 (such as 1.40.1).')
+def exit_with_fastcomp_error():
+    exit_with_error('The fastcomp backend is not getting new builds or releases. Please use the upstream llvm backend or use an older version than 2.0.0 (such as 1.40.1).')
 
 
 def expand_sdk_name(name):
-  if name in ('latest-fastcomp', 'latest-releases-fastcomp'):
-    exit_with_fastcomp_error('The fastcomp backend is not getting new builds.')
+  if name in ('latest-fastcomp', 'latest-releases-fastcomp', 'tot-fastcomp', 'sdk-nightly-latest'):
+    exit_with_fastcomp_error()
   if name in ('latest', 'sdk-latest', 'latest-64bit', 'sdk-latest-64bit'):
     # This is effectly the default SDK
     return str(find_latest_releases_sdk('upstream'))
@@ -2652,8 +2652,6 @@ def expand_sdk_name(name):
     return str(find_tot_sdk('upstream'))
   elif name == 'tot-upstream':
     return str(find_tot_sdk('upstream'))
-  elif name in ('tot-fastcomp', 'sdk-nightly-latest'):
-    exit_with_fastcomp_error('The fastcomp backend is not getting tot/nightly builds.')
   else:
     # check if it's a release handled by an emscripten-releases version,
     # and if so use that by using the right hash. we support a few notations,
@@ -2670,7 +2668,7 @@ def expand_sdk_name(name):
       backend = 'fastcomp'
     fullname = fullname.replace('sdk-', '').replace('-64bit', '').replace('tag-', '')
     if backend == 'fastcomp' and version_key(fullname) >= (2, 0, 0):
-      exit_with_fastcomp_error('The fastcomp backend is not supported in 2.0.0+.')
+      exit_with_fastcomp_error()
     releases_info = load_releases_info()['releases']
     release_hash = get_release_hash(fullname, releases_info)
     if release_hash:

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -62,7 +62,7 @@ def checked_call_with_output(cmd, expected=None, unexpected=None, stderr=None):
 def failing_call_with_output(cmd, expected):
   proc = subprocess.Popen(cmd.split(' '), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
   stdout, stderr = proc.communicate()
-  assert proc.returncode, 'call must have failed'
+  assert proc.returncode, 'call must have failed: ' + str([stdout, "\n========\n" stderr])
   assert expected in stdout or expected in stderr, 'call did not have the right output'
 
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -62,7 +62,7 @@ def checked_call_with_output(cmd, expected=None, unexpected=None, stderr=None):
 def failing_call_with_output(cmd, expected):
   proc = subprocess.Popen(cmd.split(' '), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
   stdout, stderr = proc.communicate()
-  assert proc.returncode, 'call must have failed: ' + str([stdout, "\n========\n" stderr])
+  assert proc.returncode, 'call must have failed: ' + str([stdout, "\n========\n", stderr])
   assert expected in stdout or expected in stderr, 'call did not have the right output'
 
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -152,9 +152,10 @@ print('verify latest fastcomp version is fixed at 1.40.1')
 checked_call_with_output(fastcomp_emcc + ' -v', '1.40.1', stderr=subprocess.STDOUT)
 
 print('verify that attempting to use newer fastcomp gives an error')
-failing_call_with_output(emsdk + ' install latest-fastcomp', 'The fastcomp backend is not getting new builds. Please use the upstream llvm backend')
-failing_call_with_output(emsdk + ' install tot-fastcomp', 'The fastcomp backend is not getting tot/nightly builds. Please use the upstream llvm backend')
-failing_call_with_output(emsdk + ' install 2.0.0-fastcomp', 'The fastcomp backend is not supported in 2.0.0+. Please use the upstream llvm backend')
+fastcomp_error = 'The fastcomp backend is not getting new builds or releases. Please use the upstream llvm backend or use an older version than 2.0.0 (such as 1.40.1).'
+failing_call_with_output(emsdk + ' install latest-fastcomp', fastcomp_error)
+failing_call_with_output(emsdk + ' install tot-fastcomp', fastcomp_error)
+failing_call_with_output(emsdk + ' install 2.0.0-fastcomp', fastcomp_error)
 
 print('clear cache')
 check_call(upstream_emcc + ' --clear-cache')

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -139,9 +139,9 @@ test_lib_building(upstream_emcc, use_asmjs_optimizer=True)
 print('update')
 run_emsdk('update-tags')
 
-print('test latest-releases-fastcomp')
-run_emsdk('install latest-fastcomp')
-run_emsdk('activate latest-fastcomp')
+print('test the last fastcomp release')
+run_emsdk('install 1.40.1-fastcomp')
+run_emsdk('activate 1.40.1-fastcomp')
 
 test_lib_building(fastcomp_emcc, use_asmjs_optimizer=False)
 assert open(emconfig).read().count('LLVM_ROOT') == 1
@@ -150,6 +150,11 @@ assert 'fastcomp' in open(emconfig).read()
 
 print('verify latest fastcomp version is fixed at 1.40.1')
 checked_call_with_output(fastcomp_emcc + ' -v', '1.40.1', stderr=subprocess.STDOUT)
+
+print('verify that attempting to use newer fastcomp gives an error')
+failing_call_with_output(emsdk + ' install latest-fastcomp', 'The fastcomp backend is not getting new builds. Please use the upstream llvm backend')
+failing_call_with_output(emsdk + ' install tot-fastcomp', 'The fastcomp backend is not getting tot/nightly builds. Please use the upstream llvm backend')
+failing_call_with_output(emsdk + ' install 2.0.0-fastcomp', 'The fastcomp backend is not supported in 2.0.0+. Please use the upstream llvm backend')
 
 print('clear cache')
 check_call(upstream_emcc + ' --clear-cache')
@@ -169,7 +174,7 @@ assert old_config == open(emconfig + '.old').read()
 # TODO; test on latest as well
 check_call(upstream_emcc + ' hello_world.c')
 
-print('test specific release (old)')
+print('test specific release (old, using sdk-* notation)')
 run_emsdk('install sdk-fastcomp-1.38.31-64bit')
 run_emsdk('activate sdk-fastcomp-1.38.31-64bit')
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -62,7 +62,10 @@ def checked_call_with_output(cmd, expected=None, unexpected=None, stderr=None):
 def failing_call_with_output(cmd, expected):
   proc = subprocess.Popen(cmd.split(' '), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
   stdout, stderr = proc.communicate()
-  assert proc.returncode, 'call must have failed: ' + str([stdout, "\n========\n", stderr])
+  if WINDOWS:
+    print('warning: skipping part of failing_call_with_output() due to error codes not being propagated (see #592)')
+  else:
+    assert proc.returncode, 'call must have failed: ' + str([stdout, "\n========\n", stderr])
   assert expected in stdout or expected in stderr, 'call did not have the right output'
 
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -60,7 +60,7 @@ def checked_call_with_output(cmd, expected=None, unexpected=None, stderr=None):
 
 
 def failing_call_with_output(cmd, expected):
-  proc = subprocess.Popen(cmd.split(' '), stdout=subprocess.PIPE, universal_newlines=True)
+  proc = subprocess.Popen(cmd.split(' '), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
   stdout, stderr = proc.communicate()
   assert proc.returncode, 'call must have failed'
   assert expected in stdout or expected in stderr, 'call did not have the right output'

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -63,7 +63,7 @@ def failing_call_with_output(cmd, expected):
   proc = subprocess.Popen(cmd.split(' '), stdout=subprocess.PIPE, universal_newlines=True)
   stdout, stderr = proc.communicate()
   assert proc.returncode, 'call must have failed'
-  assert expected in stdout, 'call did not have the right output'
+  assert expected in stdout or expected in stderr, 'call did not have the right output'
 
 
 def hack_emsdk(marker, replacement):


### PR DESCRIPTION
I think this is less surprising than continuing to support `latest-fastcomp`
with the last fastcomp release. That's technically correct - the last release
is 1.40.1, and always will be - but when a user asks for "latest" I think they
want something up to date. Instead, give a clear error that indicates how
they can get an actually up to date build, by using upstream.