### PR TITLE
Fix `emsdk activate` breaking configuration file

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1452,7 +1452,7 @@ def generate_dot_emscripten(active_tools):
     node_fallback = which('nodejs')
     if not node_fallback:
       node_fallback = 'node'
-    activated_config['NODE_JS'] = "'%s'" % node_fallback
+    activated_config['NODE_JS'] = node_fallback
 
   for name, value in activated_config.items():
     cfg += name + " = '" + value + "'\n"


### PR DESCRIPTION
related to issue #587

> If nodejs is not installed by `emsdk`, the output ".emscripten" file by `emsdk activate` will look like this.
> 
> ```python
> NODE_JS = ''/usr/bin/nodejs''
> # too many quotes
> ```
> 
> `emcc` fails to execute by this syntax error.
> 
> I think fixing [this line](https://github.com/emscripten-core/emsdk/blob/1.40.1/emsdk.py#L1450) could be a solution.
> 
> ```python
> activated_config['NODE_JS'] = "'%s'" % node_fallback
> # the value will be quoted later again
> ```