### PR TITLE
Parse the releases info only once in emsdk.py.

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2185,12 +2185,15 @@ def exit_with_error(msg):
 
 # Load the json info for emscripten-releases.
 def load_releases_info():
-  try:
-    text = open(sdk_path('emscripten-releases-tags.txt'), 'r').read()
-    return json.loads(text)
-  except Exception as e:
-    print('Error parsing emscripten-releases-tags.txt!')
-    exit_with_error(str(e))
+  if not hasattr(load_releases_info, 'cached_info'):
+    try:
+      text = open(sdk_path('emscripten-releases-tags.txt'), 'r').read()
+      load_releases_info.cached_info = json.loads(text)
+    except Exception as e:
+      print('Error parsing emscripten-releases-tags.txt!')
+      exit_with_error(str(e))
+
+  return load_releases_info.cached_info
 
 
 # Get a list of tags for emscripten-releases.


### PR DESCRIPTION
`load_releases_info()` from `emsdk.py` reads `emscripten-releases-tags.txt` into memory and parses it as Json. It is called many times to retrieve info about the sdk. For example `emsdk.py list` will call it 12 times.

Since each call produces the same result I think we could save some reading and parsing by caching the result, thus this pull request :)

Best regards