### PR TITLE
Fix sanity file generation in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,6 @@
 # Allow to run the test script inside the Docker container
 !/docker/test_dockerimage.sh
 
-# Allow the Dockerfile for future re-creation/reference
-!/docker/Dockerfile
-
 # Ignore unnecessary files inside top-level directory
 *.bat
 *.csh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,11 +28,15 @@ RUN echo "## Install Emscripten" \
     && echo "## Done"
 
 # This generates configuration that contains all valid paths according to installed SDK
+# TODO(sbc): We should be able to use just emcc -v here but it doesn't
+# currently create the sanity file.
 RUN cd ${EMSDK} \
     && echo "## Generate standard configuration" \
     && ./emsdk activate ${EMSCRIPTEN_VERSION} \
     && chmod 777 ${EMSDK}/upstream/emscripten \
     && chmod -R 777 ${EMSDK}/upstream/emscripten/cache \
+    && echo "int main() { return 0; }" > hello.c \
+    && ${EMSDK}/upstream/emscripten/emcc -c hello.c \
     && cat ${EMSDK}/upstream/emscripten/cache/sanity.txt \
     && echo "## Done"
 


### PR DESCRIPTION
We no longer ship the sanify file as part of the SDK but
expect it be generated on first use:
  https://github.com/WebAssembly/waterfall/pull/656

Also remove the Dockerfile itself from the docker image if
we include it then whenever you change anything in the
Dockerfile it invalides all the layers and forces a
completely rebuild.  This makes iterating on the image
very slow.