### PR TITLE
Add missing python locations to emsdk.ps1

### DIFF
--- a/emsdk.ps1
+++ b/emsdk.ps1
@@ -1,6 +1,8 @@
 $ScriptDirectory = Split-Path -parent $PSCommandPath
 
 $PythonLocations = $(
+    "python\3.7.4-pywin32_64bit\python.exe",
+    "python\3.7.4_64bit\python.exe",
     "python\2.7.13.1_64bit\python-2.7.13.amd64\python.exe",
     "python\2.7.13.1_32bit\python-2.7.13\python.exe",
     "python\2.7.5.3_64bit\python.exe",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -477,7 +477,7 @@
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-12.18.1-64bit", "python-3.7.4-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-master-64bit", "node-12.18.1-64bit", "python-3.7.4-pywin32-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "win"
   },
   {
@@ -507,7 +507,7 @@
   {
     "version": "fastcomp-master",
     "bitness": 64,
-    "uses": ["fastcomp-clang-master-64bit", "node-12.18.1-64bit", "python-3.7.4-64bit", "java-8.152-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["fastcomp-clang-master-64bit", "node-12.18.1-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "win"
   },
   {


### PR DESCRIPTION
This adds the missing python locations to emsdk.ps1 so it matches emsdk.bat. 

On Windows, if you add the emsdk dir to the path and use PowerShell as your terminal (which is almost everyone), then any call to "emsdk" will actually use the ps1 files. This means the Python version that is shipped with esmdk is not used!