### PR TITLE
Set user environment variables permanently by using `--permanent` + deprecate `--global`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,11 @@ jobs:
           command: |
             source emsdk_env.sh
             python scripts/test.py
+      - run:
+          name: --permanent test
+          shell: powershell.exe
+          command: |
+            scripts/test_permanent.ps1
 
   build-docker-image:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,12 @@ jobs:
           name: --permanent test
           shell: powershell.exe
           command: |
-            scripts/test_permanent.ps1
+            try {
+              scripts/test_permanent.ps1
+            } catch {
+              Write-Host "`n Error Message: [$($_.Exception.Message)"] -ForegroundColor Red
+              Write-Host "`n Line Number: "$_.InvocationInfo.ScriptLineNumber -ForegroundColor Red
+            }
 
   build-docker-image:
     executor: bionic

--- a/README.md
+++ b/README.md
@@ -176,9 +176,8 @@ reissuing `emsdk install`.
 
 You can toggle between different tools and SDK versions by running `emsdk
 activate <tool/sdk name>`. Activating a tool will set up `~/.emscripten` to
-point to that particular tool. On Windows, you can pass the option `--global` to
-the `activate` command to register the environment permanently to the system
-registry for all users.
+point to that particular tool. On Windows, you can pass the option `--permanent` to
+the `activate` command to register the environment permanently for the current user. Use `--system` to do this for all users.
 
 ### How do I build multiple projects with different SDK versions in parallel?
 

--- a/emsdk.py
+++ b/emsdk.py
@@ -2480,7 +2480,7 @@ def to_msys_path(p):
 
 # Looks at the current PATH and adds and removes entries so that the PATH reflects
 # the set of given active tools.
-def adjusted_path(tools_to_activate, log_additions=False, system=False):
+def adjusted_path(tools_to_activate, system=False):
   # These directories should be added to PATH
   path_add = get_required_path(tools_to_activate)
   # These already exist.

--- a/emsdk.py
+++ b/emsdk.py
@@ -2730,12 +2730,17 @@ def main():
    emsdk activate [--global] [--build=type] [--vs2017/--vs2019] <tool/sdk>
 
                                 - Activates the given tool or SDK in the
-                                  environment of the current shell. If the
-                                  --global option is passed, the registration
-                                  is done globally to all users in the system
-                                  environment.  If a custom compiler version was
-                                  used to override the compiler to use, pass
-                                  the same --vs2017/--vs2019 parameter
+                                  environment of the current shell.
+
+                                - If the `--global` option is passed, the the environment
+                                  variables are set permanently for the current user.
+
+                                - If the `--system` option is passed, the registration
+                                  is done for all users of the system
+                                  (uses Machine environment variables).
+
+                                - If a custom compiler version was used to override
+                                  the compiler to use, pass the same --vs2017/--vs2019 parameter
                                   here to choose which version to activate.
 
    emcmdprompt.bat              - Spawns a new command prompt window with the

--- a/emsdk.py
+++ b/emsdk.py
@@ -2774,6 +2774,7 @@ def main():
   arg_global = extract_bool_arg('--global')
   if arg_global:
     print('--global is deprecated. Use `--system` to set the environment variables for all users')
+    arg_permanent = True
   arg_system = extract_bool_arg('--system')
   if arg_system:
     arg_permanent = True

--- a/emsdk.py
+++ b/emsdk.py
@@ -2727,12 +2727,12 @@ def main():
 
     if WINDOWS:
       print('''
-   emsdk activate [--global] [--build=type] [--vs2017/--vs2019] <tool/sdk>
+   emsdk activate [--permanent] [--system] [--build=type] [--vs2017/--vs2019] <tool/sdk>
 
                                 - Activates the given tool or SDK in the
                                   environment of the current shell.
 
-                                - If the `--global` option is passed, the the environment
+                                - If the `--permanent` option is passed, the the environment
                                   variables are set permanently for the current user.
 
                                 - If the `--system` option is passed, the registration
@@ -2770,9 +2770,13 @@ def main():
 
   arg_old = extract_bool_arg('--old')
   arg_uses = extract_bool_arg('--uses')
+  arg_permanent = extract_bool_arg('--permanent')
   arg_global = extract_bool_arg('--global')
+  if arg_global:
+    print('--global is deprecated. Use `--system` to set the environment variables for all users')
   arg_system = extract_bool_arg('--system')
   if arg_system:
+    arg_permanent = True
     arg_global = True
   if extract_bool_arg('--embedded'):
     errlog('embedded mode is now the only mode available')
@@ -2935,7 +2939,7 @@ def main():
     print('Items marked with * are activated for the current user.')
     if has_partially_active_tools[0]:
       env_cmd = 'emsdk_env.bat' if WINDOWS else 'source ./emsdk_env.sh'
-      print('Items marked with (*) are selected for use, but your current shell environment is not configured to use them. Type "' + env_cmd + '" to set up your current shell to use them' + (', or call "emsdk activate --global <name_of_sdk>" to permanently activate them.' if WINDOWS else '.'))
+      print('Items marked with (*) are selected for use, but your current shell environment is not configured to use them. Type "' + env_cmd + '" to set up your current shell to use them' + (', or call "emsdk activate --permanent <name_of_sdk>" to permanently activate them.' if WINDOWS else '.'))
     if not arg_old:
       print('')
       print("To access the historical archived versions, type 'emsdk list --old'")
@@ -2969,8 +2973,8 @@ def main():
     fetch_emscripten_tags()
     return 0
   elif cmd == 'activate':
-    if arg_global:
-      print('Registering active Emscripten environment globally for all users.')
+    if arg_permanent:
+      print('Registering active Emscripten environment premenantly')
       print('')
 
     tools_to_activate = currently_active_tools()
@@ -2985,12 +2989,12 @@ def main():
     if not tools_to_activate:
       errlog('No tools/SDKs specified to activate! Usage:\n   emsdk activate tool/sdk1 [tool/sdk2] [...]')
       return 1
-    active_tools = set_active_tools(tools_to_activate, permanently_activate=arg_global, system=arg_system)
+    active_tools = set_active_tools(tools_to_activate, permanently_activate=arg_permanent, system=arg_system)
     if not active_tools:
       errlog('No tools/SDKs found to activate! Usage:\n   emsdk activate tool/sdk1 [tool/sdk2] [...]')
       return 1
-    if WINDOWS and not arg_global:
-      errlog('The changes made to environment variables only apply to the currently running shell instance. Use the \'emsdk_env.bat\' to re-enter this environment later, or if you\'d like to permanently register this environment globally to all users in Windows Registry, rerun this command with the option --global.')
+    if WINDOWS and not arg_permanent:
+      errlog('The changes made to environment variables only apply to the currently running shell instance. Use the \'emsdk_env.bat\' to re-enter this environment later, or if you\'d like to permanently register this environment permanently, rerun this command with the option --permanent.')
     return 0
   elif cmd == 'install':
     # Process args

--- a/emsdk.py
+++ b/emsdk.py
@@ -2736,7 +2736,8 @@ def main():
                                   variables are set permanently for the current user.
 
                                 - If the `--system` option is passed, the registration
-                                  is done for all users of the system
+                                  is done for all users of the system.
+                                  This needs admin privileges
                                   (uses Machine environment variables).
 
                                 - If a custom compiler version was used to override

--- a/emsdk.py
+++ b/emsdk.py
@@ -2778,7 +2778,6 @@ def main():
   arg_system = extract_bool_arg('--system')
   if arg_system:
     arg_permanent = True
-    arg_global = True
   if extract_bool_arg('--embedded'):
     errlog('embedded mode is now the only mode available')
   if extract_bool_arg('--no-embedded'):

--- a/emsdk.py
+++ b/emsdk.py
@@ -2773,10 +2773,10 @@ def main():
   arg_uses = extract_bool_arg('--uses')
   arg_permanent = extract_bool_arg('--permanent')
   arg_global = extract_bool_arg('--global')
+  arg_system = extract_bool_arg('--system')
   if arg_global:
     print('--global is deprecated. Use `--system` to set the environment variables for all users')
-    arg_permanent = True
-  arg_system = extract_bool_arg('--system')
+    arg_system = True
   if arg_system:
     arg_permanent = True
   if extract_bool_arg('--embedded'):

--- a/emsdk.py
+++ b/emsdk.py
@@ -2732,7 +2732,7 @@ def main():
                                 - Activates the given tool or SDK in the
                                   environment of the current shell.
 
-                                - If the `--permanent` option is passed, the the environment
+                                - If the `--permanent` option is passed, then the environment
                                   variables are set permanently for the current user.
 
                                 - If the `--system` option is passed, the registration
@@ -2974,7 +2974,7 @@ def main():
     return 0
   elif cmd == 'activate':
     if arg_permanent:
-      print('Registering active Emscripten environment premenantly')
+      print('Registering active Emscripten environment permanently')
       print('')
 
     tools_to_activate = currently_active_tools()

--- a/emsdk.py
+++ b/emsdk.py
@@ -2767,6 +2767,8 @@ def main():
   arg_uses = extract_bool_arg('--uses')
   arg_global = extract_bool_arg('--global')
   arg_system = extract_bool_arg('--system')
+  if arg_system:
+    arg_global = True
   if extract_bool_arg('--embedded'):
     errlog('embedded mode is now the only mode available')
   if extract_bool_arg('--no-embedded'):

--- a/scripts/test_permanent.ps1
+++ b/scripts/test_permanent.ps1
@@ -1,67 +1,56 @@
-$cwd=(Get-Location).Path
+$repo_root = [System.IO.Path]::GetDirectoryName((resolve-path "$PSScriptRoot"))
 
-try {
+& "$repo_root/emsdk.ps1" install latest
+& "$repo_root/emsdk.ps1" activate latest --permanent
 
-    cd([System.IO.Path]::GetDirectoryName((resolve-path "$PSScriptRoot")))
+$EMSDK_USER = [System.Environment]::GetEnvironmentVariable("EMSDK", "User")
+$EM_CONFIG_USER = [System.Environment]::GetEnvironmentVariable("EM_CONFIG", "User")
+$EMSDK_NODE_USER = [System.Environment]::GetEnvironmentVariable("EMSDK_NODE", "User")
+$EMSDK_PYTHON_USER = [System.Environment]::GetEnvironmentVariable("EMSDK_PYTHON", "User")
+$JAVA_HOME_USER = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", "User")
+$EM_CACHE_USER = [System.Environment]::GetEnvironmentVariable("EM_CACHE", "User")
+$PATH_USER = [System.Environment]::GetEnvironmentVariable("PATH", "User")
 
-    ./emsdk.ps1 install latest
-    ./emsdk.ps1 activate latest --permanently
-
-    $EMSDK_USER = [System.Environment]::GetEnvironmentVariable("EMSDK", "User")
-    $EM_CONFIG_USER = [System.Environment]::GetEnvironmentVariable("EM_CONFIG", "User")
-    $EMSDK_NODE_USER = [System.Environment]::GetEnvironmentVariable("EMSDK_NODE", "User")
-    $EMSDK_PYTHON_USER = [System.Environment]::GetEnvironmentVariable("EMSDK_PYTHON", "User")
-    $JAVA_HOME_USER = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", "User")
-    $EM_CACHE_USER = [System.Environment]::GetEnvironmentVariable("EM_CACHE", "User")
-    $PATH_USER = [System.Environment]::GetEnvironmentVariable("PATH", "User")
-
-    if (!$EMSDK_USER) {
-        throw "EMSDK is not set for the user"
-    }
-    if (!$EM_CONFIG_USER) {
-        throw "EM_CONFIG_USER is not set for the user"
-    }
-    if (!$EMSDK_NODE_USER) {
-        throw "EMSDK_NODE is not set for the user"
-    }
-    if (!$JAVA_HOME_USER) {
-        throw "JAVA_HOME is not set for the user"
-    }
-    if (!$EMSDK_PYTHON_USER) {
-        throw "EMSDK_PYTHON is not set for the user"
-    }
-    if (!$EM_CACHE_USER) {
-        throw "EM_CACHE is not set for the user"
-    }
-
-
-    $path_split = $path.Split(';')
-
-    $EMSDK_Path_USER = $path_split | Where-Object { $_ -match 'emsdk' }
-    if (!$EMSDK_Path_USER) {
-        throw "No path is added!"
-    }
-    $EMSDK_NODE_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\node' }
-    if (!$EMSDK_NODE_Path_USER) {
-        throw "emsdk\node is not added to path."
-    }
-    $EMSDK_PYTHON_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\python' }
-    if (!$EMSDK_PYTHON_Path_USER) {
-        throw "emsdk\python is not added to path."
-    }
-    $EMSDK_JAVA_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\java' }
-    if (!$EMSDK_JAVA_Path_USER) {
-        throw "emsdk\java is not added to path."
-    }
-
-    $EMSDK_UPSTREAM_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\upstream\\emscripten' }
-    if (!$EMSDK_UPSTREAM_Path_USER) {
-        throw "emsdk\upstream\emscripten is not added to path."
-    }
-
+if (!$EMSDK_USER) {
+    throw "EMSDK is not set for the user"
 }
-finally
-{
-# return back to cwd
-cd $cwd
+if (!$EM_CONFIG_USER) {
+    throw "EM_CONFIG_USER is not set for the user"
+}
+if (!$EMSDK_NODE_USER) {
+    throw "EMSDK_NODE is not set for the user"
+}
+if (!$JAVA_HOME_USER) {
+    throw "JAVA_HOME is not set for the user"
+}
+if (!$EMSDK_PYTHON_USER) {
+    throw "EMSDK_PYTHON is not set for the user"
+}
+if (!$EM_CACHE_USER) {
+    throw "EM_CACHE is not set for the user"
+}
+
+
+$path_split = $PATH_USER.Split(';')
+
+$EMSDK_Path_USER = $path_split | Where-Object { $_ -match 'emsdk' }
+if (!$EMSDK_Path_USER) {
+    throw "No path is added!"
+}
+$EMSDK_NODE_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\node' }
+if (!$EMSDK_NODE_Path_USER) {
+    throw "emsdk\node is not added to path."
+}
+$EMSDK_PYTHON_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\python' }
+if (!$EMSDK_PYTHON_Path_USER) {
+    throw "emsdk\python is not added to path."
+}
+$EMSDK_JAVA_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\java' }
+if (!$EMSDK_JAVA_Path_USER) {
+    throw "emsdk\java is not added to path."
+}
+
+$EMSDK_UPSTREAM_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\upstream\\emscripten' }
+if (!$EMSDK_UPSTREAM_Path_USER) {
+    throw "emsdk\upstream\emscripten is not added to path."
 }

--- a/scripts/test_permanent.ps1
+++ b/scripts/test_permanent.ps1
@@ -1,0 +1,67 @@
+$cwd=(Get-Location).Path
+
+try {
+
+    cd([System.IO.Path]::GetDirectoryName((resolve-path "$PSScriptRoot")))
+
+    ./emsdk.ps1 install latest
+    ./emsdk.ps1 activate latest --permanently
+
+    $EMSDK_USER = [System.Environment]::GetEnvironmentVariable("EMSDK", "User")
+    $EM_CONFIG_USER = [System.Environment]::GetEnvironmentVariable("EM_CONFIG", "User")
+    $EMSDK_NODE_USER = [System.Environment]::GetEnvironmentVariable("EMSDK_NODE", "User")
+    $EMSDK_PYTHON_USER = [System.Environment]::GetEnvironmentVariable("EMSDK_PYTHON", "User")
+    $JAVA_HOME_USER = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", "User")
+    $EM_CACHE_USER = [System.Environment]::GetEnvironmentVariable("EM_CACHE", "User")
+    $PATH_USER = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+
+    if (!$EMSDK_USER) {
+        throw "EMSDK is not set for the user"
+    }
+    if (!$EM_CONFIG_USER) {
+        throw "EM_CONFIG_USER is not set for the user"
+    }
+    if (!$EMSDK_NODE_USER) {
+        throw "EMSDK_NODE is not set for the user"
+    }
+    if (!$JAVA_HOME_USER) {
+        throw "JAVA_HOME is not set for the user"
+    }
+    if (!$EMSDK_PYTHON_USER) {
+        throw "EMSDK_PYTHON is not set for the user"
+    }
+    if (!$EM_CACHE_USER) {
+        throw "EM_CACHE is not set for the user"
+    }
+
+
+    $path_split = $path.Split(';')
+
+    $EMSDK_Path_USER = $path_split | Where-Object { $_ -match 'emsdk' }
+    if (!$EMSDK_Path_USER) {
+        throw "No path is added!"
+    }
+    $EMSDK_NODE_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\node' }
+    if (!$EMSDK_NODE_Path_USER) {
+        throw "emsdk\node is not added to path."
+    }
+    $EMSDK_PYTHON_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\python' }
+    if (!$EMSDK_PYTHON_Path_USER) {
+        throw "emsdk\python is not added to path."
+    }
+    $EMSDK_JAVA_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\java' }
+    if (!$EMSDK_JAVA_Path_USER) {
+        throw "emsdk\java is not added to path."
+    }
+
+    $EMSDK_UPSTREAM_Path_USER = $path_split | Where-Object { $_ -match 'emsdk\\upstream\\emscripten' }
+    if (!$EMSDK_UPSTREAM_Path_USER) {
+        throw "emsdk\upstream\emscripten is not added to path."
+    }
+
+}
+finally
+{
+# return back to cwd
+cd $cwd
+}


### PR DESCRIPTION
Closes https://github.com/emscripten-core/emsdk/pull/468

Fixes #467

This makes ./emsdk activate --global to set user environment variables by default instead of previous system-wide-only activation.

Also removes some magic that implicitly nukes user envvars when system ones are shadowed, as a system admin should understand what's going on when setting envvars. Thus fixes #189 and closes #192.