### PR TITLE
Minor fix to emsdk.bat file

### DIFF
--- a/emsdk.bat
+++ b/emsdk.bat
@@ -4,11 +4,11 @@
 
 setlocal
 
+:: When using our bundled python we never want the users
+:: PYTHONHOME or PYTHONPATH
+:: https://github.com/emscripten-core/emsdk/issues/598
 if exist "%~dp0python\3.7.4-pywin32_64bit\python.exe" (
   set EMSDK_PY="%~dp0python\3.7.4-pywin32_64bit\python.exe"
-  :: When using our bundled python we never want the users
-  :: PYTHONHOME or PYTHONPATH
-  :: https://github.com/emscripten-core/emsdk/issues/598
   set PYTHONHOME=
   set PYTHONPATH=
   goto end


### PR DESCRIPTION
It seems that using ``::`` style comments in bat file function blocks causes weird errors in the command line as it's interpreted as a path.

https://stackoverflow.com/questions/12407800/which-comment-style-should-i-use-in-batch-files/12408045#12408045
