### PR TITLE
Fix MSYS2/MinGW python mistaking system as Linux

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -74,7 +74,7 @@ if platform.mac_ver()[0] != '':
   MACOS = True
 
 LINUX = False
-if not MACOS and (platform.system() == 'Linux' or os.name == 'posix'):
+if not MACOS and (platform.system() == 'Linux'):
   LINUX = True
 
 UNIX = (MACOS or LINUX)


### PR DESCRIPTION
When running `source emsdk_env.sh` along with python provided by MSYS2/MinGW the environment gets falsely identified as Linux.

See discussion for details:
https://github.com/emscripten-core/emscripten/issues/12376#issuecomment-702245993

