### PR TITLE
Add test-msys2 job to circleci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,7 @@ workflows:
   test-windows:
     jobs:
       - test-windows
+      - test-msys2
   build-docker-image:
     jobs:
       - build-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,16 +111,16 @@ jobs:
           command: choco install --confirm msys2
       - run:
           name: Install msys2 packages
-          command: $MSYS_CMD "pacman --sync --noconfirm --needed base-devel cmake gcc python"
+          command: %MSYS_CMD% "pacman --sync --noconfirm --needed base-devel cmake gcc python"
       - run:
           name: test.sh
-          command: $MSYS_CMD "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
+          command: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
       - run:
           name: test_source_env.sh
-          command: $MSYS_CMD "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
+          command: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
       - run:
           name: test.py
-          command: $MSYS_CMD "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
+          command: %MSYS_CMD% "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
 
   build-docker-image:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,26 @@ jobs:
               Write-Host "`n Error Message: [$($_.Exception.Message)"] -ForegroundColor Red
               Write-Host "`n Line Number: "$_.InvocationInfo.ScriptLineNumber -ForegroundColor Red
             }
+            
+  test-msys2:
+    executor:
+      name: win/vs2019
+      shell: cmd.exe
+    environment:
+      MSYS_CMD: C:\\tools\\msys64\\msys2_shell.cmd -here -defterm -no-start -c
+    steps:
+      - checkout
+      - run:
+          name: Install msys2 (via choco)
+          command: choco --confirm install msys2
+      - run:
+          name: Install msys2 packages
+          command: %MSYS_CMD% "pacman --sync --noconfirm --needed base-devel cmake gcc"
+      - run: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
+      - run: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
+      - run:
+          name: test.py
+          command: %MSYS_CMD% "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
 
   build-docker-image:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,12 +111,16 @@ jobs:
           command: choco --confirm install msys2
       - run:
           name: Install msys2 packages
-          command: %MSYS_CMD% "pacman --sync --noconfirm --needed base-devel cmake gcc python"
-      - run: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
-      - run: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
+          command: $MSYS_CMD "pacman --sync --noconfirm --needed base-devel cmake gcc python"
+      - run:
+          name: test.sh
+          command: $MSYS_CMD "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
+      - run:
+          name: test_source_env.sh
+          command: $MSYS_CMD "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
       - run:
           name: test.py
-          command: %MSYS_CMD% "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
+          command: $MSYS_CMD "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
 
   build-docker-image:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           command: choco --confirm install msys2
       - run:
           name: Install msys2 packages
-          command: %MSYS_CMD% "pacman --sync --noconfirm --needed base-devel cmake gcc"
+          command: %MSYS_CMD% "pacman --sync --noconfirm --needed base-devel cmake gcc python"
       - run: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
       - run: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,16 +111,24 @@ jobs:
           command: choco install --confirm msys2
       - run:
           name: Install msys2 packages
-          command: %MSYS_CMD% "pacman --sync --noconfirm --needed base-devel cmake gcc python"
+          command: >
+            %MSYS_CMD%
+            "pacman --sync --noconfirm --needed base-devel cmake gcc python"
       - run:
           name: test.sh
-          command: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
+          command: >
+            %MSYS_CMD%
+            "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
       - run:
           name: test_source_env.sh
-          command: %MSYS_CMD% "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
+          command: >
+            %MSYS_CMD%
+            "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
       - run:
           name: test.py
-          command: %MSYS_CMD% "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
+          command: >
+            %MSYS_CMD%
+            "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
 
   build-docker-image:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
           command: C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -Syuu'
       - run:
           name: Update others
-          command: C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -Syuu msys2-devel python cmake'
+          command: C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -Syuu'
       - run:
           name: Install dependencies
           command: C:\msys64\usr\bin\bash -lc 'pacman --noconfirm --sync --needed msys2-devel python cmake'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       name: win/vs2019
       shell: cmd.exe
     environment:
-      MSYS_CMD: C:\\tools\\msys64\\msys2_shell.cmd -here -defterm -no-start -c
+      MSYS_CMD: C:\\tools\\msys64\\msys2_shell.cmd -here -defterm -no-start -msys2 -c
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
   test-msys2:
     executor:
       name: win/vs2019
-      shell: cmd.exe
+      shell: bash.exe
     environment:
       MSYS_CMD: C:\\tools\\msys64\\msys2_shell.cmd -here -defterm -no-start -c
     steps:
@@ -109,18 +109,23 @@ jobs:
       - run:
           name: Install msys2 (via choco)
           command: choco --confirm install msys2
+          shell: cmd.exe
       - run:
           name: Install msys2 packages
           command: $MSYS_CMD "pacman --sync --noconfirm --needed base-devel cmake gcc python"
+          shell: cmd.exe
       - run:
           name: test.sh
           command: $MSYS_CMD "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
+          shell: cmd.exe
       - run:
           name: test_source_env.sh
           command: $MSYS_CMD "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
+          shell: cmd.exe
       - run:
           name: test.py
           command: $MSYS_CMD "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
+          shell: cmd.exe
 
   build-docker-image:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
           name: Install msys2 packages
           command: >
             %MSYS_CMD%
-            "pacman --sync --noconfirm --needed base-devel cmake gcc python"
+            "pacman --sync --noconfirm --needed msys2-devel python cmake"
       - run:
           name: test.sh
           command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,34 +95,41 @@ jobs:
   test-msys2:
     executor:
       name: win/vs2019
-      shell: cmd.exe
+      shell: powershell.exe
     environment:
-      MSYS_CMD: C:\\tools\\msys64\\msys2_shell.cmd -here -defterm -no-start -msys2 -c
+      MSYS2_INSTALLER_URI: https://github.com/msys2/msys2-installer/releases/download/2020-09-03/msys2-base-x86_64-20200903.sfx.exe
+      CHERE_INVOKING: 'yes'
+      MSYSTEM: 'MSYS'
     steps:
       - checkout
       - run:
-          name: Install msys2 (via choco)
-          command: choco install --confirm msys2
+          name: Download msys2
+          command: (New-Object System.Net.WebClient).DownloadFile("$Env:MSYS2_INSTALLER_URI", 'msys2.exe')
       - run:
-          name: Install msys2 packages
-          command: >
-            %MSYS_CMD%
-            "pacman --sync --noconfirm --needed msys2-devel python cmake"
+          name: Install
+          command: .\msys2.exe -y -oC:\
+      - run: Remove-Item msys2.exe
+      - run:
+          name: Bootstrap
+          command: C:\msys64\usr\bin\bash -lc ' '
+      - run:
+          name: Update core
+          command: C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -Syuu'
+      - run:
+          name: Update others
+          command: C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -Syuu msys2-devel python cmake'
+      - run:
+          name: Install dependencies
+          command: C:\msys64\usr\bin\bash -lc 'pacman --noconfirm --sync --needed msys2-devel python cmake'
       - run:
           name: test.sh
-          command: >
-            %MSYS_CMD%
-            "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
+          command: C:\msys64\usr\bin\bash -lc "export EMSDK_NOTTY='1' && ./scripts/test.sh"
       - run:
           name: test_source_env.sh
-          command: >
-            %MSYS_CMD%
-            "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
+          command: C:\msys64\usr\bin\bash -lc "export EMSDK_NOTTY='1' && ./scripts/test_source_env.sh"
       - run:
           name: test.py
-          command: >
-            %MSYS_CMD%
-            "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
+          command: C:\msys64\usr\bin\bash -lc "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
 
   build-docker-image:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
       - checkout
       - run:
           name: Install msys2 (via choco)
-          command: choco --confirm install msys2
+          command: choco install --confirm msys2
       - run:
           name: Install msys2 packages
           command: $MSYS_CMD "pacman --sync --noconfirm --needed base-devel cmake gcc python"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
   test-msys2:
     executor:
       name: win/vs2019
-      shell: bash.exe
+      shell: cmd.exe
     environment:
       MSYS_CMD: C:\\tools\\msys64\\msys2_shell.cmd -here -defterm -no-start -c
     steps:
@@ -109,23 +109,18 @@ jobs:
       - run:
           name: Install msys2 (via choco)
           command: choco --confirm install msys2
-          shell: cmd.exe
       - run:
           name: Install msys2 packages
           command: $MSYS_CMD "pacman --sync --noconfirm --needed base-devel cmake gcc python"
-          shell: cmd.exe
       - run:
           name: test.sh
           command: $MSYS_CMD "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test.sh"
-          shell: cmd.exe
       - run:
           name: test_source_env.sh
           command: $MSYS_CMD "export EMSDK_NOTTY='1' && /usr/bin/sh.exe scripts/test_source_env.sh"
-          shell: cmd.exe
       - run:
           name: test.py
           command: $MSYS_CMD "source emsdk_env.sh && export EMSDK_NOTTY='1' && /usr/bin/python scripts/test.py"
-          shell: cmd.exe
 
   build-docker-image:
     executor: bionic


### PR DESCRIPTION
Run steps are modeled on the test-linux job but executed inside an MSYS2 shell.