### PR TITLE
Revert "Skip installing optional npm deps, but manually install Closure Compiler native package"

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1241,40 +1241,12 @@ def emscripten_npm_install(tool, directory):
   print('Running post-install step: npm ci ...')
   try:
     subprocess.check_output(
-        [npm, 'ci', '--production', '--no-optional'],
+        [npm, 'ci', '--production'],
         cwd=directory, stderr=subprocess.STDOUT, env=env,
         universal_newlines=True)
   except subprocess.CalledProcessError as e:
     print('Error running %s:\n%s' % (e.cmd, e.output))
     return False
-
-  # Manually install the appropriate native Closure Compiler package
-  # This is currently needed because npm ci will install the packages
-  # for Closure for all platforms, adding 180MB to the download size
-  # There are two problems here:
-  #   1. npm ci does not consider the platform of optional dependencies
-  #      https://github.com/npm/cli/issues/558
-  #   2. A bug with the native compiler has bloated the packages from
-  #      30MB to almost 300MB
-  #      https://github.com/google/closure-compiler-npm/issues/186
-  # If either of these bugs are fixed then we can remove this exception
-  closure_compiler_native = ''
-  if LINUX:
-    closure_compiler_native = 'google-closure-compiler-linux'
-  if MACOS:
-    closure_compiler_native = 'google-closure-compiler-osx'
-  if WINDOWS:
-    closure_compiler_native = 'google-closure-compiler-windows'
-  if closure_compiler_native:
-    print('Running post-install step: npm install', closure_compiler_native)
-    try:
-      subprocess.check_output(
-        [npm, 'install', closure_compiler_native],
-        cwd=directory, stderr=subprocess.STDOUT, env=env,
-        universal_newlines=True)
-    except subprocess.CalledProcessError as e:
-      print('Error running %s:\n%s' % (e.cmd, e.output))
-      return False
 
   print('Done running: npm ci')
   return True


### PR DESCRIPTION
Reverts emscripten-core/emsdk#630

See https://github.com/emscripten-core/emsdk/issues/632