### PR TITLE
Skip installing optional npm deps, but manually install Closure Compiler native package

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1241,9 +1241,9 @@ def emscripten_npm_install(tool, directory):
   #      https://github.com/google/closure-compiler-npm/issues/186
   # If either of these bugs are fixed then we can remove this exception
   closure_compiler_native = ''
-  if LINUX and ARCH in ('x86' , 'x86_64'):
+  if LINUX and ARCH in ('x86', 'x86_64'):
     closure_compiler_native = 'google-closure-compiler-linux'
-  if MACOS and ARCH in ('x86' , 'x86_64'):
+  if MACOS and ARCH in ('x86', 'x86_64'):
     closure_compiler_native = 'google-closure-compiler-osx'
   if WINDOWS and ARCH == 'x86_64':
     closure_compiler_native = 'google-closure-compiler-windows'

--- a/emsdk.py
+++ b/emsdk.py
@@ -1241,9 +1241,9 @@ def emscripten_npm_install(tool, directory):
   #      https://github.com/google/closure-compiler-npm/issues/186
   # If either of these bugs are fixed then we can remove this exception
   closure_compiler_native = ''
-  if LINUX and (ARCH == 'x86' or ARCH == 'x86_64'):
+  if LINUX and ARCH in ('x86' , 'x86_64'):
     closure_compiler_native = 'google-closure-compiler-linux'
-  if MACOS and (ARCH == 'x86' or ARCH == 'x86_64'):
+  if MACOS and ARCH in ('x86' , 'x86_64'):
     closure_compiler_native = 'google-closure-compiler-osx'
   if WINDOWS and ARCH == 'x86_64':
     closure_compiler_native = 'google-closure-compiler-windows'

--- a/emsdk.py
+++ b/emsdk.py
@@ -1229,7 +1229,7 @@ def emscripten_npm_install(tool, directory):
   except subprocess.CalledProcessError as e:
     print('Error running %s:\n%s' % (e.cmd, e.output))
     return False
-  
+
   # Manually install the appropriate native Closure Compiler package
   # This is currently needed because npm ci will install the packages
   # for Closure for all platforms, adding 180MB to the download size


### PR DESCRIPTION
Now checks ARCH

Follow on to #625, #630, #632, #633
Fixes emscripten-core/emscripten#12406