### PR TITLE
Update mac circleci environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             scripts/test.py
   test-mac:
     macos:
-      xcode: "9.0"
+      xcode: "12.2.0"
     environment:
       EMSDK_NOTTY: "1"
       # Without this, any `brew installl` command will result in self-update of

--- a/emsdk
+++ b/emsdk
@@ -11,11 +11,17 @@ if [ -z "$EMSDK_PYTHON" ]; then
   PYTHON3=$(dirname $0)/python/3.7.4-2_64bit/bin/python3
   if [ -e $PYTHON3 ]; then
     EMSDK_PYTHON=$PYTHON3
+
     # When using our bundled python we never want the users
     # PYTHONHOME or PYTHONPATH
     # https://github.com/emscripten-core/emsdk/issues/598
     unset PYTHONHOME
     unset PYTHONPATH
+
+    # This is needed for MacOS.  Without this, the urlopen
+    # code will try to use /usr/local/etc/openssl/cert.pem
+    # which may or may not exist on the system.
+    export SSL_CERT_FILE=$(dirname $0)/python/3.7.4-2_64bit/lib/python3.7/site-packages/certifi/cacert.pem
   fi
 fi
 

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -294,7 +294,7 @@
     "macos_url": "python-3.7.4-2-macos.tar.gz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "PYTHON='%installation_dir%/bin/python3'",
-    "activated_env": "EMSDK_PYTHON=%installation_dir%/bin/python3"
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/bin/python3;SSL_CERT_FILE=%installation_dir%/lib/python3.7/site-packages/certifi/cacert.pem"
   },
   {
     "id": "java",


### PR DESCRIPTION
Apparently `Image xcode:9.0 is not supported` these days.