### PR TITLE
circleci: Add explict version to `setup_remote_docker`. NFC.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
           name: install docker
           command: apt-get update -q && apt-get install -q -y docker.io
       - setup_remote_docker
+          version: 19.03.13
       # Build and test the tip-of-tree build of EMSDK
       - run:
           name: build
@@ -117,6 +118,7 @@ jobs:
           name: install docker
           command: apt-get update -q && apt-get install -q -y docker.io
       - setup_remote_docker
+          version: 19.03.13
       - run:
           name: build
           command: make -C ./docker version=${CIRCLE_TAG} build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - run:
           name: install docker
           command: apt-get update -q && apt-get install -q -y docker.io
-      - setup_remote_docker
+      - setup_remote_docker:
           version: 19.03.13
       # Build and test the tip-of-tree build of EMSDK
       - run:
@@ -117,7 +117,7 @@ jobs:
       - run:
           name: install docker
           command: apt-get update -q && apt-get install -q -y docker.io
-      - setup_remote_docker
+      - setup_remote_docker:
           version: 19.03.13
       - run:
           name: build


### PR DESCRIPTION
Apparently we are supposed to do this:
 https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572