### PR TITLE
On windows, construct environment separately when storing to registry

### DIFF
--- a/scripts/check_path.py
+++ b/scripts/check_path.py
@@ -1,0 +1,28 @@
+# Given a previous path check that the current path
+# contains all the same elements in the same order
+# with no elements removed.
+
+import os
+import sys
+
+old_path = sys.argv[1].split(os.pathsep)
+new_path = os.environ['PATH'].split(os.pathsep)
+
+paths_added = [p for p in new_path if p not in old_path]
+paths_preserved = [p for p in new_path if p in old_path]
+
+for p in old_path:
+  if p not in paths_preserved:
+    print('path not reserved: ' + p)
+    sys.exit(1)
+
+# Check that ordering matches too.
+if old_path != paths_preserved:
+  print('preserved paths don\'t match original path:')
+  print('old:')
+  for p in old_path:
+    print(' - ' + p)
+  print('preserved:')
+  for p in paths_preserved:
+    print(' - ' + p)
+  sys.exit(1)

--- a/scripts/test.bat
+++ b/scripts/test.bat
@@ -1,7 +1,10 @@
 :: equivilent of test.sh as windows bat file
 set PATH=%PATH%;%PYTHON_BIN%
+set OLD_PATH=%PATH%
 @CALL emsdk install latest
 @CALL emsdk activate latest
 @CALL emsdk_env.bat --build=Release
 @CALL python -c "import sys; print(sys.executable)"
 @CALL emcc.bat -v
+:: Check that no path elements were removed
+@CALL python scripts/check_path.py "%OLD_PATH%"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,6 +5,7 @@ echo "test the standard workflow (as close as possible to how a user would do it
 set -x
 set -e
 
+OLD_PATH=$PATH
 ./emsdk install latest
 ./emsdk activate latest
 source ./emsdk_env.sh --build=Release
@@ -12,3 +13,5 @@ source ./emsdk_env.sh --build=Release
 # bundled version.
 which python3
 emcc -v
+# Check that no path elements were removed
+python3 scripts/check_path.py "$OLD_PATH"


### PR DESCRIPTION
We can't use the same set of environment variables when setting local
values and when storing to the windows registry.  

This is because the new PATH value is constructed very differently
when updating the local shell compared to when updating the
registry.

Add test that verifies that no path elements are removed by
emsdk_env.  This includes not re-ordering or removing duplicates
that might exist already in the user's path.

Fixes: #634