### PR TITLE
Remove used arg in scripts/test.bat

### DIFF
--- a/scripts/test.bat
+++ b/scripts/test.bat
@@ -2,6 +2,6 @@
 set PATH=%PATH%;%PYTHON_BIN%
 @CALL emsdk install latest
 @CALL emsdk activate latest
-@CALL emsdk_env.bat --build=Release
+@CALL emsdk_env.bat
 @CALL python -c "import sys; print(sys.executable)"
 @CALL emcc.bat -v


### PR DESCRIPTION
I have no idea why this argument was included when this
script was first added.  `emsdk_env.bat` does not even pass
its argument into `emsdk.py` so this argument has no effect
here.