### PR TITLE
Add Git-LFS package to EMSDK Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,6 +101,7 @@ RUN echo "## Update and install packages" \
         zip \
         unzip \
         git \
+        git-lfs \
         ssh-client \
         build-essential \
         make \


### PR DESCRIPTION
I could imagine that using Git-LFS together with emscripten is not that uncommon, when asset files are pre-loaded.

This PR adds the git-lfs apt package to the docker image. This way, git-lfs doesn't have to be installed during each run in a Github Action build or similar.