### PR TITLE
fix: \`file\` command output without mimetype on MacOS

### DIFF
--- a/bazel/emscripten_toolchain/emscripten_config
+++ b/bazel/emscripten_toolchain/emscripten_config
@@ -1,9 +1,13 @@
 import os
+import platform
 
 ROOT_DIR = os.environ["ROOT_DIR"]
 EMSCRIPTEN_ROOT = os.environ["EMSCRIPTEN"]
 
 LLVM_ROOT = ROOT_DIR + "/external/emscripten/bin"
 EMSCRIPTEN_NATIVE_OPTIMIZER = LLVM_ROOT + "/optimizer"
-NODE_JS = ROOT_DIR + "/external/nodejs_linux_amd64/bin/node"
+
+system = platform.system()
+nodejs_binary = "node.exe" if(system =="Windows") else "bin/node"
+NODE_JS = ROOT_DIR + "/external/nodejs_{}_amd64/{}".format(system.lower(), nodejs_binary)
 BINARYEN_ROOT = ROOT_DIR + "/external/emscripten"

--- a/bazel/emscripten_toolchain/wasm_binary.py
+++ b/bazel/emscripten_toolchain/wasm_binary.py
@@ -46,7 +46,7 @@ def main(argv):
   stem = basename.split('.')[0]
 
   # Check the type of the input file
-  mimetype_bytes = subprocess.check_output(['file', '-Lib', FLAGS.archive])
+  mimetype_bytes = subprocess.check_output(['file', '-Lb', '--mime-type', '--mime-encoding', FLAGS.archive])
   mimetype = mimetype_bytes.decode(sys.stdout.encoding)
 
   # If we have a tar, extract all files. If we have just a single file, copy it.


### PR DESCRIPTION
fix: bazel/emscripten_toolchain/wasm_binary.py  \`file\` command output without mimetype on MacOS