### PR TITLE
Release 2.0.13 and update bazel toolchain

### DIFF
--- a/bazel/WORKSPACE
+++ b/bazel/WORKSPACE
@@ -8,12 +8,12 @@ http_archive(
 
 load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
 
-# emscripten 2.0.12
+# emscripten 2.0.13
 http_archive(
     name = "emscripten",
-    sha256 = "bfff9fb0326363c12e19b542f27a5f12cedbfc310f30621dc497c9af51d2d2e3",
+    sha256 = "8986ed886e111c661099c5147126b8a379a4040aab6a1f572fe01f0f9b99a343",
     strip_prefix = "install",
-    url = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/linux/dcf819a7821f8db0c8f15ac336fea8960ec204f5/wasm-binaries.tbz2",
+    url = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/linux/ce0e4a4d1cab395ee5082a60ebb4f3891a94b256/wasm-binaries.tbz2",
     build_file = "//emscripten_toolchain:emscripten.BUILD",
     type = "tar.bz2",
 )

--- a/bazel/emscripten_toolchain/crosstool.bzl
+++ b/bazel/emscripten_toolchain/crosstool.bzl
@@ -70,9 +70,8 @@ def _impl(ctx):
 
     cc_target_os = "emscripten"
     emscripten_version = ctx.attr.emscripten_version
-    emscripten_root = "external/emscripten/" + emscripten_version
 
-    builtin_sysroot = None
+    builtin_sysroot = "external/emscripten/emscripten/cache/sysroot"
 
     ################################################################
     # Tools
@@ -513,14 +512,7 @@ def _impl(ctx):
         # Language Features
         flag_set(
             actions = all_cpp_compile_actions,
-            flags = [
-                "-std=gnu++17",
-                "-nostdinc",
-                "-Xclang",
-                "-nobuiltininc",
-                "-Xclang",
-                "-nostdsysteminc",
-            ],
+            flags = ["-std=gnu++17", "-nostdinc", "-nostdinc++",],
         ),
 
         # Emscripten-specific settings:
@@ -904,30 +896,10 @@ def _impl(ctx):
             actions = preprocessor_compile_actions +
                       [ACTION_NAMES.cc_flags_make_variable],
             flags = [
-                "-isystem",
-                emscripten_root + "/system/lib/libc/musl/arch/emscripten",
-                "-isystem",
-                emscripten_root + "/system/lib/libc/musl/arch/js",
-                "-isystem",
-                emscripten_root + "/system/local/include",
-                "-isystem",
-                emscripten_root + "/system/include/compat",
-                "-isystem",
-                emscripten_root + "/system/include",
-                "-isystem",
-                emscripten_root + "/system/include/libcxx",
-                "-isystem",
-                emscripten_root + "/system/lib/libcxxabi/include",
-                "-isystem",
-                emscripten_root + "/system/lib/compiler-rt/include",
-                "-isystem",
-                emscripten_root + "/system/include/libc",
-                "-isystem",
-                emscripten_root + "/system/include/gfx",
-                "-isystem",
-                emscripten_root + "/system/include/SDL",
-                "-isystem",
-                emscripten_root + "/lib/clang/12.0.0/include",
+                "-iwithsysroot" + "/include/c++/v1",
+                "-iwithsysroot" + "/include/compat",
+                "-iwithsysroot" + "/include",
+                "-isystem", "external/emscripten/lib/clang/12.0.0/include",
             ],
         ),
         # Inputs and outputs
@@ -1070,18 +1042,10 @@ def _impl(ctx):
     features.append(crosstool_default_flags_feature)
 
     cxx_builtin_include_directories = [
-        emscripten_version + "/system/lib/libc/musl/arch/emscripten",
-        emscripten_version + "/system/lib/libc/musl/arch/js",
-        emscripten_version + "/system/local/include",
-        emscripten_version + "/system/include/compat",
-        emscripten_version + "/system/include",
-        emscripten_version + "/system/include/libcxx",
-        emscripten_version + "/system/lib/compiler-rt/include",
-        emscripten_version + "/system/lib/libcxxabi/include",
-        emscripten_version + "/system/include/libc",
-        emscripten_version + "/system/include/gfx",
-        emscripten_version + "/system/include/SDL",
-        emscripten_version + "/lib/clang/12.0.0/include",
+        "external/emscripten/emscripten/cache/sysroot/include/c++/v1",
+        "external/emscripten/emscripten/cache/sysroot/include/compat",
+        "external/emscripten/emscripten/cache/sysroot/include",
+        "external/emscripten/lib/clang/12.0.0/include",
     ]
 
     artifact_name_patterns = []

--- a/bazel/emscripten_toolchain/emscripten_config
+++ b/bazel/emscripten_toolchain/emscripten_config
@@ -3,11 +3,10 @@ import platform
 
 ROOT_DIR = os.environ["ROOT_DIR"]
 EMSCRIPTEN_ROOT = os.environ["EMSCRIPTEN"]
-
 LLVM_ROOT = ROOT_DIR + "/external/emscripten/bin"
-EMSCRIPTEN_NATIVE_OPTIMIZER = LLVM_ROOT + "/optimizer"
+BINARYEN_ROOT = ROOT_DIR + "/external/emscripten"
+FROZEN_CACHE = True
 
 system = platform.system()
 nodejs_binary = "node.exe" if(system =="Windows") else "bin/node"
 NODE_JS = ROOT_DIR + "/external/nodejs_{}_amd64/{}".format(system.lower(), nodejs_binary)
-BINARYEN_ROOT = ROOT_DIR + "/external/emscripten"

--- a/bazel/emscripten_toolchain/env.sh
+++ b/bazel/emscripten_toolchain/env.sh
@@ -2,6 +2,4 @@
 
 export ROOT_DIR=`(pwd -P)`
 export EMSCRIPTEN=${ROOT_DIR}/external/emscripten/emscripten
-
 export EM_CONFIG=${ROOT_DIR}/emscripten_toolchain/emscripten_config
-export EM_CACHE=${ROOT_DIR}/emscripten_toolchain/cache

--- a/emscripten-releases-tags.txt
+++ b/emscripten-releases-tags.txt
@@ -1,6 +1,7 @@
 {
-  "latest": "2.0.12",
+  "latest": "2.0.13",
   "releases": {
+    "2.0.13":  "ce0e4a4d1cab395ee5082a60ebb4f3891a94b256",
     "2.0.12":  "dcf819a7821f8db0c8f15ac336fea8960ec204f5",
     "2.0.11":  "4764c5c323a474f7ba28ae991b0c9024fccca43c",
     "2.0.10":  "37fc7647c754ac9a28ad588c143b82286de0ef71",

--- a/scripts/test_bazel.sh
+++ b/scripts/test_bazel.sh
@@ -13,7 +13,7 @@ VER=$(grep -oP '(?<=latest\": \")([\d\.]+)(?=\")' \
 HASH=$(grep "${VER}" emscripten-releases-tags.txt \
       | grep -v latest \
       | cut -f4 -d\")
-      
+
 FAILMSG="!!! scripts/update_bazel_toolchain.sh needs to be run !!!"
 
 # Ensure the WORKSPACE file is up to date with the latest version.


### PR DESCRIPTION
This change comes with fairly major change to the bazel toolchain.

- Use pre-built cache that comes with emsdk
- Mark cache as readonly using FROZEN_CACHE
- Pass `--sysroot` to match upstream emscripten change