### PR TITLE
Fix: wrong clang path in Bazel toolchain

### DIFF
--- a/bazel/emscripten_toolchain/crosstool.bzl
+++ b/bazel/emscripten_toolchain/crosstool.bzl
@@ -899,7 +899,7 @@ def _impl(ctx):
                 "-iwithsysroot" + "/include/c++/v1",
                 "-iwithsysroot" + "/include/compat",
                 "-iwithsysroot" + "/include",
-                "-isystem", "external/emscripten/lib/clang/12.0.0/include",
+                "-isystem", "external/emscripten/lib/clang/13.0.0/include",
             ],
         ),
         # Inputs and outputs
@@ -1045,7 +1045,7 @@ def _impl(ctx):
         "external/emscripten/emscripten/cache/sysroot/include/c++/v1",
         "external/emscripten/emscripten/cache/sysroot/include/compat",
         "external/emscripten/emscripten/cache/sysroot/include",
-        "external/emscripten/lib/clang/12.0.0/include",
+        "external/emscripten/lib/clang/13.0.0/include",
     ]
 
     artifact_name_patterns = []

--- a/bazel/hello-world/BUILD
+++ b/bazel/hello-world/BUILD
@@ -6,7 +6,17 @@ cc_binary(
     srcs = ["hello-world.cc"],
 )
 
+cc_binary(
+    name = "hello-world-simd",
+    srcs = ["hello-world-simd.cc"],
+)
+
 wasm_cc_binary(
     name = "hello-world-wasm",
     cc_target = ":hello-world",
+)
+
+wasm_cc_binary(
+    name = "hello-world-wasm-simd",
+    cc_target = ":hello-world-simd",
 )

--- a/bazel/hello-world/hello-world-simd.cc
+++ b/bazel/hello-world/hello-world-simd.cc
@@ -1,0 +1,10 @@
+#include <wasm_simd128.h>
+
+void multiply_arrays(int* out, int* in_a, int* in_b, int size) {
+  for (int i = 0; i < size; i += 4) {
+    v128_t a = wasm_v128_load(&in_a[i]);
+    v128_t b = wasm_v128_load(&in_b[i]);
+    v128_t prod = wasm_i32x4_mul(a, b);
+    wasm_v128_store(&out[i], prod);
+  }
+}

--- a/scripts/test_bazel.sh
+++ b/scripts/test_bazel.sh
@@ -22,3 +22,4 @@ grep ${HASH} bazel/WORKSPACE || (echo ${FAILMSG} && false)
 
 cd bazel
 bazel build //hello-world:hello-world-wasm
+bazel build --copt="-msimd128" //hello-world:hello-world-wasm-simd


### PR DESCRIPTION
I added a small example to reproduce the issue with SIMD header file not found (#699).

```
In file included from hello-world/hello-world-simd.cc:1:
external/emscripten/emscripten/cache/sysroot/include/wasm_simd128.h:10:15: fatal error: 'wasm_simd128.h' file not found
#include_next <wasm_simd128.h>
              ^~~~~~~~~~~~~~~~
1 error generated.
```

This PR fixes the issue by locating `wasm_simd128.h` in the right directory.