### PR TITLE
make hello world simd a bit cleaner

### DIFF
--- a/bazel/hello-world/BUILD
+++ b/bazel/hello-world/BUILD
@@ -19,4 +19,5 @@ wasm_cc_binary(
 wasm_cc_binary(
     name = "hello-world-wasm-simd",
     cc_target = ":hello-world-simd",
+    simd = True,
 )

--- a/scripts/test_bazel.sh
+++ b/scripts/test_bazel.sh
@@ -22,4 +22,4 @@ grep ${HASH} bazel/WORKSPACE || (echo ${FAILMSG} && false)
 
 cd bazel
 bazel build //hello-world:hello-world-wasm
-bazel build --copt="-msimd128" //hello-world:hello-world-wasm-simd
+bazel build //hello-world:hello-world-wasm-simd


### PR DESCRIPTION
By passing `--copt="-msimd128"` on the command line, that will be passed to everything built by your command. For example, if a user wants to build a server that has a dependency on some simd-enabled wasm, they probably don't want to be passing `-msimd128` to their server build.

Instead, we have two options. One is to instead pass `--features=wasm_simd`, which will ensure `-msimd128` is only passed to the wasm builds. The other (and preferred) way is to add `simd = True,` to the `wasm_cc_binary` rule.

I'll also note that adding a `copts` attribute to the `cc_binary` rule may not work as the user expects. The `copts` passed in that case will only apply to that specific target, not any of its dependencies. This is unintuitive for many users, so best to avoid it.