### PR TITLE
Ccache

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1271,7 +1271,9 @@ def build_ccache(tool):
       for s in ['.exe', '']:
         ccache = e + s
         if os.path.isfile(ccache):
-          shutil.copyfile(ccache, os.path.join(bin_dir, 'ccache' + s))
+          dst = os.path.join(bin_dir, 'ccache' + s)
+          shutil.copyfile(ccache, dst)
+          os.chmod(dst, os.stat(dst).st_mode | stat.S_IEXEC)
 
     cache_dir = os.path.join(root, 'cache')
     open(os.path.join(root, 'emcc_ccache.conf'), 'w').write('''# Set maximum cache size to 10 GB:

--- a/emsdk.py
+++ b/emsdk.py
@@ -2043,20 +2043,6 @@ class Tool(object):
       else:
         raise Exception('Unknown custom_install_script command "' + self.custom_install_script + '"!')
 
-    if hasattr(self, 'custom_install_script'):
-      if self.custom_install_script == 'emscripten_post_install':
-        success = emscripten_post_install(self)
-      elif self.custom_install_script == 'emscripten_npm_install':
-        success = emscripten_npm_install(self, self.installation_path())
-      elif self.custom_install_script in ('build_fastcomp', 'build_llvm'):
-        # 'build_fastcomp' is a special one that does the download on its
-        # own, others do the download manually.
-        pass
-      elif self.custom_install_script == 'build_binaryen':
-        success = build_binaryen_tool(self)
-      else:
-        raise Exception('Unknown custom_install_script command "' + self.custom_install_script + '"!')
-
     if not success:
       exit_with_error("Installation failed!")
 

--- a/emsdk.py
+++ b/emsdk.py
@@ -1244,7 +1244,7 @@ def build_ccache(tool):
 
   # Configure
   cmake_generator = CMAKE_GENERATOR
-  args = []
+  args = ['-DZSTD_FROM_INTERNET=ON']
   if 'Visual Studio 16' in CMAKE_GENERATOR:  # VS2019
     # With Visual Studio 16 2019, CMake changed the way they specify target arch.
     # Instead of appending it into the CMake generator line, it is specified

--- a/emsdk.py
+++ b/emsdk.py
@@ -1280,27 +1280,6 @@ cache_dir = %s
 ''' % cache_dir)
     mkdir_p(cache_dir)
 
-    for f in ['emcc', 'em++']:
-      open(os.path.join(root, f + '.bat'), 'w').write('''@setlocal
-
-@if "%EMSCRIPTEN%"=="" (
-  @echo "Environment variable EMSCRIPTEN is not set! If you'd like to use Emscripten with ccache, you should do one of:"
-  @echo "  1) activate CCache in Emscripten SDK, and enter Emscripten SDK environment on cmdline with emsdk_env.bat before executing %~dp0\\%~n0.bat, or"
-  @echo "  2) set EMCC_CCACHE=%~dp0 environment variable, and execute %~n0.bat in Emscripten directory, or"
-  @echo "  3) set EMSCRIPTEN=c:\\path\\to\\emscripten\\emcc.bat environment variable before executing %~dp0\\%~n0.bat, or"
-  @echo "  4) invoke ccache manually by explicitly calling 'ccache emcc <args>' instead of relying on the automatic rerouting."
-  @echo ""
-  @echo " Option 1) is considered the easiest and 'canonical' solution."
-)
-
-@set EM_PY=%EMSDK_PYTHON%
-@if "%EM_PY%"=="" (
-  set EM_PY=python
-)
-
-@"%EM_PY%" "%EMSCRIPTEN%\\%~n0.py" %*
-''')
-
   return success
 
 

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -483,9 +483,9 @@
     "bitness": 64,
     "url": "https://github.com/juj/ccache.git",
     "git_branch": "emscripten",
-    "activated_cfg": "EMCC_CCACHE='%installation_dir%'",
+    "activated_cfg": "EMCC_CCACHE=1",
     "activated_path": "%installation_dir%/bin",
-    "activated_env": "EMCC_CCACHE=%installation_dir%;CCACHE_CONFIGPATH=%installation_dir%/emcc_ccache.conf",
+    "activated_env": "EMCC_CCACHE=1;CCACHE_CONFIGPATH=%installation_dir%/emcc_ccache.conf",
     "cmake_build_type": "Release",
     "custom_install_script": "build_ccache"
   }

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -476,6 +476,18 @@
     "windows_url": "mingw_7.1.0_64bit.zip",
     "activated_cfg": "MINGW_ROOT='%installation_dir%'",
     "activated_path": "%installation_dir%/bin"
+  },
+  {
+    "id": "ccache",
+    "version": "4.2",
+    "bitness": 64,
+    "url": "https://github.com/juj/ccache.git",
+    "git_branch": "emscripten",
+    "activated_cfg": "EMCC_CCACHE='%installation_dir%'",
+    "activated_path": "%installation_dir%/bin",
+    "activated_env": "EMCC_CCACHE=%installation_dir%;CCACHE_CONFIGPATH=%installation_dir%/emcc_ccache.conf",
+    "cmake_build_type": "Release",
+    "custom_install_script": "build_ccache"
   }
   ],
 

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -478,8 +478,19 @@
     "activated_path": "%installation_dir%/bin"
   },
   {
+    "id": "ninja",
+    "version": "git-release",
+    "bitness": 64,
+    "url": "https://github.com/ninja-build/ninja.git",
+    "git_branch": "release",
+    "activated_cfg": "NINJA=%installation_dir%/bin",
+    "activated_path": "%installation_dir%/bin",
+    "cmake_build_type": "Release",
+    "custom_install_script": "build_ninja"
+  },
+  {
     "id": "ccache",
-    "version": "4.2",
+    "version": "git-emscripten",
     "bitness": 64,
     "url": "https://github.com/juj/ccache.git",
     "git_branch": "emscripten",


### PR DESCRIPTION
This PR adds support for Ninja build system and ccache, to be built from source.

Needs a bit of code duplication cleanup in order to be able to land, but posting for visibility so that users can try it out.

The corresponding PR for emscripten is at https://github.com/emscripten-core/emscripten/pull/13498 and the corresponding changes to ccache itself are at https://github.com/juj/ccache/tree/emscripten.

The general mechanism is that after activating ccache in Emscripten SDK, emcc and em++ will automatically take usage of the installed ccache tool.

Usage:

```
emsdk install sdk-upstream-master-64bit ccache-git-emscripten-64bit
emsdk activate sdk-upstream-master-64bit  ccache-git-emscripten-64bit
cd %EMSCRIPTEN%
git remote add juj https://github.com/juj/emscripten.git
git fetch emscripten
git checkout ccache

# Example 1: rebuilding libc is fast from cache:
ccache -s # check initial ccache statistics: zero compiled files in cache
emcc --clear-cache

python embuilder.py build libc # cache miss
ccache -s # will show 862 files missed cache

ccache -z # zero ccache statistics

emcc --clear-cache
python embuilder.py build libc # cache hit!
ccache -s # now shows 862 files found from cache

# Example 2: rebuilding custom code is fast from cache:
ccache -z # zero statistics
emcc -c tests\hello_world.c -o a.o # cache miss
ccache -s # shows one file missed cache
emcc -c tests\hello_world.c -o a.o # cache hit!
ccache -s # shows one file hit cache
```
