### PR TITLE
Only add node/bin to user's PATH if one is not already found

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1431,6 +1431,8 @@ def get_required_path(active_tools):
   path_add = [to_native_path(emsdk_path())]
   for tool in active_tools:
     if hasattr(tool, 'activated_path'):
+      if hasattr(tool, 'activated_path_skip') and which(tool.activated_path_skip):
+        continue
       path = to_native_path(tool.expand_vars(tool.activated_path))
       path_add.append(path)
   return path_add

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -191,6 +191,7 @@
     "arch": "x86",
     "windows_url": "node-v14.15.5-win-x86.zip",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
@@ -201,6 +202,7 @@
     "bitness": 32,
     "linux_url": "node-v14.15.5-linux-armv7l.tar.xz",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
@@ -213,6 +215,7 @@
     "windows_url": "node-v14.15.5-win-x64.zip",
     "linux_url": "node-v14.15.5-linux-x64.tar.xz",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
@@ -223,6 +226,7 @@
     "bitness": 64,
     "linux_url": "node-v14.15.5-linux-arm64.tar.xz",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },


### PR DESCRIPTION
If the user already has a version of node in their PATH don't clobber
it.  This doesn't effect emscripten since the version of node we use
there is controlled via the config file, not via PATH.

Part of fix for #705.