### PR TITLE
Rename llvm-git-master -> llvm-git-main

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -2,7 +2,7 @@
   "tools": [
   {
     "id": "llvm-git",
-    "version": "master",
+    "version": "main",
     "bitness": 32,
     "install_path": "llvm/git",
     "git_branch": "main",
@@ -16,7 +16,7 @@
   },
   {
     "id": "llvm-git",
-    "version": "master",
+    "version": "main",
     "bitness": 64,
     "install_path": "llvm/git",
     "git_branch": "main",
@@ -464,25 +464,25 @@
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-14.15.5-64bit", "python-3.7.4-pywin32-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "python-3.7.4-pywin32-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "win"
   },
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-14.15.5-64bit", "python-3.7.4-2-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "python-3.7.4-2-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "macos"
   },
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-master-64bit", "node-14.15.5-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
     "os": "linux"
   },
   {
     "version": "upstream-master",
     "bitness": 32,
-    "uses": ["llvm-git-master-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
+    "uses": ["llvm-git-main-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
     "os": "linux"
   },
   {


### PR DESCRIPTION
To match the branch rename that happened in #693.