### PR TITLE
Avoid post-install when nothing is installed

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -550,7 +550,7 @@
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
     ]
-  },  
+  },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,


### PR DESCRIPTION
This avoids re-running the post-install scripts when commands such as
`./emsdk install latest` a re-run.  This re-running of npm ci can be
significant slowdown especially during testing and developerment.

Becuase of the refactoring this change change also means we exit ealier
when a given tool fails to install.  In general we want to error out as
early as possible on the first failure so as not to bury it.