### PR TITLE
Remove `update-tags` phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ SDK from the local hard drive completely.
 
 `emsdk update` will fetch package information for all the new tools and
 SDK versions. After that, run `emsdk install <tool/sdk name>` to install a new
-version. The command `emsdk update-tags` obtains a list of all new tagged
-releases from GitHub without updating Emscripten SDK itself.
+version.
 
 ### How do I install an old Emscripten compiler version?
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,6 @@ COPY . ${EMSDK}
 
 RUN echo "## Install Emscripten" \
     && cd ${EMSDK} \
-    && if [ "$EMSCRIPTEN_VERSION" = "tot" ]; then ./emsdk update-tags; fi \
     && ./emsdk install ${EMSCRIPTEN_VERSION} \
     && echo "## Done"
 


### PR DESCRIPTION
Its not really very useful to cache the tot release in a local text
file.  Instead just fetch the revsion each time `install tot` is run.

This avoids folks accidentally installing "old" tot releases.

Also, make the output a little less chatty when looking up tot version.