### PR TITLE
Rename binaryen-master to binaryen-main

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -422,7 +422,7 @@
   },
   {
     "id": "binaryen",
-    "version": "master",
+    "version": "main",
     "bitness": 64,
     "append_bitness": false,
     "url": "https://github.com/WebAssembly/binaryen.git",
@@ -464,55 +464,55 @@
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "python-3.7.4-pywin32-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "python-3.7.4-pywin32-64bit", "emscripten-master-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "python-3.7.4-2-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "python-3.7.4-2-64bit", "emscripten-master-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "upstream-master",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "emscripten-master-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
     "version": "upstream-master",
     "bitness": 32,
-    "uses": ["llvm-git-main-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
+    "uses": ["llvm-git-main-32bit", "emscripten-master-32bit", "binaryen-main-32bit"],
     "os": "linux"
   },
   {
     "version": "fastcomp-master",
     "bitness": 32,
-    "uses": ["fastcomp-clang-master-32bit", "node-14.15.5-32bit", "python-3.7.4-32bit", "java-8.152-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
+    "uses": ["fastcomp-clang-master-32bit", "node-14.15.5-32bit", "python-3.7.4-32bit", "java-8.152-32bit", "emscripten-master-32bit", "binaryen-main-32bit"],
     "os": "win"
   },
   {
     "version": "fastcomp-master",
     "bitness": 64,
-    "uses": ["fastcomp-clang-master-64bit", "node-14.15.5-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["fastcomp-clang-master-64bit", "node-14.15.5-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "emscripten-master-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
     "version": "fastcomp-master",
     "bitness": 64,
-    "uses": ["fastcomp-clang-master-64bit", "node-14.15.5-64bit", "python-3.7.4-2-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["fastcomp-clang-master-64bit", "node-14.15.5-64bit", "python-3.7.4-2-64bit", "emscripten-master-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "fastcomp-master",
     "bitness": 32,
-    "uses": ["fastcomp-clang-master-32bit", "node-14.15.5-32bit", "emscripten-master-32bit", "binaryen-master-32bit"],
+    "uses": ["fastcomp-clang-master-32bit", "node-14.15.5-32bit", "emscripten-master-32bit", "binaryen-main-32bit"],
     "os": "linux"
   },
   {
     "version": "fastcomp-master",
     "bitness": 64,
-    "uses": ["fastcomp-clang-master-64bit", "node-14.15.5-64bit", "emscripten-master-64bit", "binaryen-master-64bit"],
+    "uses": ["fastcomp-clang-master-64bit", "node-14.15.5-64bit", "emscripten-master-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {

--- a/test/test.py
+++ b/test/test.py
@@ -231,7 +231,7 @@ int main() {
 
   def test_binaryen_from_source(self):
     print('test binaryen source build')
-    run_emsdk(['install', '--build=Release', '--generator=Unix Makefiles', 'binaryen-master-64bit'])
+    run_emsdk(['install', '--build=Release', '--generator=Unix Makefiles', 'binaryen-main-64bit'])
 
   def test_no_32bit(self):
     print('test 32-bit error')


### PR DESCRIPTION
This matches the branch name that was already updated/renamed.