### PR TITLE
Change base to Ubuntu 20.04.2 LTS (Focal Fossa).

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster AS stage_build
+FROM ubuntu:focal AS stage_build
 
 ARG EMSCRIPTEN_VERSION=tot
 ENV EMSDK /emsdk
@@ -56,7 +56,7 @@ RUN echo "## Aggressive optimization: Remove debug symbols" \
 # -------------------------------- STAGE DEPLOY --------------------------------
 # ------------------------------------------------------------------------------
 
-FROM debian:buster-slim AS stage_deploy
+FROM ubuntu:focal AS stage_deploy
 
 COPY --from=stage_build /emsdk /emsdk
 
@@ -86,10 +86,11 @@ RUN echo "## Create emscripten user (1000:1000)" \
 # ------------------------------------------------------------------------------
 
 RUN echo "## Update and install packages" \
-    # mitigate problem with create symlink to man for base debian image
-    && mkdir -p /usr/share/man/man1/ \
     && apt-get -qq -y update \
-    && apt-get -qq install -y --no-install-recommends \
+    # Somewhere in here apt sets up tzdata which asks for your time zone and blocks
+    # waiting for the answer which you can't give as docker build doesn't read from
+    # the terninal. The env vars set here avoid the interactive prompt and set the TZ.
+    && DEBIAN_FRONTEND="noninteractive" TZ="America/San_Francisco" apt-get -qq install -y --no-install-recommends \
         sudo \
         libxml2 \
         ca-certificates \


### PR DESCRIPTION
This is principally, for me at least, to be able to include a more up to date version of CMake. Focal has 3.16.3. The Debian Buster based image had CMake 3.13. Installing the most recent CMake from KitWare into that Docker image proved impossible because it had a dependency on a version of libssl not in Buster.

`test_dockerimage.sh` runs successfully using the updated image as does my own project's build.

The size of this image is 1.67GB. The Buster-based image is 1.59GB.

Note that I have left intact all the explicit package installs as I did not want to spend time determining which of them may be installed by default in Focal.

After you merge this PR, how can I determine when the emscripten/emsdk image at docker.com has been updated?