### PR TITLE
Rename sdk-upstream-master SDK to sdk-upstream-main

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ categories.
 To obtain and build latest upstream wasm SDK from source, run
 
 ```
-emsdk install sdk-upstream-master-64bit
-emsdk activate sdk-upstream-master-64bit
+emsdk install sdk-upstream-main-64bit
+emsdk activate sdk-upstream-main-64bit
 ```
 
 You can use this target for example to bootstrap developing patches to LLVM,
@@ -155,8 +155,8 @@ https://emscripten.org/docs/contributing/developers_guide.html?highlight=develop
 ### When working on git branches compiled from source, how do I update to a newer compiler version?
 
 Unlike tags and precompiled versions, a few of the SDK packages are based on
-"moving" git branches and compiled from source (e.g. sdk-upstream-master,
-sdk-master, emscripten-master, binaryen-master). Because of that, the
+"moving" git branches and compiled from source (e.g. sdk-upstream-main,
+sdk-main, emscripten-main, binaryen-main). Because of that, the
 compiled versions will eventually go out of date as new commits are introduced
 to the development branches. To update an old compiled installation of one of
 this branches, simply reissue the "emsdk install" command on that tool/SDK. This
@@ -197,11 +197,11 @@ where you directly interact with the github repositories. This allows you to
 obtain new features and latest fixes immediately as they are pushed to the
 github repository, without having to wait for release to be tagged. You do not
 need a github account or a fork of Emscripten to do this. To switch to using the
-latest upstream git development branch `master`, run the following:
+latest upstream git development branch `main`, run the following:
 
     emsdk install git-1.9.4 # Install git. Skip if the system already has it.
-    emsdk install sdk-upstream-master-64bit # Clone+pull the latest emscripten-core/emscripten/master.
-    emsdk activate sdk-upstream-master-64bit # Set the master SDK as the currently active one.
+    emsdk install sdk-upstream-main-64bit # Clone+pull the latest emscripten-core/emscripten/main.
+    emsdk activate sdk-upstream-main-64bit # Set the main SDK as the currently active one.
 
 ### How do I use my own Emscripten github fork with the SDK?
 
@@ -211,16 +211,16 @@ acquainted with working on multiple remotes in a git clone, these steps should
 be familiar to you. This is useful in the case when you want to make your own
 modifications to the Emscripten toolchain, but still keep using the SDK
 environment and tools. To set up your own fork as the currently active
-Emscripten toolchain, first install the `sdk-master` SDK like shown in the
+Emscripten toolchain, first install the `sdk-main` SDK like shown in the
 previous section, and then run the following commands in the emsdk directory:
 
-    cd emscripten/master
+    cd emscripten/main
     # Add a git remote link to your own repository.
     git remote add myremote https://github.com/mygituseraccount/emscripten.git
     # Obtain the changes in your link.
     git fetch myremote
-    # Switch the emscripten-master tool to use your fork.
-    git checkout -b mymaster --track myremote/master
+    # Switch the emscripten-main tool to use your fork.
+    git checkout -b mymain --track myremote/main
 
 In this way you can utilize the Emscripten SDK tools while using your own git
 fork. You can switch back and forth between remotes via the `git checkout`

--- a/emsdk.py
+++ b/emsdk.py
@@ -2588,7 +2588,7 @@ def exit_with_fastcomp_error():
 
 def expand_sdk_name(name, activating):
   if 'upstream-master' in name:
-    errlog('upstream-master SDK has been renames upstream-main')
+    errlog('upstream-master SDK has been renamed upstream-main')
     name = name.replace('upstream-master', 'upstream-main')
   if name in ('latest-fastcomp', 'latest-releases-fastcomp', 'tot-fastcomp', 'sdk-nightly-latest'):
     exit_with_fastcomp_error()

--- a/emsdk.py
+++ b/emsdk.py
@@ -37,9 +37,8 @@ else:
   from urlparse import urljoin
   from urllib2 import urlopen
 
-emsdk_master_server = 'https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/'
 
-emsdk_packages_url = emsdk_master_server
+emsdk_packages_url = 'https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/'
 
 emscripten_releases_repo = 'https://chromium.googlesource.com/emscripten-releases'
 
@@ -1717,8 +1716,8 @@ class Tool(object):
     # For e.g. fastcomp clang from git repo, the activated PATH is the
     # directory where the compiler is built to, and installation_path is
     # the directory where the source tree exists. To distinguish between
-    # multiple packages sharing the same source (clang-master-32bit,
-    # clang-master-64bit, clang-master-32bit and clang-master-64bit each
+    # multiple packages sharing the same source (clang-main-32bit,
+    # clang-main-64bit, clang-main-32bit and clang-main-64bit each
     # share the same git repo), require that in addition to the installation
     # directory, each item in the activated PATH must exist.
     if hasattr(self, 'activated_path') and not os.path.exists(self.expand_vars(self.activated_path)):
@@ -2588,6 +2587,9 @@ def exit_with_fastcomp_error():
 
 
 def expand_sdk_name(name, activating):
+  if 'upstream-master' in name:
+    errlog('upstream-master SDK has been renames upstream-main')
+    name = name.replace('upstream-master', 'upstream-main')
   if name in ('latest-fastcomp', 'latest-releases-fastcomp', 'tot-fastcomp', 'sdk-nightly-latest'):
     exit_with_fastcomp_error()
   if name in ('latest', 'sdk-latest', 'latest-64bit', 'sdk-latest-64bit'):

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -462,25 +462,25 @@
 
   "sdks": [
   {
-    "version": "upstream-master",
+    "version": "upstream-main",
     "bitness": 64,
     "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "python-3.7.4-pywin32-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
-    "version": "upstream-master",
+    "version": "upstream-main",
     "bitness": 64,
     "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "python-3.7.4-2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
-    "version": "upstream-master",
+    "version": "upstream-main",
     "bitness": 64,
     "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
-    "version": "upstream-master",
+    "version": "upstream-main",
     "bitness": 32,
     "uses": ["llvm-git-main-32bit", "emscripten-main-32bit", "binaryen-main-32bit"],
     "os": "linux"


### PR DESCRIPTION
Now that all the components (binaryen, emscripten and llvm) use `main`
as the brnach name is makes sense to give the SDK this name.

Keep backwards compat with the old name but issue a warning when its
used.