### PR TITLE
Simplify the notation for installing by hash to just "emsdk install HASH"

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2767,6 +2767,8 @@ def expand_sdk_name(name, activating):
           backend = 'fastcomp'
       return 'sdk-releases-%s-%s-64bit' % (backend, release_hash)
     elif len(version) == 40:
+      if backend is None:
+        backend = 'upstream'
       global extra_release_tag
       extra_release_tag = version
       return 'sdk-releases-%s-%s-64bit' % (backend, version)

--- a/test/test.py
+++ b/test/test.py
@@ -259,10 +259,10 @@ int main() {
 
   def test_install_arbitrary(self):
     # Test that its possible to install arbrary emscripten-releases SDKs
-    run_emsdk('install sdk-releases-upstream-5c776e6a91c0cb8edafca16a652ee1ee48f4f6d2')
+    run_emsdk('install 5c776e6a91c0cb8edafca16a652ee1ee48f4f6d2')
 
     # Check that its not re-downloaded
-    checked_call_with_output(emsdk + ' install sdk-releases-upstream-5c776e6a91c0cb8edafca16a652ee1ee48f4f6d2', expected='Skipped', unexpected='Downloading:')
+    checked_call_with_output(emsdk + ' install 5c776e6a91c0cb8edafca16a652ee1ee48f4f6d2', expected='Skipped', unexpected='Downloading:')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously this had to be

```
emsdk install sdk-releases-upstream-HASH
```

The only thing preventing using just the hash was that there was no
default for the backend, so defaulting to upstream fixes this.  And then
we can do

```
emsdk install HASH
```