### PR TITLE
List "Release" as the default build option

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2806,7 +2806,7 @@ def main(args):
                   --build=<type>: Controls what kind of build of LLVM to
                                   perform. Pass either 'Debug', 'Release',
                                   'MinSizeRel' or 'RelWithDebInfo'. Default:
-                                  'RelWithDebInfo'.
+                                  'Release'.
 
               --generator=<type>: Specifies the CMake Generator to be used
                                   during the build. Possible values are the


### PR DESCRIPTION
This was set back in commit cea44f475af10c6fde85d4906111a39818e3f134

Fixes #760

A minor change that clears up the confusion when building / packaging emscripten, the default build option does not match up with what was listed in `./emsdk.py`