### PR TITLE
Quick hack to treat macOS-arm64 as macOS-x86_64

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -116,6 +116,9 @@ elif machine.endswith('86'):
   ARCH = 'x86'
 elif machine.startswith('aarch64') or machine.lower().startswith('arm64'):
   ARCH = 'aarch64'
+  if MACOS:
+    # arm64 macOS runs x86_64 binaries and we don't have build bots yet for native
+    ARCH = 'x86_64'
 elif platform.machine().startswith('arm'):
   ARCH = 'arm'
 else:


### PR DESCRIPTION
Proposed temporary workaround for Apple Silicon (M1/ARM/Aarch64) Macs: treat arm64 on macOS as x86_64 instead, fetching the precompiled x64 binaries which work under emulation at some cost of performance.

This gets things working with the x86_64 binaries under emulation on an Apple Silicon Mac. It's not ideal, as the compiler will run slower and use more memory than it would without emulation, but users may use their Macs as web developer workstations.

This is not ideal; python and node should use native arm64 builds or universal binaries if possible. Ideally the binaryen and clang/llvm tools would be built as universal binaries or else separately for both architectures if that's not possible.