### PR TITLE
Avoid setting `EM_CACHE` unless we really need to

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -12,12 +12,6 @@ MACOS = sys.platform == 'darwin'
 
 assert 'EM_CONFIG' in os.environ, "emsdk should be activated before running this script"
 
-# Remove the EM_CACHE environment variable.  It interferes with testing since
-# it would otherwise be fixed for the duration of the script and we expect
-# "emsdk activate" to be able switch between SDKs during the running of this
-# script.
-del os.environ['EM_CACHE']
-
 emconfig = os.environ['EM_CONFIG']
 upstream_emcc = os.path.join('upstream', 'emscripten', 'emcc')
 fastcomp_emcc = os.path.join('fastcomp', 'emscripten', 'emcc')

--- a/test/test_activation.ps1
+++ b/test/test_activation.ps1
@@ -32,7 +32,6 @@ try {
     $EMSDK_NODE = [System.Environment]::GetEnvironmentVariable("EMSDK_NODE", $env_type)
     $EMSDK_PYTHON = [System.Environment]::GetEnvironmentVariable("EMSDK_PYTHON", $env_type)
     $JAVA_HOME = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", $env_type)
-    $EM_CACHE = [System.Environment]::GetEnvironmentVariable("EM_CACHE", $env_type)
     $PATH = [System.Environment]::GetEnvironmentVariable("PATH", $env_type)
 
     if (!$EMSDK) {
@@ -49,9 +48,6 @@ try {
     }
     if (!$EMSDK_PYTHON) {
         throw "EMSDK_PYTHON is not set for the user"
-    }
-    if (!$EM_CACHE) {
-        throw "EM_CACHE is not set for the user"
     }
 
 
@@ -91,7 +87,6 @@ finally {
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "User")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "User")
-    [Environment]::SetEnvironmentVariable("EM_CACHE", $null, "User")
 
     try {
         [Environment]::SetEnvironmentVariable("EMSDK", $null, "Machine")
@@ -99,7 +94,6 @@ finally {
         [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Machine")
         [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
-        [Environment]::SetEnvironmentVariable("EM_CACHE", $null, "Machine")
     } catch {}
 
 
@@ -108,7 +102,6 @@ finally {
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Process")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Process")
-    [Environment]::SetEnvironmentVariable("EM_CACHE", $null, "Process")
 
     refreshenv
 }

--- a/test/test_path_preservation.ps1
+++ b/test/test_path_preservation.ps1
@@ -127,7 +127,6 @@ finally {
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "User")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "User")
-    [Environment]::SetEnvironmentVariable("EM_CACHE", $null, "User")
 
     try {
         [Environment]::SetEnvironmentVariable("EMSDK", $null, "Machine")
@@ -135,7 +134,6 @@ finally {
         [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Machine")
         [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
-        [Environment]::SetEnvironmentVariable("EM_CACHE", $null, "Machine")
     } catch {}
 
 
@@ -144,7 +142,6 @@ finally {
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Process")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Process")
-    [Environment]::SetEnvironmentVariable("EM_CACHE", $null, "Process")
 
     refreshenv
 


### PR DESCRIPTION
This avoid polluting the global environment which makes
side-by-side installational of different emscripten version
harder.

See https://github.com/emscripten-core/emscripten/pull/13954