### PR TITLE
Unset emsdk-related environment variables from inactive tools

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -13,9 +13,23 @@ source ./emsdk_env.sh
 which emcc
 emcc -v
 
+# Install an older version of the SDK that requires EM_CACHE to be
+# set in the environment, so that we can test it is later removed
+./emsdk install sdk-fastcomp-3b8cff670e9233a6623563add831647e8689a86b
+./emsdk activate sdk-fastcomp-3b8cff670e9233a6623563add831647e8689a86b
+source ./emsdk_env.sh
+which emcc
+emcc -v
+test -n "$EM_CACHE"
+
+# Install the latest version of the SDK which is the expected precondition
+# of test.py.
 ./emsdk install latest
 ./emsdk activate latest
 source ./emsdk_env.sh --build=Release
+# Test that EM_CACHE was unset
+test -z "$EM_CACHE"
+
 # On mac and windows python3 should be in the path and point to the
 # bundled version.
 which python3


### PR DESCRIPTION
When we deactivate a tool we also want to remove its environment
variables.   One driver for this is that modern sdks don't set
`EM_CACHE` whereas old ones did and we want to make sure that
`EM_CACHE` gets unset when folks upgrade (and then re-set if
they downgrade).  See #797.