### PR TITLE
Remove explicit closure install step

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1390,34 +1390,6 @@ def emscripten_npm_install(tool, directory):
     errlog('Error running %s:\n%s' % (e.cmd, e.output))
     return False
 
-  # Manually install the appropriate native Closure Compiler package
-  # This is currently needed because npm ci will install the packages
-  # for Closure for all platforms, adding 180MB to the download size
-  # There are two problems here:
-  #   1. npm ci does not consider the platform of optional dependencies
-  #      https://github.com/npm/cli/issues/558
-  #   2. A bug with the native compiler has bloated the packages from
-  #      30MB to almost 300MB
-  #      https://github.com/google/closure-compiler-npm/issues/186
-  # If either of these bugs are fixed then we can remove this exception
-  closure_compiler_native = ''
-  if LINUX and ARCH in ('x86', 'x86_64'):
-    closure_compiler_native = 'google-closure-compiler-linux'
-  if MACOS and ARCH in ('x86', 'x86_64'):
-    closure_compiler_native = 'google-closure-compiler-osx'
-  if WINDOWS and ARCH == 'x86_64':
-    closure_compiler_native = 'google-closure-compiler-windows'
-  if closure_compiler_native:
-    print('Running post-install step: npm install', closure_compiler_native)
-    try:
-      subprocess.check_output(
-        [npm, 'install', '--production', '--no-optional', closure_compiler_native],
-        cwd=directory, stderr=subprocess.STDOUT, env=env,
-        universal_newlines=True)
-    except subprocess.CalledProcessError as e:
-      errlog('Error running %s:\n%s' % (e.cmd, e.output))
-      return False
-
   print('Done running: npm ci')
   return True
 


### PR DESCRIPTION
Remove explicit closure install step, the first install command does already seem to install google-closure-compiler-windows at least.

See #802 , #793, #636.

This would help from Linux and macOS testing to see if that works for people. CC also @curiousdannii 
