### PR TITLE
2.0.21

### DIFF
--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -2,6 +2,12 @@
 # DO NOT MODIFY
 
 EMSCRIPTEN_TAGS = {
+   "2.0.21": struct(
+        hash = "72f4ec97fbc7ec16c15ae68a75b0a257b2835160",
+        sha_linux = "741264f33f96ba4b785ed0b133861ebdfefbaefab76ddcfe7bde6522829d6f70",
+        sha_mac = "b07c0d65ee7e2799170c6f3b2aacebfe070c2e4975088bcd1b3a4140fecd8418",
+        sha_win = "dc3cbf47aa4be52a92526f1790a013734ecbd407f7f36286ed0283c96355999a",
+    ),
    "2.0.20": struct(
         hash = "e0c15cd14170f407a9eb27fcbad22931dc67feb7",
         sha_linux = "a196504fd1095836ca3961208338ff9e292be7729ea529bc19800aa7c966d34a",

--- a/emscripten-releases-tags.txt
+++ b/emscripten-releases-tags.txt
@@ -1,10 +1,11 @@
 {
-  "latest": "2.0.20",
+  "latest": "2.0.21",
   "releases": {
-    "2.0.20-lto": "d1b26cd17e51c5c705eea69b9545975e3705c058",
+    "2.0.21": "72f4ec97fbc7ec16c15ae68a75b0a257b2835160",
     "2.0.20": "e0c15cd14170f407a9eb27fcbad22931dc67feb7",
-    "2.0.19-lto": "4487f6c5107e7882ae2bad6d26c34ffdceb713f0",
+    "2.0.20-lto": "d1b26cd17e51c5c705eea69b9545975e3705c058",
     "2.0.19": "9b9ff2dabfb4a7fbacbc004c0bead12a60f9d05c",
+    "2.0.19-lto": "4487f6c5107e7882ae2bad6d26c34ffdceb713f0",
     "2.0.18": "c2ac7520fad29a7937ed60ab6a95b08eb374c7ba",
     "2.0.17": "f5c45e60392b82f603e3a8039c62db294fab02d2",
     "2.0.16": "80d9674f2fafa6b9346d735c42d5c52b8cc8aa8e",


### PR DESCRIPTION
This one doesn't include an LTO build, because the mac build timed out (because it now does 2 builds, for x86-64 and arm64, it takes twice as long). 