### PR TITLE
macOS and Linux backwards compatibility

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1056,10 +1056,13 @@ def cmake_configure(generator, build_root, src_root, build_type, extra_cmake_arg
       generator = ['-G', generator]
     else:
       generator = []
-    cmdline = ['cmake'] + generator + ['-DCMAKE_BUILD_TYPE=' + build_type, '-DPYTHON_EXECUTABLE=' + sys.executable,
-      # Target macOS 10.11 at minimum, to support widest range of Mac devices from "Mid 2007" and newer:
-      # https://en.wikipedia.org/wiki/MacBook_Pro#Supported_macOS_releases
-      '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11'] + extra_cmake_args + [src_root]
+
+    cmdline = ['cmake'] + generator + ['-DCMAKE_BUILD_TYPE=' + build_type, '-DPYTHON_EXECUTABLE=' + sys.executable]
+    # Target macOS 10.11 at minimum, to support widest range of Mac devices from "Mid 2007" and newer:
+    # https://en.wikipedia.org/wiki/MacBook_Pro#Supported_macOS_releases
+    cmdline += ['-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11']
+    cmdline += extra_cmake_args + [src_root]
+
     print('Running CMake: ' + str(cmdline))
 
     # Specify the deployment target also as an env. var, since some Xcode versions

--- a/scripts/update_python.py
+++ b/scripts/update_python.py
@@ -108,7 +108,7 @@ def build_python():
         check_call(['brew', 'install', 'openssl', 'pkg-config'])
         if platform.machine() == 'x86_64':
             prefix = '/usr/local'
-            min_macos_version = '10.13'
+            min_macos_version = '10.11'
         elif platform.machine() == 'arm64':
             prefix = '/opt/homebrew'
             min_macos_version = '11.0'


### PR DESCRIPTION
This PR resolves four backwards compatibility issues that affects people generating redistributable packages of Emscripten SDK:

1. Set the macOS version to target to macOS 10.11 for LLVM. This enables developers to package up Emscripten SDK on e.g. macOS Big Sur 11.0 machines, but still be able to target older macOS systems. Also fall back the previous Python target from 10.13 to 10.11. macOS 10.11 is chosen because of a) neither Python or LLVM really need any new macOS system SDK functions, but they are pretty self-contained and build fine targeting macOS 10.11, and b) looking at the table https://en.wikipedia.org/wiki/MacBook_Pro#Supported_macOS_releases gives macOS 10.11 the "universal" sweet spot that targets the widest audience.
2. Disable libxml2 from LLVM build with `-DDLLVM_ENABLE_LIBXML2=OFF`. On macOS there is a CMake libxml2 path search issue, where if one has Mono or some other tool that comes with libxml2.dylibs in PATH, then LLVM CMake build will pick up that libxml2 DLL, causing an unwanted dependency to wrong version of libxml2. Searching through LLVM codebase for what it uses libxml2, it seems to be for Windows manifest file generation, and some lldb related operation. It is unlikely that Emscripten users need this.
3. Disable LLVM terminfo dependency. This has been observed to cause system .so lookup issues on different versions of Ubuntu that would force people to manually apt install curses or terminfo packages. This looks also like very unlikely for emsdk developers to need.
4. Disable the other optional LLVM and LLDB dependencies: `-DLLDB_ENABLE_LIBEDIT=OFF`, `-DLLVM_ENABLE_LIBEDIT=OFF` and `-DLLVM_ENABLE_LIBPFM=OFF`. No particular observed reason, except that we don't know that anyone would need these, and be on the safe side that these won't cause similar redistribution issues like terminfo and libxml2 are known to have.

