### PR TITLE
bugfix: allow to install SDK binaries alone

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2812,6 +2812,7 @@ def expand_sdk_name(name, activating):
     fullname = fullname.replace('-fastcomp', '')
     backend = 'fastcomp'
   version = fullname.replace('sdk-', '').replace('releases-', '').replace('-64bit', '').replace('tag-', '')
+  sdk = 'sdk-' if not name.startswith('releases-') else ''
   releases_info = load_releases_info()['releases']
   release_hash = get_release_hash(version, releases_info)
   if release_hash:
@@ -2823,7 +2824,7 @@ def expand_sdk_name(name, activating):
         backend = 'upstream'
       else:
         backend = 'fastcomp'
-    full_name = 'sdk-releases-%s-%s-64bit' % (backend, release_hash)
+    full_name = '%sreleases-%s-%s-64bit' % (sdk, backend, release_hash)
     print("Resolving SDK version '%s' to '%s'" % (version, full_name))
     return full_name
 
@@ -2832,7 +2833,7 @@ def expand_sdk_name(name, activating):
       backend = 'upstream'
     global extra_release_tag
     extra_release_tag = version
-    return 'sdk-releases-%s-%s-64bit' % (backend, version)
+    return '%sreleases-%s-%s-64bit' % (sdk, backend, version)
 
   return name
 

--- a/test/test.py
+++ b/test/test.py
@@ -260,7 +260,7 @@ int main() {
 
   def test_install_tool(self):
     # Test that its possible to install emscripten as tool instead of SDK
-    checked_call_with_output(emsdk + 'install releases-upstream-77b065ace39e6ab21446e13f92897f956c80476a', unexpected='Installing SDK')
+    checked_call_with_output(emsdk + ' install releases-upstream-77b065ace39e6ab21446e13f92897f956c80476a', unexpected='Installing SDK')
 
 
 if __name__ == '__main__':

--- a/test/test.py
+++ b/test/test.py
@@ -258,6 +258,10 @@ int main() {
     # Check that its not re-downloaded
     checked_call_with_output(emsdk + ' install 5c776e6a91c0cb8edafca16a652ee1ee48f4f6d2', expected='Skipped', unexpected='Downloading:')
 
+  def test_install_tool(self):
+    # Test that its possible to install emscripten as tool instead of SDK
+    checked_call_with_output(emsdk + 'install releases-upstream-77b065ace39e6ab21446e13f92897f956c80476a', unexpected='Installing SDK')
+
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)


### PR DESCRIPTION
an alternative approach to #833.

> this fixes the wrong behavior of emsdk:

> The command `emsdk install releases-upstream-<commit>-64bit` should install emscripten only, but `expand_sdk_name()` rewrite the args so it behaves same as `emsdk install sdk-releases-upstream-<commit>-64bit`.


as #833 broke extra_release_tag, this change uses a more straightforward way: if name starts with "releases-", we treat this as a tool instead of sdk.

The current code is bug prone (for example, if a tool's name is exactly length of 40, it will be treated as a "version" of SDK), but I don't think there is a easy fix as several places depends on global variable extra_release_tag. the ideal fix is to have a strict definition of whether a name is a tool or sdk, and perform a check based on that. considering backward compatibility this may be a hard work.