### PR TITLE
Add `llvm-12` and `rust-compat` tags

### DIFF
--- a/emscripten-releases-tags.txt
+++ b/emscripten-releases-tags.txt
@@ -2,6 +2,7 @@
   "latest": "2.0.23",
   "releases": {
     "llvm-12": "56b877afe7d1b651d6b9a2ba5d5df074876172ff",
+    "rust-compat": "56b877afe7d1b651d6b9a2ba5d5df074876172ff",
     "2.0.23": "77b065ace39e6ab21446e13f92897f956c80476a",
     "2.0.23-lto": "3f6dbb899f61fab52e4574beb4f7c8382658aa20",
     "2.0.22": "6465a9acb820207acf7da44661a7de52d0a1ae3c",

--- a/emscripten-releases-tags.txt
+++ b/emscripten-releases-tags.txt
@@ -1,7 +1,6 @@
 {
   "latest": "2.0.23",
   "releases": {
-    "rust-compat": "56b877afe7d1b651d6b9a2ba5d5df074876172ff",
     "llvm-12": "56b877afe7d1b651d6b9a2ba5d5df074876172ff",
     "2.0.23": "77b065ace39e6ab21446e13f92897f956c80476a",
     "2.0.23-lto": "3f6dbb899f61fab52e4574beb4f7c8382658aa20",

--- a/emscripten-releases-tags.txt
+++ b/emscripten-releases-tags.txt
@@ -1,6 +1,8 @@
 {
   "latest": "2.0.23",
   "releases": {
+    "rust-compat": "56b877afe7d1b651d6b9a2ba5d5df074876172ff",
+    "llvm-12": "56b877afe7d1b651d6b9a2ba5d5df074876172ff",
     "2.0.23": "77b065ace39e6ab21446e13f92897f956c80476a",
     "2.0.23-lto": "3f6dbb899f61fab52e4574beb4f7c8382658aa20",
     "2.0.22": "6465a9acb820207acf7da44661a7de52d0a1ae3c",


### PR DESCRIPTION
These are human-readable tags for https://github.com/emscripten-core/emscripten/pull/14394#discussion_r646844218.

I went with `rust-compat` instead of `rust` because `emsdk install rust` might be confusing and suggest that it will install Rust itself too.