### PR TITLE
Improve emscripten-releases-tags.txt to support mutliple aliases

### DIFF
--- a/emscripten-releases-tags.txt
+++ b/emscripten-releases-tags.txt
@@ -1,5 +1,13 @@
 {
-  "latest": "2.0.23",
+  "aliases": {
+    "latest": "2.0.23",
+    "latest-sdk": "latest",
+    "latest-64bit": "latest",
+    "sdk-latest-64bit": "latest",
+    "latest-upstream": "latest",
+    "latest-clang-upstream": "latest",
+    "latest-releases-upstream": "latest"
+  },
   "releases": {
     "2.0.23": "77b065ace39e6ab21446e13f92897f956c80476a",
     "2.0.23-lto": "3f6dbb899f61fab52e4574beb4f7c8382658aa20",

--- a/test/test.py
+++ b/test/test.py
@@ -140,7 +140,7 @@ int main() {
   def test_list(self):
     # Test we report installed tools properly. The latest version should be
     # installed, but not some random old one.
-    checked_call_with_output(emsdk + ' list', expected=TAGS['latest'] + '    INSTALLED', unexpected='1.39.15    INSTALLED:')
+    checked_call_with_output(emsdk + ' list', expected=TAGS['aliases']['latest'] + '    INSTALLED', unexpected='1.39.15    INSTALLED:')
 
   def test_config_contents(self):
     print('test .emscripten contents')


### PR DESCRIPTION
Also, improve reporting of version resolution. e.g.:

```
$ ./emsdk  install sdk-latest
Resolving SDK alias 'latest' to '2.0.23'
Resolving SDK version '2.0.23' to 'sdk-releases-upstream-77b065ace39e6ab21446e13f92897f956c80476a-64bit'
Installing SDK 'sdk-releases-upstream-77b065ace39e6ab21446e13f92897f956c80476a-64bit'..
...
```

Should help with #836.