### PR TITLE
Support linking with `-o filename`

### DIFF
--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -51,7 +51,7 @@ parser.add_argument('--oformat')
 options = parser.parse_known_args(param_file_args)[0]
 output_file = options.o
 oformat = options.oformat
-outdir = os.path.dirname(output_file)
+outdir = os.path.normpath(os.path.dirname(output_file))
 base_name = os.path.basename(output_file)
 
 # The output file name is the name of the build rule that was built.


### PR DESCRIPTION
When linking with `-o filename` (such as in various CMake build checks), the parameter passed to the linker is a temporary file, and it is passed as a bare filename (i.e. relative path without a `'/'`). In such cases, `outdir` would have been the empty string, and the final `tar` command would fail (actually the call to `subprocess.check_call(…)` is what fails).