### PR TITLE
Small fix for Bazel instructions

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -25,7 +25,7 @@ emsdk_emscripten_deps()
 
 Put the following lines into your `.bazelrc`:
 ```
-build:wasm --crosstool_top=//emscripten_toolchain:everything
+build:wasm --crosstool_top=@emsdk//emscripten_toolchain:everything
 build:wasm --cpu=wasm
 build:wasm --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 ```


### PR DESCRIPTION
In the past the instructions were to copy `emscripten_toolchain` into the project dir, now it downloads emsdk as a package so the `bazelrc` part has to refer to `@emsdk`.