### PR TITLE
Add back node.js 12.18.1 packages for Windows 7 support.

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -202,6 +202,52 @@
   },
   {
     "id": "node",
+    "version": "12.18.1",
+    "bitness": 32,
+    "arch": "x86",
+    "windows_url": "node-v12.18.1-win-x86.zip",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%",
+    "is_old": true
+  },
+  {
+    "id": "node",
+    "version": "12.18.1",
+    "arch": "arm",
+    "bitness": 32,
+    "linux_url": "node-v12.18.1-linux-armv7l.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%",
+    "is_old": true
+  },
+  {
+    "id": "node",
+    "version": "12.18.1",
+    "bitness": 64,
+    "arch": "x86_64",
+    "macos_url": "node-v12.18.1-darwin-x64.tar.gz",
+    "windows_url": "node-v12.18.1-win-x64.zip",
+    "linux_url": "node-v12.18.1-linux-x64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%",
+    "is_old": true
+  },
+  {
+    "id": "node",
+    "version": "12.18.1",
+    "arch": "aarch64",
+    "bitness": 64,
+    "linux_url": "node-v12.18.1-linux-arm64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%",
+    "is_old": true
+  },
+  {
+    "id": "node",
     "version": "14.15.5",
     "bitness": 32,
     "arch": "x86",


### PR DESCRIPTION
The current Node.js version 14.15.5 has unfortunately dropped support for Windows 7. At Unity we do still need to support that, so this PR adds back the earlier Node.js 12.18.1 packages.

Likewise, latest Python has dropped Windows 7 support, but using the (still existing) Python 3.7.4 works.

In the absence of any actual requirement to use newer Node 14, I would actually entertain the thought to go even further and revert back Node 12.18.1 as the default Node.js version, and the earlier Python 3.7.4 the default Python version, so that they will get unit tested.

Has Emscripten adopted any compile-time Node 14 or Python 3.9 requiring features? Ran the Emscripten test suite locally with this node.js & python version, which completed fine - so I suppose the answer is no. Would it make sense to fall back to these by default until April of 2022?
