### PR TITLE
[Bazel] Fix llvm bin path

### DIFF
--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -105,7 +105,7 @@ if os.path.exists(wasm_base + '.debug.wasm') and os.path.exists(wasm_base):
   # is the blaze output path; we want it to be just the filename.
 
   llvm_objcopy = os.path.join(
-      os.environ['EMSCRIPTEN'], 'llvm-bin/llvm-objcopy')
+      os.environ['EM_BIN_PATH'], 'bin/llvm-objcopy')
   # First, check to make sure the .wasm file has the header that needs to be
   # rewritten.
   rtn = subprocess.call([


### PR DESCRIPTION
Closes https://github.com/emscripten-core/emsdk/issues/887

The path to `llvm-objcopy` is incorrect from what I can tell. I've tested this change using `local_repository` and I am now able to successfully build with `-s SINGLE_FILE=0` with separate .js, .wasm and .debug.wasm files.