### PR TITLE
Fix error handling: untargz() in emsdk.py

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -539,10 +539,10 @@ def untargz(source_filename, dest_dir, unpack_even_if_exists=False):
     return True
   print("Unpacking '" + source_filename + "' to '" + dest_dir + "'")
   mkdir_p(dest_dir)
-  run(['tar', '-xvf' if VERBOSE else '-xf', sdk_path(source_filename), '--strip', '1'], cwd=dest_dir)
+  returncode = run(['tar', '-xvf' if VERBOSE else '-xf', sdk_path(source_filename), '--strip', '1'], cwd=dest_dir)
   # tfile = tarfile.open(source_filename, 'r:gz')
   # tfile.extractall(dest_dir)
-  return True
+  return returncode == 0
 
 
 # On Windows, it is not possible to reference path names that are longer than


### PR DESCRIPTION
Fix #218

Make `untargz()` function in emsdk.py return `False` if `tar` command failed.

### Background

Without `xz` command, installation failed. Regardless of that, the message was "no error was detected" as follows:

```
$ ./emsdk install latest

...

Installing tool 'node-14.15.5-64bit'..
Downloading: /workspaces/emsdk/zips/node-v14.15.5-linux-x64.tar.xz from https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v14.15.5-linux-x64.tar.xz, 21391232 Bytes
Unpacking '/workspaces/emsdk/zips/node-v14.15.5-linux-x64.tar.xz' to '/workspaces/emsdk/node/14.15.5_64bit'
tar (child): xz: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
['tar', '-xf', '/workspaces/emsdk/zips/node-v14.15.5-linux-x64.tar.xz', '--strip', '1'] failed with error code 2!
Done installing tool 'node-14.15.5-64bit'.
error: installation of 'node-14.15.5-64bit' failed, but no error was detected. Either something went wrong with the installation, or this may indicate an internal emsdk error.
```

This is because `untargz()` function always returns `True`. After fixing it, the message became more clear as follows:

```
$ ./emsdk install latest

...

Installing tool 'node-14.15.5-64bit'..
Downloading: /workspaces/emsdk/zips/node-v14.15.5-linux-x64.tar.xz from https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v14.15.5-linux-x64.tar.xz, 21391232 Bytes
Unpacking '/workspaces/emsdk/zips/node-v14.15.5-linux-x64.tar.xz' to '/workspaces/emsdk/node/14.15.5_64bit'
tar (child): xz: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
['tar', '-xf', '/workspaces/emsdk/zips/node-v14.15.5-linux-x64.tar.xz', '--strip', '1'] failed with error code 2!
error: installation failed!
```
