### PR TITLE
bazel: pass -g3 instead of -g4 for wasm_asan feature

### DIFF
--- a/bazel/emscripten_toolchain/crosstool.bzl
+++ b/bazel/emscripten_toolchain/crosstool.bzl
@@ -619,7 +619,7 @@ def _impl(ctx):
             actions = all_compile_actions +
                       all_link_actions,
             flags = [
-                "-g4",
+                "-g3",
                 "-fsanitize=address",
                 "-O1",
                 "-DADDRESS_SANITIZER=1",


### PR DESCRIPTION
fixes #903 