### PR TITLE
Improve flags in Bazel example

### DIFF
--- a/bazel/test_external/BUILD
+++ b/bazel/test_external/BUILD
@@ -16,11 +16,11 @@ BASE_LINKOPTS = [
 ]
 
 RELEASE_OPTS = [
-    "--closure 1",  # Run the closure compiler
+    "--closure=1",  # Run the closure compiler
 ]
 
 DEBUG_OPTS = [
-    "--closure 0",  # Do not use closure
+    "--closure=0",  # Do not use closure
 ]
 
 config_setting(


### PR DESCRIPTION
Follow-up from #912  @sbc100 

> You can use --closure=1, which makes this into a single argument and avoid any questions of how/where the space here is parsed.

Done

> DEBUG_OPTS should not be needed. closure is not enabled by default except in higher optimization levels.

I agree that it does not change the behavior, but I think it makes the example look more complete - a better building block if someone wants to have their own custom flags for debug and release mode. WDYT?