### PR TITLE
Forward Bazel platforms from CLI onward

### DIFF
--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -6,6 +6,7 @@ def _wasm_transition_impl(settings, attr):
 
     features = list(settings["//command_line_option:features"])
     linkopts = list(settings["//command_line_option:linkopt"])
+    platforms = list(settings["//command_line_option:platforms"])
 
     if attr.threads == "emscripten":
         # threads enabled
@@ -32,7 +33,7 @@ def _wasm_transition_impl(settings, attr):
         "//command_line_option:features": features,
         "//command_line_option:dynamic_mode": "off",
         "//command_line_option:linkopt": linkopts,
-        "//command_line_option:platforms": [],
+        "//command_line_option:platforms": platforms,
         "//command_line_option:custom_malloc": "@emsdk//emscripten_toolchain:malloc",
     }
 
@@ -41,6 +42,7 @@ _wasm_transition = transition(
     inputs = [
         "//command_line_option:features",
         "//command_line_option:linkopt",
+        "//command_line_option:platforms",
     ],
     outputs = [
         "//command_line_option:compiler",


### PR DESCRIPTION
I was very confused why the platforms I was specifying on the CLI were not getting passed through the `wasm_cc_binary` rule. For the Skia project, we make use of [platforms and constraint values](https://skia-review.googlesource.com/c/skia/+/463517/4/bazel/common_config_settings/BUILD.bazel#51) to define things like WebGL vs WebGPU support, so we those to get passed through to our cc_library rules and such, so we can build the correct supporting code.

If there was a good reason to use empty list for platform, that should probably be documented. If we, the Skia team, should not be using platforms like that, I'd like to hear what to use instead.
