### PR TITLE
2.0.33

### DIFF
--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -2,6 +2,12 @@
 # DO NOT MODIFY
 
 EMSCRIPTEN_TAGS = {
+    "2.0.33": struct(
+        hash = "cef8850d57278271766fb2163eebcb07354018e7",
+        sha_linux = "958a0f4b1533e877c1a5ed3c13cb8baabc80e791d45858c2c94ac62325ada953",
+        sha_mac = "8ecb248653d44c3748e23c089cb9f0e3d4eee7cda13fdec27ec0113b896e34c4",
+        sha_win = "6b6b2831f8b338488f787b4a8c34700277bf3988358dbb54426f017155603ac9",
+    ),
     "2.0.32": struct(
         hash = "74646397e3c5010824ad60d1de86c6bcbe334dff",
         sha_linux = "236b3954e71d3bb30d347c655b9f47f2a091aa2e61046e1912c8da90152f4ca1",

--- a/emscripten-releases-tags.json
+++ b/emscripten-releases-tags.json
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "latest": "2.0.32",
+    "latest": "2.0.33",
     "latest-sdk": "latest",
     "latest-64bit": "latest",
     "sdk-latest-64bit": "latest",
@@ -9,6 +9,7 @@
     "latest-releases-upstream": "latest"
   },
   "releases": {
+    "2.0.33": "cef8850d57278271766fb2163eebcb07354018e7",
     "2.0.32": "74646397e3c5010824ad60d1de86c6bcbe334dff",
     "2.0.31": "597724ca3f6cd6e84bea73f1f519a3953b5c273d",
     "2.0.31-asserts": "c1065389ccf4a81e3c1af080316afd444788bc46",

--- a/test/test.py
+++ b/test/test.py
@@ -232,6 +232,8 @@ int main() {
     run_emsdk('activate sdk-tag-1.38.33-64bit')
 
   def test_binaryen_from_source(self):
+    if MACOS:
+      self.skipTest("https://github.com/WebAssembly/binaryen/issues/4299")
     print('test binaryen source build')
     run_emsdk(['install', '--build=Release', '--generator=Unix Makefiles', 'binaryen-main-64bit'])
 


### PR DESCRIPTION
I add to temporarily disable the test_binaryen_from_source test
under macOS to work around:
https://github.com/WebAssembly/binaryen/issues/4299
