### PR TITLE
Update CMAKE_OSX_DEPLOYMENT_TARGET from 10.11 to 10.12

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1058,16 +1058,16 @@ def cmake_configure(generator, build_root, src_root, build_type, extra_cmake_arg
       generator = []
 
     cmdline = ['cmake'] + generator + ['-DCMAKE_BUILD_TYPE=' + build_type, '-DPYTHON_EXECUTABLE=' + sys.executable]
-    # Target macOS 10.11 at minimum, to support widest range of Mac devices from "Mid 2007" and newer:
-    # https://en.wikipedia.org/wiki/MacBook_Pro#Supported_macOS_releases
-    cmdline += ['-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11']
+    # Target macOS Sierra (10.12) at minimum.
+    # This is the minimum version required to build binaryen.
+    cmdline += ['-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12']
     cmdline += extra_cmake_args + [src_root]
 
     print('Running CMake: ' + str(cmdline))
 
     # Specify the deployment target also as an env. var, since some Xcode versions
     # read this instead of the CMake field.
-    os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.11'
+    os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.12'
 
     def quote_parens(x):
       if ' ' in x:

--- a/scripts/update_python.py
+++ b/scripts/update_python.py
@@ -108,7 +108,8 @@ def build_python():
         check_call(['brew', 'install', 'openssl', 'pkg-config'])
         if platform.machine() == 'x86_64':
             prefix = '/usr/local'
-            min_macos_version = '10.11'
+            # Keep in sync with CMAKE_OSX_DEPLOYMENT_TARGET in emsdk.py
+            min_macos_version = '10.12'
         elif platform.machine() == 'arm64':
             prefix = '/opt/homebrew'
             min_macos_version = '11.0'


### PR DESCRIPTION
Apparently 10.11 is no longer good enough to run the latest version of
binaryen.  Specifically since binaryen switched to using std::variant it
now fails to build with this set to 10.11.