### PR TITLE
Optionally keep the downloaded archives

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2935,6 +2935,13 @@ def main(args):
        'activate' commands and the invocation of 'emsdk_env', or otherwise
        these commands will default to operating on the default build type
        which in and RelWithDebInfo.''')
+
+    print('''
+
+   Environment:
+      EMSDK_NOTTY=1              - override isatty() result (mainly to log progress).
+      EMSDK_NUM_CORES=n          - limit parallelism to n cores.
+      EMSDK_VERBOSE=1            - very verbose output, useful for debugging.''')
     return 0
 
   # Extracts a boolean command line argument from args and returns True if it was present

--- a/emsdk.py
+++ b/emsdk.py
@@ -2733,7 +2733,7 @@ def construct_env_with_vars(env_vars_to_add):
   # if no such tool is active.
   # Ignore certain keys that are inputs to emsdk itself.
   ignore_keys = set(['EMSDK_POWERSHELL', 'EMSDK_CSH', 'EMSDK_CMD', 'EMSDK_BASH',
-                     'EMSDK_NUM_CORES', 'EMSDK_TTY'])
+                     'EMSDK_NUM_CORES', 'EMSDK_NOTTY'])
   env_keys_to_add = set(pair[0] for pair in env_vars_to_add)
   for key in os.environ:
     if key.startswith('EMSDK_') or key.startswith('EM_'):


### PR DESCRIPTION
I have been switching Emscripten versions quite a few times, and emsdk always downloads the binaries. So this adds the environment setting EMSDK_KEEP_DOWNLOADS, which keeps the downloaded archives around.

This also includes a documentation commit for some other EMSDK_* env-vars and one minor typo fix, which I didn't test, but seemed obviously broken.