### PR TITLE
Simplify and improve .dockerignore. NFC.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,7 @@
 !emsdk_env.sh
 !emsdk_manifest.json
 
-# TODO: Somehow these legacy files are also required for building
+# Allow files required to install legacy versions
 !legacy-binaryen-tags.txt
 !legacy-emscripten-tags.txt
 !llvm-tags-64bit.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,21 +1,20 @@
-# Ignore all subdirectories
-*/*
+# Ignore everything
+*
 
 # Allow to run the test script inside the Docker container
 !/docker/test_dockerimage.sh
 
-# Ignore unnecessary files inside top-level directory
-*.bat
-*.csh
-*.fish
-*.ps1
-*.pyc
-.emscripten
-.emscripten.old
-.emscripten_cache
-.emscripten_cache__last_clear
-.emscripten_sanity
-.emscripten_sanity_wasm
-.flake8
-emscripten-releases-tot.txt
-README.md
+# Allow license file
+!LICENSE
+
+# Allow necessary build files in top-level directory
+!emscripten-releases-tags.json
+!emsdk
+!emsdk.py
+!emsdk_env.sh
+!emsdk_manifest.json
+
+# TODO: Somehow these legacy files are also required for building
+!legacy-binaryen-tags.txt
+!legacy-emscripten-tags.txt
+!llvm-tags-64bit.txt

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 This Dockerfile builds a self-contained version of Emscripten SDK that enables Emscripten to be used without any
 other installation on the host system.
 
-It is published at https://hub.docker.com/u/emscripten/emsdk
+It is published at https://hub.docker.com/r/emscripten/emsdk.
 
 ### Usage
 


### PR DESCRIPTION
This PR simplifies and improves the `.dockerignore` file by excluding everything and using a allow list to include the things that are really needed.

The reason for this is that the `*/*` syntax in `.dockerignore` still causes empty directories.
```bash
$ docker run -it emscripten/emsdk:2.0.34 ls -l /emsdk
total 224
-rw-r--r-- 1 root root   1326 Nov  4 21:53 LICENSE
drwxr-xr-x 2 root root   4096 Nov  4 21:53 bazel
drwxr-xr-x 2 root root   4096 Nov  4 21:54 docker
-rw-r--r-- 1 root root   5147 Nov  4 21:53 emscripten-releases-tags.json
-rwxr-xr-x 1 root root   1630 Nov  4 21:53 emsdk
-rw-r--r-- 1 root root 124970 Nov  4 21:53 emsdk.py
-rw-r--r-- 1 root root   1975 Nov  4 21:53 emsdk_env.sh
-rw-r--r-- 1 root root  30131 Nov  4 21:53 emsdk_manifest.json
-rw-r--r-- 1 root root     25 Nov  4 21:56 hello.c
-rw-r--r-- 1 root root    387 Nov  4 21:56 hello.o
-rw-r--r-- 1 root root    659 Nov  4 21:53 legacy-binaryen-tags.txt
-rw-r--r-- 1 root root   1190 Nov  4 21:53 legacy-emscripten-tags.txt
-rw-r--r-- 1 root root   2380 Nov  4 21:53 llvm-tags-64bit.txt
drwxr-xr-x 3 root root   4096 Nov  4 21:55 node
drwxr-xr-x 2 root root   4096 Nov  4 21:53 scripts
drwxr-xr-x 2 root root   4096 Nov  4 21:53 test
drwxr-xr-x 7 root root   4096 Nov  4 21:55 upstream
drwxr-xr-x 2 root root   4096 Nov  4 21:55 zips
$ docker run -it emscripten/emsdk:2.0.34 ls -l /emsdk/test
total 0
```

This was not a issue before, so I think a recent Docker upgrade changed the behavior of this.
```bash
$ docker run -it emscripten/emsdk:2.0.2 ls -l /emsdk
-rw-r--r-- 1 root root   1326 Sep  2  2020 LICENSE
drwxr-xr-x 2 root root   4096 Sep  2  2020 docker
-rw-r--r-- 1 root root   2523 Sep  2  2020 emscripten-releases-tags.txt
-rwxr-xr-x 1 root root    593 Sep  2  2020 emsdk
-rwxr-xr-x 1 root root 118150 Sep  2  2020 emsdk.py
-rw-r--r-- 1 root root   1963 Sep  2  2020 emsdk_env.sh
-rw-r--r-- 1 root root  27100 Sep  2  2020 emsdk_manifest.json
-rw-r--r-- 1 root root      0 Sep  2  2020 llvm-tags-32bit.txt
-rw-r--r-- 1 root root   2379 Sep  2  2020 llvm-tags-64bit.txt
drwxr-xr-x 3 root root   4096 Sep  2  2020 node
drwxr-xr-x 2 root root   4096 Sep  2  2020 scripts
drwxr-xr-x 2 root root   4096 Sep  2  2020 tmp
drwxr-xr-x 8 root root   4096 Sep  2  2020 upstream
drwxr-xr-x 2 root root   4096 Sep  2  2020 zips
```