### PR TITLE
Always output a tarball from cc_binary to simplify logic.

### DIFF
--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -153,15 +153,11 @@ if os.path.exists(wasm_base + '.debug.wasm') and os.path.exists(wasm_base):
         wasm_base,
         '--add-section=external_debug_info=debugsection.tmp'])
 
-# If we have more than one output file then create tarball
-if len(files) > 1:
+# If we have one or more output files then create a tarball
+if len(files) >= 1:
   cmd = ['tar', 'cf', 'tmp.tar'] + files
   subprocess.check_call(cmd, cwd=outdir)
   os.rename(os.path.join(outdir, 'tmp.tar'), output_file)
-elif len(files) == 1:
-  # Otherwise, if only have a single output than move it to the expected name
-  if files[0] != os.path.basename(output_file):
-    os.rename(os.path.join(outdir, files[0]), output_file)
 else:
   print('emcc.py did not appear to output any known files!')
   sys.exit(1)

--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -153,13 +153,14 @@ if os.path.exists(wasm_base + '.debug.wasm') and os.path.exists(wasm_base):
         wasm_base,
         '--add-section=external_debug_info=debugsection.tmp'])
 
-# If we have one or more output files then create a tarball
-if len(files) >= 1:
-  cmd = ['tar', 'cf', 'tmp.tar'] + files
-  subprocess.check_call(cmd, cwd=outdir)
-  os.rename(os.path.join(outdir, 'tmp.tar'), output_file)
-else:
+# Make sure we have at least one output file.
+if not len(files):
   print('emcc.py did not appear to output any known files!')
   sys.exit(1)
+
+# cc_binary must output exactly one file; put all the output files in a tarball.
+cmd = ['tar', 'cf', 'tmp.tar'] + files
+subprocess.check_call(cmd, cwd=outdir)
+os.rename(os.path.join(outdir, 'tmp.tar'), output_file)
 
 sys.exit(0)

--- a/bazel/emscripten_toolchain/wasm_binary.py
+++ b/bazel/emscripten_toolchain/wasm_binary.py
@@ -21,7 +21,6 @@ WebAssembly binary into a larger web application.
 import argparse
 import os
 import subprocess
-import sys
 
 
 def ensure(f):
@@ -44,26 +43,9 @@ def main():
   basename = os.path.basename(args.archive)
   stem = basename.split('.')[0]
 
-  # Check the type of the input file
-  mimetype_bytes = subprocess.check_output(['file', '-Lb', '--mime-type', '--mime-encoding', args.archive])
-  mimetype = mimetype_bytes.decode(sys.stdout.encoding)
-
-  # If we have a tar, extract all files. If we have just a single file, copy it.
-  if 'tar' in mimetype:
-    subprocess.check_call(
-        ['tar', 'xf', args.archive, '-C', args.output_path])
-  elif 'binary' in mimetype:
-    subprocess.check_call([
-        'cp',
-        args.archive,
-        os.path.join(args.output_path, stem + '.wasm')])
-  elif 'text' in mimetype:
-    subprocess.check_call([
-        'cp',
-        args.archive,
-        os.path.join(args.output_path, stem + '.js')])
-  else:
-    subprocess.check_call(['cp', args.archive, args.output_path])
+  # Extract all files from the tarball.
+  subprocess.check_call(
+      ['tar', 'xf', args.archive, '-C', args.output_path])
 
   # At least one of these two files should exist at this point.
   ensure(os.path.join(args.output_path, stem + '.js'))


### PR DESCRIPTION
This will change the result of --config=wasm builds that were previously outputting a single file.

Helps prepare for windows support (#814) and removes the need for #929 to add an external python dep.