### PR TITLE
Canonical optimization levels in bazel toolchain

### DIFF
--- a/bazel/emscripten_toolchain/crosstool.bzl
+++ b/bazel/emscripten_toolchain/crosstool.bzl
@@ -572,7 +572,7 @@ def _impl(ctx):
         flag_set(
             actions = all_compile_actions +
                       all_link_actions,
-            flags = ["-O3"],
+            flags = ["-O2"],
             features = ["opt"],
         ),
         # Users can override opt-level with semantic names...
@@ -598,7 +598,7 @@ def _impl(ctx):
         flag_set(
             actions = all_compile_actions +
                       all_link_actions,
-            flags = ["-O2"],
+            flags = ["-O0"],
             features = ["fastbuild"],
         ),
 

--- a/bazel/emscripten_toolchain/crosstool.bzl
+++ b/bazel/emscripten_toolchain/crosstool.bzl
@@ -575,6 +575,7 @@ def _impl(ctx):
             flags = ["-O2"],
             features = ["opt"],
         ),
+
         # Users can override opt-level with semantic names...
         flag_set(
             actions = all_compile_actions +


### PR DESCRIPTION
Bazel has three compilation modes, fastbuild, dbg and opt. Docs [here](https://docs.bazel.build/versions/main/user-manual.html#flag--compilation_mode).

Copying the definitions here for reference:
```
- fastbuild means build as fast as possible: generate minimal debugging information (-gmlt -Wl,-S), and don't optimize. This is the default. Note: -DNDEBUG will not be set.
- dbg means build with debugging enabled (-g), so that you can use gdb (or another debugger).
- opt means build with optimization enabled and with assert() calls disabled (-O2 -DNDEBUG). Debugging information will not be generated in opt mode unless you also pass --copt -g.
```

Currently in the emscripten bazel toolchain, dbg seems to be doing the right thing (`-O0 -g`). But fastbuild is optimizing at -O2 when it is supposed to be -O0. And opt is going up to -O3 instead of -O2. 

I believe what we want to achieve is the following:
`-c dbg` -> `-O0 -g` (-g implies -g3)
`-c fastbuild` or nothing, since fastbuild is the default -> `-O0 -g0`
`-c opt` -> `-O2 -g0 -NDEBUG`

`-c opt --features=optimized_for_speed`  -> `-O3 -g0 -NDEBUG`
`-c opt --features=optimized_for_size`  -> `-Oz -g0 -NDEBUG`
`-c opt --features=full_debug_info` -> `-O2 -g -NDEBUG`
etc etc.

Thoughts @sbc100 @celentes @walkingeyerobot?