### PR TITLE
Minor node version update v14.15.5 -> v14.18.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,8 +65,8 @@ COPY --from=stage_build /emsdk /emsdk
 # (sub-stages) or with custom / no entrypoint
 ENV EMSDK=/emsdk \
     EM_CONFIG=/emsdk/.emscripten \
-    EMSDK_NODE=/emsdk/node/14.15.5_64bit/bin/node \
-    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/14.15.5_64bit/bin:${PATH}"
+    EMSDK_NODE=/emsdk/node/14.18.2_64bit/bin/node \
+    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/14.18.2_64bit/bin:${PATH}"
 
 # ------------------------------------------------------------------------------
 # Create a 'standard` 1000:1000 user

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -258,6 +258,53 @@
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%",
     "is_old": true
   },
+
+
+  {
+    "id": "node",
+    "version": "14.18.2",
+    "bitness": 32,
+    "arch": "x86",
+    "windows_url": "node-v14.18.2-win-x86.zip",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "14.18.2",
+    "arch": "arm",
+    "bitness": 32,
+    "linux_url": "node-v14.18.2-linux-armv7l.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "14.18.2",
+    "bitness": 64,
+    "arch": "x86_64",
+    "macos_url": "node-v14.18.2-darwin-x64.tar.gz",
+    "windows_url": "node-v14.18.2-win-x64.zip",
+    "linux_url": "node-v14.18.2-linux-x64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "14.18.2",
+    "arch": "aarch64",
+    "bitness": 64,
+    "macos_url": "node-v14.18.2-darwin-x64.tar.gz",
+    "linux_url": "node-v14.18.2-linux-arm64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+
+
   {
     "id": "node",
     "version": "14.15.5",
@@ -301,6 +348,8 @@
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
+
+
   {
     "id": "python",
     "version": "2.7.13.1",
@@ -595,19 +644,19 @@
   {
     "version": "upstream-main",
     "bitness": 64,
-    "uses": ["python-3.9.2-1-64bit", "llvm-git-main-64bit", "node-14.15.5-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.9.2-1-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
     "version": "upstream-main",
     "bitness": 64,
-    "uses": ["python-3.9.2-1-64bit", "llvm-git-main-64bit", "node-14.15.5-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.9.2-1-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "upstream-main",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-14.15.5-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
@@ -655,14 +704,14 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.15.5-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.15.5-64bit", "python-3.9.2-1-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.9.2-1-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -670,7 +719,7 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.15.5-64bit", "python-3.9.2-1-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.9.2-1-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
@@ -678,21 +727,21 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.15.5-64bit", "python-3.9.2-1-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.9.2-1-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.15.5-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.15.5-64bit", "python-3.7.4-2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.7.4-2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -700,7 +749,7 @@
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.15.5-64bit", "python-3.9.2-1-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.9.2-1-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
@@ -708,7 +757,7 @@
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.15.5-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   },

--- a/scripts/update_node.py
+++ b/scripts/update_node.py
@@ -16,7 +16,7 @@ import subprocess
 import os
 import shutil
 
-version = '14.15.5'
+version = '14.18.2'
 base = 'https://nodejs.org/dist/latest-v14.x/'
 upload_base = 'gs://webassembly/emscripten-releases-builds/deps/'
 

--- a/test/test.py
+++ b/test/test.py
@@ -185,9 +185,9 @@ int main() {
 
     # Test the normal tools like node don't re-download on re-install
     print('another install must re-download')
-    checked_call_with_output(emsdk + ' uninstall node-14.15.5-64bit')
-    checked_call_with_output(emsdk + ' install node-14.15.5-64bit', expected='Downloading:', unexpected='already installed')
-    checked_call_with_output(emsdk + ' install node-14.15.5-64bit', unexpected='Downloading:', expected='already installed')
+    checked_call_with_output(emsdk + ' uninstall node-14.18.2-64bit')
+    checked_call_with_output(emsdk + ' install node-14.18.2-64bit', expected='Downloading:', unexpected='already installed')
+    checked_call_with_output(emsdk + ' install node-14.18.2-64bit', unexpected='Downloading:', expected='already installed')
 
   def test_tot_upstream(self):
     print('test update-tags')


### PR DESCRIPTION
The newer versions of eslint require 14.17.0 or above.  This
updates our node version to the latest in the 14.XX series.

I don't expect any user-visible changes.