### PR TITLE
3.1.0

### DIFF
--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -2,6 +2,12 @@
 # DO NOT MODIFY
 
 EMSCRIPTEN_TAGS = {
+    "3.1.0": struct(
+        hash = "562e3a0af169e6dea5e6dbecac2255d67c2c8b94",
+        sha_linux = "0714344e32e244e6d44d9ea75937633ab1338e417a232fb66d6dcd7d4b704e8c",
+        sha_mac = "f6c1cad729ed799e1df09eacf5aa80cce9861d69ec6d9581c17e4ba8d9b064ce",
+        sha_win = "756c41cbcab4ae6077cca30834d16151392b8c19ab186c13d42d7d05d6d727cc",
+    ),
     "3.0.1": struct(
         hash = "91b7a67a486d2430e73423a38d950d8a550826ed",
         sha_linux = "25fd430268596229c4ac38e188d7c2b31f75c2ec8172b1351d763e37c830c6af",

--- a/emscripten-releases-tags.json
+++ b/emscripten-releases-tags.json
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "latest": "3.0.1",
+    "latest": "3.1.0",
     "latest-sdk": "latest",
     "latest-64bit": "latest",
     "sdk-latest-64bit": "latest",
@@ -9,6 +9,8 @@
     "latest-releases-upstream": "latest"
   },
   "releases": {
+    "3.1.0": "562e3a0af169e6dea5e6dbecac2255d67c2c8b94",
+    "3.1.0-asserts": "1de2db691103282dad6b2037018db6ece54f57c6",
     "3.0.1": "91b7a67a486d2430e73423a38d950d8a550826ed",
     "3.0.1-asserts": "2a84a08e92ce8748015dfc3eee40ee35a853fed0",
     "3.0.0-asserts": "f1d65c26f502220e278d31e7621e99b673e28093",


### PR DESCRIPTION
This is the first version of include ES6 features in the JS output by default so I bumped to 3.1 rather than 3.0.2