### PR TITLE
Don't advertise "per_object_debug_info" feature in Bazel.

### DIFF
--- a/bazel/emscripten_toolchain/crosstool.bzl
+++ b/bazel/emscripten_toolchain/crosstool.bzl
@@ -298,10 +298,6 @@ def _impl(ctx):
         # Blaze also tests if this feature is supported, before setting the "pic" build-variable.
         feature(name = "pic"),
 
-        # Blaze requests this feature if fission is requested
-        # Blaze also tests if it's supported to see if we support fission.
-        feature(name = "per_object_debug_info"),
-
         # Blaze requests this feature by default.
         # Blaze also tests if this feature is supported before setting preprocessor_defines
         # (...but why?)


### PR DESCRIPTION
It breaks @emsdk in workspaces that have this feature enabled.

The following error appears when using the latest commit:

    cc_toolchain '@emsdk//emscripten_toolchain:everything' with
    identifier 'emscripten-wasm' doesn't define a tool path for 'dwp'

The following error appears after adding `emdwp` tool and scripts:

    output '*.dwo' was not created

Signed-off-by: Piotr Sikora <piotrsikora@google.com>