### PR TITLE
Support Bazel builds on Apple silicon

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -17,6 +17,14 @@ config_setting(
 )
 
 config_setting(
+    name = "macos_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
     name = "windows",
     constraint_values = [
         "@platforms//os:windows",
@@ -31,6 +39,7 @@ alias(
     actual = select({
         ":linux": "@emscripten_bin_linux//:all",
         ":macos": "@emscripten_bin_mac//:all",
+        ":macos_arm64": "@emscripten_bin_mac_arm64//:all",
         ":windows": "@emscripten_bin_win//:all",
         "//conditions:default": ":empty",
     }),
@@ -41,6 +50,7 @@ alias(
     actual = select({
         ":linux": "@emscripten_npm_linux//:node_modules",
         ":macos": "@emscripten_npm_mac//:node_modules",
+        ":macos_arm64": "@emscripten_npm_mac//:node_modules",
         ":windows": "@emscripten_npm_win//:node_modules",
         "//conditions:default": ":empty",
     }),

--- a/bazel/WORKSPACE
+++ b/bazel/WORKSPACE
@@ -4,6 +4,11 @@ load(":deps.bzl", "deps")
 
 deps()
 
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
+node_repositories(
+    node_version = "16.6.2",
+)
+
 load(":emscripten_deps.bzl", "emscripten_deps")
 
 emscripten_deps()

--- a/bazel/WORKSPACE
+++ b/bazel/WORKSPACE
@@ -4,11 +4,6 @@ load(":deps.bzl", "deps")
 
 deps()
 
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
-node_repositories(
-    node_version = "16.6.2",
-)
-
 load(":emscripten_deps.bzl", "emscripten_deps")
 
 emscripten_deps()

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "npm_install", "node_repositories")
 load(":revisions.bzl", "EMSCRIPTEN_TAGS")
 
 def _parse_version(v):
@@ -24,6 +24,12 @@ def emscripten_deps(emscripten_version = "latest"):
     # This could potentially backfire for projects with multiple emscripten
     # dependencies that use different emscripten versions
     excludes = native.existing_rules().keys()
+    if "nodejs_toolchains" not in excludes:
+        # Node 16 is the first version that supports darwin_arm64
+        node_repositories(
+            node_version = "16.6.2",
+        )
+
     if "emscripten_bin_linux" not in excludes:
         http_archive(
             name = "emscripten_bin_linux",

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -19,7 +19,7 @@ def emscripten_deps(emscripten_version = "latest"):
 
     revision = EMSCRIPTEN_TAGS[version]
 
-    emscripten_url = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/{}/{}/wasm-binaries.{}"
+    emscripten_url = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/{}/{}/wasm-binaries{}.{}"
 
     # This could potentially backfire for projects with multiple emscripten
     # dependencies that use different emscripten versions
@@ -28,7 +28,7 @@ def emscripten_deps(emscripten_version = "latest"):
         http_archive(
             name = "emscripten_bin_linux",
             strip_prefix = "install",
-            url = emscripten_url.format("linux", revision.hash, "tbz2"),
+            url = emscripten_url.format("linux", revision.hash, "", "tbz2"),
             sha256 = revision.sha_linux,
             build_file = "@emsdk//emscripten_toolchain:emscripten.BUILD",
             type = "tar.bz2",
@@ -38,8 +38,18 @@ def emscripten_deps(emscripten_version = "latest"):
         http_archive(
             name = "emscripten_bin_mac",
             strip_prefix = "install",
-            url = emscripten_url.format("mac", revision.hash, "tbz2"),
+            url = emscripten_url.format("mac", revision.hash, "", "tbz2"),
             sha256 = revision.sha_mac,
+            build_file = "@emsdk//emscripten_toolchain:emscripten.BUILD",
+            type = "tar.bz2",
+        )
+
+    if "emscripten_bin_mac_arm64" not in excludes:
+        http_archive(
+            name = "emscripten_bin_mac_arm64",
+            strip_prefix = "install",
+            url = emscripten_url.format("mac", revision.hash, "-arm64", "tbz2"),
+            sha256 = revision.sha_mac_arm64,
             build_file = "@emsdk//emscripten_toolchain:emscripten.BUILD",
             type = "tar.bz2",
         )
@@ -48,7 +58,7 @@ def emscripten_deps(emscripten_version = "latest"):
         http_archive(
             name = "emscripten_bin_win",
             strip_prefix = "install",
-            url = emscripten_url.format("win", revision.hash, "zip"),
+            url = emscripten_url.format("win", revision.hash, "", "zip"),
             sha256 = revision.sha_win,
             build_file = "@emsdk//emscripten_toolchain:emscripten.BUILD",
             type = "zip",
@@ -66,6 +76,13 @@ def emscripten_deps(emscripten_version = "latest"):
             name = "emscripten_npm_mac",
             package_json = "@emscripten_bin_mac//:emscripten/package.json",
             package_lock_json = "@emscripten_bin_mac//:emscripten/package-lock.json",
+        )
+
+    if "emscripten_npm_mac_arm64" not in excludes:
+        npm_install(
+            name = "emscripten_npm_mac",
+            package_json = "@emscripten_bin_mac_arm64//:emscripten/package.json",
+            package_lock_json = "@emscripten_bin_mac_arm64//:emscripten/package-lock.json",
         )
 
     if "emscripten_npm_win" not in excludes:

--- a/bazel/emscripten_toolchain/emscripten_config
+++ b/bazel/emscripten_toolchain/emscripten_config
@@ -8,5 +8,7 @@ LLVM_ROOT = BINARYEN_ROOT + "/bin"
 FROZEN_CACHE = True
 
 system = platform.system()
+
+machine = "arm64" if platform.machine() == "arm64" else "amd64"
 nodejs_binary = "bin/nodejs/node.exe" if(system =="Windows") else "bin/node"
-NODE_JS = ROOT_DIR + "/external/nodejs_{}_amd64/{}".format(system.lower(), nodejs_binary)
+NODE_JS = ROOT_DIR + "/external/nodejs_{}_{}/{}".format(system.lower(), machine, nodejs_binary)

--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -12,6 +12,7 @@ EMSCRIPTEN_TAGS = {
         hash = "6626e25d6d866cf283147ca68d54ac9326fe399f",
         sha_linux = "4fb53364a2ba1de8978445aa26b2204bfd215b41da5d7df04f231040b197010a",
         sha_mac = "a8e347accb1ff402d96a128912ac8cda1731611c9f89095fee0ad39a6a18bbc3",
+        sha_mac_arm64 = "4374f5c852d0403b0a3b0e9dc8a3856a340e9d82ecf0f20aa8b36c6179d31fc8",
         sha_win = "e96f6ab8252fefa42f461676311d4c4e2d96fdc2e876ece07d9d7a49ef31aef0",
     ),
     "3.1.1": struct(
@@ -48,6 +49,7 @@ EMSCRIPTEN_TAGS = {
         hash = "cef8850d57278271766fb2163eebcb07354018e7",
         sha_linux = "958a0f4b1533e877c1a5ed3c13cb8baabc80e791d45858c2c94ac62325ada953",
         sha_mac = "8ecb248653d44c3748e23c089cb9f0e3d4eee7cda13fdec27ec0113b896e34c4",
+        sha_mac_arm64 = "1ec6f3d7afa5e10f3af996e26d9c3a66f02ae49e48e512a4b5d6b7165c61290f",
         sha_win = "6b6b2831f8b338488f787b4a8c34700277bf3988358dbb54426f017155603ac9",
     ),
     "2.0.32": struct(

--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -6,6 +6,7 @@ EMSCRIPTEN_TAGS = {
         hash = "2ddc66235392b37e5b33477fd86cbe01a14b8aa2",
         sha_linux = "8b840819eb88f9178c11bad25859ce448a0559e485823a863a6add21380636ca",
         sha_mac = "0cb3f9bfbcc744233eae9d20036155738409405eacf8a3d4f9beefc5919d809a",
+        sha_mac_arm64 = "ee2772f380419df17d154e00388a16bcddc78c7af035c16a2ee534d6ecf099aa",
         sha_win = "c0549e1dbaa581ae66934c38beebd4250cd450cc2778e9a602cd9431bc81bc37",
     ),
     "3.1.2": struct(

--- a/scripts/update_bazel_workspace.sh
+++ b/scripts/update_bazel_workspace.sh
@@ -34,16 +34,16 @@ if [[ $ERR = 1 ]]; then
 fi
 
 URL1=https://storage.googleapis.com/webassembly/emscripten-releases-builds/
-URL2=/wasm-binaries.
+URL2=/wasm-binaries
 
 # Get commit hash for $1 version
 get_hash () {
-  echo $(grep "$1" emscripten-releases-tags.json | grep -v latest | cut -f4 -d\")
+  echo $(grep "$1" emscripten-releases-tags.json | grep -v latest | grep -v asserts | cut -f4 -d\")
 }
 
-# Get sha256 for $1 os $2 extname $3 hash
+# Get sha256 for $1 os $2 extname $3 hash $4 architecture
 get_sha () {
-  echo $(curl "${URL1}$1/$3${URL2}$2" 2>/dev/null | sha256sum | awk '{print $1}')
+  echo $(curl "${URL1}$1/$3${URL2}$4.$2" 2>/dev/null | sha256sum | awk '{print $1}')
 }
 
 # Assemble dictionary line
@@ -54,6 +54,7 @@ revisions_item () {
       "\       hash = \"$(get_hash ${hash})\",\n" \
       "\       sha_linux = \"$(get_sha linux tbz2 ${hash})\",\n" \
       "\       sha_mac = \"$(get_sha mac tbz2 ${hash})\",\n" \
+      "\       sha_mac_arm64 = \"$(get_sha mac tbz2 ${hash} -arm64)\",\n" \
       "\       sha_win = \"$(get_sha win zip ${hash})\",\n" \
       "\   ),"
 }


### PR DESCRIPTION
Add `macos_arm64` as a supported platform.