### PR TITLE
3.1.4

### DIFF
--- a/bazel/emscripten_toolchain/crosstool.bzl
+++ b/bazel/emscripten_toolchain/crosstool.bzl
@@ -911,7 +911,7 @@ def _impl(ctx):
                 "-iwithsysroot" + "/include/compat",
                 "-iwithsysroot" + "/include",
                 "-isystem",
-                emscripten_dir + "/lib/clang/14.0.0/include",
+                emscripten_dir + "/lib/clang/15.0.0/include",
             ],
         ),
         # Inputs and outputs
@@ -1073,7 +1073,7 @@ def _impl(ctx):
         emscripten_dir + "/emscripten/cache/sysroot/include/c++/v1",
         emscripten_dir + "/emscripten/cache/sysroot/include/compat",
         emscripten_dir + "/emscripten/cache/sysroot/include",
-        emscripten_dir + "/lib/clang/14.0.0/include",
+        emscripten_dir + "/lib/clang/15.0.0/include",
     ]
 
     artifact_name_patterns = []

--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -2,6 +2,13 @@
 # DO NOT MODIFY
 
 EMSCRIPTEN_TAGS = {
+    "3.1.4": struct(
+        hash = "39e60dda6945cfcd6487725bdb1361ae7975173f",
+        sha_linux = "4a57c0d60eeb4e021de61c8497f0b595a0a9db0235f1640a528de752409f4fcf",
+        sha_mac = "f28a9a4f42f67de1d5c4d8a288f29e5082bbf4fcb172e0c6e248695163372478",
+        sha_mac_arm64 = "be35043edad7a7022f7b174e8efc90e2db54ba4fd71288760bea4db082835f56",
+        sha_win = "d97ff247bdfc7e839610cbcd87d30a65018f964d183d5b852b6021d43c5d199a",
+    ),
     "3.1.3": struct(
         hash = "2ddc66235392b37e5b33477fd86cbe01a14b8aa2",
         sha_linux = "8b840819eb88f9178c11bad25859ce448a0559e485823a863a6add21380636ca",

--- a/emscripten-releases-tags.json
+++ b/emscripten-releases-tags.json
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "latest": "3.1.3",
+    "latest": "3.1.4",
     "latest-sdk": "latest",
     "latest-64bit": "latest",
     "sdk-latest-64bit": "latest",
@@ -9,6 +9,8 @@
     "latest-releases-upstream": "latest"
   },
   "releases": {
+    "3.1.4": "39e60dda6945cfcd6487725bdb1361ae7975173f",
+    "3.1.4-asserts": "05edbd634e300fc79ce0f635251bd5bef375328b",
     "3.1.3": "2ddc66235392b37e5b33477fd86cbe01a14b8aa2",
     "3.1.3-asserts": "66aaf7da980346898a84e3e1b70477286e225eec",
     "3.1.2": "6626e25d6d866cf283147ca68d54ac9326fe399f",


### PR DESCRIPTION
Update emscripten-releases tags, and update Bazel include paths to match the new clang version number.