### PR TITLE
Fix native Closure Compiler to work.

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1440,6 +1440,7 @@ def emscripten_npm_install(tool, directory):
     except KeyError as e:
       # The target version of Emscripten does not (did not) have a package.json that would contain google-closure-compiler. (fastcomp)
       # Skip manual native google-closure-compiler installation there.
+      print(str(e))
       print('Emscripten version does not have a npm package.json with google-closure-compiler dependency, skipping native google-closure-compiler install step')
       return True
 

--- a/emsdk.py
+++ b/emsdk.py
@@ -1439,16 +1439,22 @@ def emscripten_npm_install(tool, directory):
         cwd=directory, stderr=subprocess.STDOUT, env=env,
         universal_newlines=True)
 
-      # Now that we succeeded to install the native version, delete the Java version
-      # since that takes up ~12.5MB of installation space that is no longer needed
-      # as we have a native version of the compiler instead.
-      # This process is currently a little bit hacky, see https://github.com/google/closure-compiler/issues/3926
-      remove_tree(os.path.join(directory, 'node_modules', 'google-closure-compiler-java'))
-
       # Remove import of Java Closure Compiler module.
       compiler_filename = os.path.join(directory, 'node_modules', 'google-closure-compiler', 'lib', 'node', 'closure-compiler.js')
-      compiler_js = open(compiler_filename, 'r').read().replace("require('google-closure-compiler-java')", "''/*require('google-closure-compiler-java') XXX Removed by Emsdk*/")
-      open(compiler_filename, 'w').write(compiler_js)
+      if os.path.isfile(compiler_filename):
+        old_js = open(compiler_filename, 'r').read()
+        new_js = old_js.replace("require('google-closure-compiler-java')", "''/*require('google-closure-compiler-java') XXX Removed by Emsdk*/")
+        if old_js == new_js:
+          raise Exception('Failed to patch google-closure-compiler-java dependency away!')
+        open(compiler_filename, 'w').write(new_js)
+
+        # Now that we succeeded to install the native version and patch away the Java dependency, delete the Java version
+        # since that takes up ~12.5MB of installation space that is no longer needed.
+        # This process is currently a little bit hacky, see https://github.com/google/closure-compiler/issues/3926
+        remove_tree(os.path.join(directory, 'node_modules', 'google-closure-compiler-java'))
+        print('Removed google-closure-compiler-java dependency.')
+      else:
+        errlog('Failed to patch away google-closure-compiler Java dependency. ' + compiler_filename + ' does not exist.')
     except subprocess.CalledProcessError as e:
       errlog('Error running %s:\n%s' % (e.cmd, e.output))
       return False

--- a/emsdk.py
+++ b/emsdk.py
@@ -1421,6 +1421,7 @@ def emscripten_npm_install(tool, directory):
   #      30MB to almost 300MB
   #      https://github.com/google/closure-compiler-npm/issues/186
   # If either of these bugs are fixed then we can remove this exception
+  # See also https://github.com/google/closure-compiler/issues/3925
   closure_compiler_native = ''
   if LINUX and ARCH in ('x86', 'x86_64'):
     closure_compiler_native = 'google-closure-compiler-linux'

--- a/emsdk.py
+++ b/emsdk.py
@@ -1435,7 +1435,14 @@ def emscripten_npm_install(tool, directory):
   if closure_compiler_native:
     # Check which version of native Closure Compiler we want to install via npm.
     # (npm install command has this requirement that we must explicitly tell the pinned version)
-    closure_version = json.load(open(os.path.join(directory, 'package.json')))['dependencies']['google-closure-compiler']
+    try:
+      closure_version = json.load(open(os.path.join(directory, 'package.json')))['dependencies']['google-closure-compiler']
+    except KeyError as e:
+      # The target version of Emscripten does not (did not) have a package.json that would contain google-closure-compiler. (fastcomp)
+      # Skip manual native google-closure-compiler installation there.
+      print('Emscripten version does not have a npm package.json with google-closure-compiler dependency, skipping native google-closure-compiler install step')
+      return True
+
     closure_compiler_native += '@' + closure_version
     print('Running post-install step: npm install', closure_compiler_native)
     try:


### PR DESCRIPTION
Fix native Closure Compiler to work.

Reverts my earlier PR #803 which was a great mistake, as it caused Emscripten to silently fall back to Java version of the Closure Compiler.

After this PR, Closure Compiler will work on user platforms that do not have Java installed.

Also forcibly remove Java version of Closure Compiler on systems where installing the native version succeeds, in order to save on disk size.