### PR TITLE
Fix macOS build

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1071,14 +1071,14 @@ def cmake_configure(generator, build_root, src_root, build_type, extra_cmake_arg
     cmdline = ['cmake'] + generator + ['-DCMAKE_BUILD_TYPE=' + build_type, '-DPYTHON_EXECUTABLE=' + sys.executable]
     # Target macOS 10.11 at minimum, to support widest range of Mac devices from "Mid 2007" and newer:
     # https://en.wikipedia.org/wiki/MacBook_Pro#Supported_macOS_releases
-    cmdline += ['-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11']
+    cmdline += ['-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14']
     cmdline += extra_cmake_args + [src_root]
 
     print('Running CMake: ' + str(cmdline))
 
     # Specify the deployment target also as an env. var, since some Xcode versions
     # read this instead of the CMake field.
-    os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.11'
+    os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.14'
 
     def quote_parens(x):
       if ' ' in x:

--- a/emsdk.py
+++ b/emsdk.py
@@ -1069,8 +1069,8 @@ def cmake_configure(generator, build_root, src_root, build_type, extra_cmake_arg
       generator = []
 
     cmdline = ['cmake'] + generator + ['-DCMAKE_BUILD_TYPE=' + build_type, '-DPYTHON_EXECUTABLE=' + sys.executable]
-    # Target macOS 10.11 at minimum, to support widest range of Mac devices from "Mid 2007" and newer:
-    # https://en.wikipedia.org/wiki/MacBook_Pro#Supported_macOS_releases
+    # Target macOS 10.14 at minimum, to support widest range of Mac devices from "Early 2008" and newer:
+    # https://en.wikipedia.org/wiki/MacBook_(2006–2012)#Supported_operating_systems
     cmdline += ['-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14']
     cmdline += extra_cmake_args + [src_root]
 


### PR DESCRIPTION
Emsdk is unable to build Binaryen from source on macOS since Binaryen adopted new libstdc++ that required a newer macOS, issue https://github.com/WebAssembly/binaryen/issues/4299

Bump the minimum build requirement up to that version.