### PR TITLE
Switch to nuget python package for windows

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -422,6 +422,15 @@
   },
   {
     "id": "python",
+    "version": "3.9.2-nuget",
+    "bitness": 64,
+    "arch": "x86_64",
+    "windows_url": "python-3.9.2-4-amd64+pywin32.zip",
+    "activated_cfg": "PYTHON='%installation_dir%/python.exe'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python.exe"
+  },
+  {
+    "id": "python",
     "version": "3.9.2",
     "bitness": 64,
     "arch": "x86_64",
@@ -644,7 +653,7 @@
   {
     "version": "upstream-main",
     "bitness": 64,
-    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
@@ -727,7 +736,7 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.9.2-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   },


### PR DESCRIPTION
Previously we were using the "embedded" version python which has caused
us a few problems over time.  Currently the issue is that it does not include
pip.  This is a more normal distribution of python that does include pip.

Fixes https://github.com/emscripten-core/emscripten/issues/16466