### PR TITLE
Add prebuilt binaries of 3.1.7 for linux/arm64

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -42,7 +42,7 @@ emsdk_packages_url = 'https://storage.googleapis.com/webassembly/emscripten-rele
 
 emscripten_releases_repo = 'https://chromium.googlesource.com/emscripten-releases'
 
-emscripten_releases_download_url_template = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/%s/%s/wasm-binaries.%s"
+emscripten_releases_download_url_template = "https://storage.googleapis.com/webassembly/emscripten-releases-builds/%s/%s/wasm-binaries%s.%s"
 
 # This was previously `master.zip` but we are transitioning to `main` and
 # `HEAD.zip` works for both cases.  In future we could switch this to
@@ -2166,10 +2166,14 @@ def get_emscripten_releases_tot():
   # The recent releases are the latest hashes in the git repo. There
   # may not be a build for the most recent ones yet; find the last
   # that does.
+  arch = ''
+  if ARCH == 'aarch64':
+    arch = '-arm64'
   for release in recent_releases:
     url = emscripten_releases_download_url_template % (
       os_name(),
       release,
+      arch,
       'tbz2' if not WINDOWS else 'zip'
     )
     try:

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -108,6 +108,7 @@
     "bitness": 64,
     "arch": "aarch64",
     "macos_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/mac/%releases-tag%/wasm-binaries-arm64.tbz2",
+    "linux_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/linux/%releases-tag%/wasm-binaries-arm64.tbz2",
     "zipfile_prefix": "%releases-tag%-",
     "install_path": "upstream",
     "activated_path": "%installation_dir%/emscripten",


### PR DESCRIPTION
Thanks for @otterley for doing that hard work of actually building these binaries.

I basically uploaded them and then did and confirmed they are installable have have the right architecture:

```
$ EMSDK_ARCH=aarch64 ./emsdk install 3.1.7
$ file upstream/bin/clang-15 
upstream/bin/clang-15: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[xxHash]=15798223cc2ffa5f, not stripped
```
