### PR TITLE
Remove non-ascii char from emsdk.py. NFC

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1034,7 +1034,7 @@ def cmake_configure(generator, build_root, src_root, build_type, extra_cmake_arg
 
     cmdline = ['cmake'] + generator + ['-DCMAKE_BUILD_TYPE=' + build_type, '-DPYTHON_EXECUTABLE=' + sys.executable]
     # Target macOS 10.14 at minimum, to support widest range of Mac devices from "Early 2008" and newer:
-    # https://en.wikipedia.org/wiki/MacBook_(2006–2012)#Supported_operating_systems
+    # https://en.wikipedia.org/wiki/MacBook_(2006-2012)#Supported_operating_systems
     cmdline += ['-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14']
     cmdline += extra_cmake_args + [src_root]
 


### PR DESCRIPTION
This was introduced by mistake in #996 and cause `Emsdk.test_no_32bit` to fail.