### PR TITLE
3.1.8

### DIFF
--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -2,6 +2,13 @@
 # DO NOT MODIFY
 
 EMSCRIPTEN_TAGS = {
+    "3.1.8": struct(
+        hash = "8c9e0a76ebed2c5e88a718d43e8b62452def3771",
+        sha_linux = "6b170777eb523e62972ad458e533b1853cd0c4e02f6f2cf4cd68e109499ccd9b",
+        sha_mac = "ede01fe160c3b8443f53f94dbad530e0e7e8197a1b874c7bb9038b187279080c",
+        sha_mac_arm64 = "9ecc8678f948875e7f64defeababc0320f98e103547f395c390c01d76e5a1d64",
+        sha_win = "039d27d4ae43b50d0858dbc4dcf412f572351e98e1056d7fdcdf2aab1740557e",
+    ),
     "3.1.7": struct(
         hash = "d0e637fe48197587d981f79e8114757731d0c2a9",
         sha_linux = "d941738a3c755d6d530bab66d38325515b9dbaa588d2db2b8a63b2a8a1961e52",

--- a/emscripten-releases-tags.json
+++ b/emscripten-releases-tags.json
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "latest": "3.1.7",
+    "latest": "3.1.8",
     "latest-sdk": "latest",
     "latest-64bit": "latest",
     "sdk-latest-64bit": "latest",
@@ -9,6 +9,8 @@
     "latest-releases-upstream": "latest"
   },
   "releases": {
+    "3.1.8": "8c9e0a76ebed2c5e88a718d43e8b62452def3771",
+    "3.1.8-asserts": "d33ae3c8d16f04b004b76c1d7c1989d637aa36e0",
     "3.1.7": "d0e637fe48197587d981f79e8114757731d0c2a9",
     "3.1.7-asserts": "88f0cab4e7db846e171cbbbbf20cc1a51b8c779f",
     "3.1.6": "8791c3e936141cbc2dd72d76290ea9b2726d39f3",


### PR DESCRIPTION
The mac builder timed because it took over 7 hours!  But only have it had run build everything and
run all of the `other` tests an some of the `core` tests.. so I don't think there is any cause for concern.