### PR TITLE
Set environment for powershell on all platforms

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2461,7 +2461,7 @@ def process_tool_list(tools_to_activate):
 
 
 def write_set_env_script(env_string):
-  assert(WINDOWS)
+  assert(CMD or POWERSHELL)
   open(EMSDK_SET_ENV, 'w').write(env_string)
 
 
@@ -2478,18 +2478,18 @@ def set_active_tools(tools_to_activate, permanently_activate, system):
 
   generate_dot_emscripten(tools_to_activate)
 
-  # Construct a .bat script that will be invoked to set env. vars and PATH
-  # We only do this on windows since emsdk.bat is able to modify the
-  # calling shell environment.  On other platform `source emsdk_env.sh` is
+  # Construct a .bat or .ps1 script that will be invoked to set env. vars and PATH
+  # We only do this on cmd or powershell since emsdk.bat/ps1 is able to modify the
+  # calling shell environment.  On other shell `source emsdk_env.sh` is
   # required.
-  if WINDOWS:
+  if CMD or POWERSHELL:
     # always set local environment variables since permanently activating will only set the registry settings and
     # will not affect the current session
     env_vars_to_add = get_env_vars_to_add(tools_to_activate, system, user=permanently_activate)
     env_string = construct_env_with_vars(env_vars_to_add)
     write_set_env_script(env_string)
 
-    if permanently_activate:
+    if WINDOWS and permanently_activate:
       win_set_environment_variables(env_vars_to_add, system, user=permanently_activate)
 
   return tools_to_activate
@@ -3101,7 +3101,7 @@ def main(args):
     tools_to_activate = currently_active_tools()
     tools_to_activate = process_tool_list(tools_to_activate)
     env_string = construct_env(tools_to_activate, arg_system, arg_permanent)
-    if WINDOWS and not BASH:
+    if CMD or POWERSHELL:
       write_set_env_script(env_string)
     else:
       sys.stdout.write(env_string)


### PR DESCRIPTION
## Before this PR

Running ` . ./emsdk_env.ps1` on Linux PowerShell (`pwsh`) only output `Setting environment variables`, but **none
of these variables are set actually**.

```pwsh
PS /home/kyaru/projects/emsdk> . ./emsdk_env.ps1
Adding directories to PATH: ...
Setting environment variables: ...

PS /home/kyaru/projects/emsdk> emsdk
emsdk: The term 'emsdk' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

## Solution

Decide whether to call `write_set_env_script` or not by checking current shell, not platform.

## After this PR

The script works on all platforms.

```pwsh
PS /home/kyaru/projects/emsdk> . ./emsdk_env.ps1
Adding directories to PATH: ...
Setting environment variables: ...

PS /home/kyaru/projects/emsdk> emsdk
Missing command; Type 'emsdk help' to get a list of commands.
```
