### PR TITLE
Cache git executable search into a variable.

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -743,6 +743,7 @@ cached_git_executable = None
 #               If true, the search is required to succeed, and the execution
 #               will terminate with sys.exit(1) if not found.
 def GIT(must_succeed=True):
+  global cached_git_executable
   if cached_git_executable is not None:
     return cached_git_executable
   # The order in the following is important, and specifies the preferred order

--- a/emsdk.py
+++ b/emsdk.py
@@ -734,7 +734,9 @@ def run_get_output(cmd, cwd=None):
   stdout, stderr = process.communicate()
   return (process.returncode, stdout, stderr)
 
+
 cached_git_executable = None
+
 
 # must_succeed: If false, the search is performed silently without printing out
 #               errors if not found. Empty string is returned if git is not found.

--- a/emsdk.py
+++ b/emsdk.py
@@ -734,12 +734,15 @@ def run_get_output(cmd, cwd=None):
   stdout, stderr = process.communicate()
   return (process.returncode, stdout, stderr)
 
+cached_git_executable = None
 
 # must_succeed: If false, the search is performed silently without printing out
 #               errors if not found. Empty string is returned if git is not found.
 #               If true, the search is required to succeed, and the execution
 #               will terminate with sys.exit(1) if not found.
 def GIT(must_succeed=True):
+  if cached_git_executable is not None:
+    return cached_git_executable
   # The order in the following is important, and specifies the preferred order
   # of using the git tools.  Primarily use git from emsdk if installed. If not,
   # use system git.
@@ -748,6 +751,7 @@ def GIT(must_succeed=True):
     try:
       ret, stdout, stderr = run_get_output([git, '--version'])
       if ret == 0:
+        cached_git_executable = git
         return git
     except:
       pass


### PR DESCRIPTION
Cache git executable search into a variable. This helps reduce noise in the verbose debug logging output messages when EMSDK_VERBOSE=1 is enabled.