### PR TITLE
Add windows download location to python search path - to match manifest

### DIFF
--- a/emsdk.ps1
+++ b/emsdk.ps1
@@ -2,6 +2,7 @@ $ScriptDirectory = Split-Path -parent $PSCommandPath
 
 $PythonLocations = $(
     "python\3.9.2-1_64bit\python.exe",
+    "python\3.9.2-nuget_64bit\python.exe",
     "python\3.7.4-pywin32_64bit\python.exe",
     "python\3.7.4_64bit\python.exe",
     "python\2.7.13.1_64bit\python-2.7.13.amd64\python.exe",


### PR DESCRIPTION
Fixes: https://github.com/emscripten-core/emsdk/issues/1023 

The downloaded location for python on windows does not match the manifest and hence will not be found.  The system will attempt to default to python found in the path.  (although I think the Powershell for that fallback mechanism does not work in strict mode - fails with `The variable '$EMSDK_PY' cannot be retrieved because it has not been set.` - another story)  .  

This PR adds the location I have observed on my machine for the download and install location of Python to emsdk's search list

![image](https://user-images.githubusercontent.com/2720041/162584135-7f95c299-289c-48b8-a1be-2c9f8020abb3.png)

