### PR TITLE
Pass -DENABLE_WERROR=0 when building Binaryen

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1538,7 +1538,7 @@ def build_binaryen_tool(tool):
   build_type = decide_cmake_build_type(tool)
 
   # Configure
-  args = ['-DENABLE_WERROR=0'] # -Werror is not useful for end users
+  args = ['-DENABLE_WERROR=0']  # -Werror is not useful for end users
 
   cmake_generator = CMAKE_GENERATOR
   if 'Visual Studio 16' in CMAKE_GENERATOR:  # VS2019

--- a/emsdk.py
+++ b/emsdk.py
@@ -1538,7 +1538,7 @@ def build_binaryen_tool(tool):
   build_type = decide_cmake_build_type(tool)
 
   # Configure
-  args = []
+  args = ['-DENABLE_WERROR=0'] # -Werror is not useful for end users
 
   cmake_generator = CMAKE_GENERATOR
   if 'Visual Studio 16' in CMAKE_GENERATOR:  # VS2019


### PR DESCRIPTION
We are experiencing an issue at our Unity CI with building Binaryen: https://github.com/WebAssembly/binaryen/issues/4588

It seems that for end users, disabling -Werror is a good general measure to enable wider chance of success to build. Emsdk installations are unlikely to be used by Binaryen developers to iterate on Binaryen development, so it is not necessary there?