### PR TITLE
[bazel] Switch to platforms-based toolchain resolution

### DIFF
--- a/bazel/.bazelrc
+++ b/bazel/.bazelrc
@@ -1,0 +1,1 @@
+build --incompatible_enable_cc_toolchain_resolution

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -66,3 +66,10 @@ alias(
         "//conditions:default": ":empty",
     }),
 )
+
+platform(
+    name = "platform_wasm",
+    constraint_values = [
+        "@platforms//cpu:wasm32",
+    ],
+)

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -17,6 +17,9 @@ emsdk_deps()
 
 load("@emsdk//:emscripten_deps.bzl", emsdk_emscripten_deps = "emscripten_deps")
 emsdk_emscripten_deps(emscripten_version = "2.0.31")
+
+load("@emsdk//:toolchains.bzl", "register_emscripten_toolchains")
+register_emscripten_toolchains()
 ```
 The SHA1 hash in the above `strip_prefix` and `url` parameters correspond to the git revision of
 [emsdk 2.0.31](https://github.com/emscripten-core/emsdk/releases/tag/2.0.31). To get access to
@@ -26,7 +29,6 @@ parameter of `emsdk_emscripten_deps()`. Supported versions are listed in `revisi
 
 ## Building
 
-### Using wasm_cc_binary (preferred)
 First, write a new rule wrapping your `cc_binary`.
 
 ```
@@ -54,17 +56,3 @@ and all of its dependencies, and does not require amending `.bazelrc`. This
 is the preferred way, since it also unpacks the resulting tarball.
 
 See `test_external/` for an example using [embind](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html).
-
-### Using --config=wasm
-
-Put the following lines into your `.bazelrc`:
-```
-build:wasm --crosstool_top=@emsdk//emscripten_toolchain:everything
-build:wasm --cpu=wasm
-build:wasm --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
-```
-
-Simply pass `--config=wasm` when building a normal `cc_binary`. The result of
-this build will be a tar archive containing any files produced by emscripten.
-See the [Bazel documentation](https://docs.bazel.build/versions/main/tutorial/cc-toolchain-config.html)
-for more details

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -29,7 +29,13 @@ parameter of `emsdk_emscripten_deps()`. Supported versions are listed in `revisi
 
 ## Building
 
-First, write a new rule wrapping your `cc_binary`.
+Put the following line into your `.bazelrc`:
+
+```
+build --incompatible_enable_cc_toolchain_resolution
+```
+
+Then write a new rule wrapping your `cc_binary`.
 
 ```
 load("@rules_cc//cc:defs.bzl", "cc_binary")

--- a/bazel/WORKSPACE
+++ b/bazel/WORKSPACE
@@ -7,3 +7,7 @@ deps()
 load(":emscripten_deps.bzl", "emscripten_deps")
 
 emscripten_deps()
+
+load(":toolchains.bzl", "register_emscripten_toolchains")
+
+register_emscripten_toolchains()

--- a/bazel/bazelrc
+++ b/bazel/bazelrc
@@ -1,0 +1,2 @@
+build:wasm --incompatible_enable_cc_toolchain_resolution
+build:wasm --platforms=@emsdk//:platform_wasm

--- a/bazel/bazelrc
+++ b/bazel/bazelrc
@@ -1,5 +1,0 @@
-build:wasm --crosstool_top=//emscripten_toolchain:everything
-
-build:wasm --cpu=wasm
-
-build:wasm --host_crosstool_top=@bazel_tools//tools/cpp:toolchain

--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -1,4 +1,4 @@
-load(":crosstool.bzl", "emscripten_cc_toolchain_config_rule")
+load(":toolchain.bzl", "emscripten_cc_toolchain_config_rule")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -84,6 +84,13 @@ cc_toolchain_suite(
         "wasm": ":cc-compiler-wasm",
         "wasm|emscripten": ":cc-compiler-wasm",
     },
+)
+
+toolchain(
+    name = "cc-toolchain-wasm",
+    target_compatible_with = ["@platforms//cpu:wasm32"],
+    toolchain = ":cc-compiler-wasm",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
 py_binary(

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -1105,7 +1105,7 @@ emscripten_cc_toolchain_config_rule = rule(
     attrs = {
         "cpu": attr.string(mandatory = True, values = ["asmjs", "wasm"]),
         "em_config": attr.label(mandatory = True, allow_single_file = True),
-        "emscripten_binaries": attr.label(mandatory = True),
+        "emscripten_binaries": attr.label(mandatory = True, cfg = "exec"),
         "script_extension": attr.string(mandatory = True, values = ["sh", "bat"]),
     },
     provides = [CcToolchainConfigInfo],

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -26,13 +26,10 @@ def _wasm_transition_impl(settings, attr):
         features.append("wasm_simd")
 
     return {
-        "//command_line_option:compiler": "emscripten",
-        "//command_line_option:crosstool_top": "@emsdk//emscripten_toolchain:everything",
-        "//command_line_option:cpu": "wasm",
         "//command_line_option:features": features,
         "//command_line_option:dynamic_mode": "off",
         "//command_line_option:linkopt": linkopts,
-        "//command_line_option:platforms": [],
+        "//command_line_option:platforms": ["@emsdk//:platform_wasm"],
         "//command_line_option:custom_malloc": "@emsdk//emscripten_toolchain:malloc",
     }
 
@@ -43,9 +40,6 @@ _wasm_transition = transition(
         "//command_line_option:linkopt",
     ],
     outputs = [
-        "//command_line_option:compiler",
-        "//command_line_option:cpu",
-        "//command_line_option:crosstool_top",
         "//command_line_option:features",
         "//command_line_option:dynamic_mode",
         "//command_line_option:linkopt",

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -26,6 +26,9 @@ def _wasm_transition_impl(settings, attr):
         features.append("wasm_simd")
 
     return {
+        "//command_line_option:compiler": "emscripten",
+        "//command_line_option:crosstool_top": "@emsdk//emscripten_toolchain:everything",
+        "//command_line_option:cpu": "wasm",
         "//command_line_option:features": features,
         "//command_line_option:dynamic_mode": "off",
         "//command_line_option:linkopt": linkopts,
@@ -40,6 +43,9 @@ _wasm_transition = transition(
         "//command_line_option:linkopt",
     ],
     outputs = [
+        "//command_line_option:compiler",
+        "//command_line_option:cpu",
+        "//command_line_option:crosstool_top",
         "//command_line_option:features",
         "//command_line_option:dynamic_mode",
         "//command_line_option:linkopt",

--- a/bazel/test_external/.bazelrc
+++ b/bazel/test_external/.bazelrc
@@ -1,0 +1,1 @@
+build --incompatible_enable_cc_toolchain_resolution

--- a/bazel/test_external/WORKSPACE
+++ b/bazel/test_external/WORKSPACE
@@ -10,3 +10,7 @@ deps()
 load("@emsdk//:emscripten_deps.bzl", "emscripten_deps")
 
 emscripten_deps()
+
+load("@emsdk//:toolchains.bzl", "register_emscripten_toolchains")
+
+register_emscripten_toolchains()

--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -1,0 +1,2 @@
+def register_emscripten_toolchains():
+    native.register_toolchains(str(Label("//emscripten_toolchain:cc-toolchain-wasm")))


### PR DESCRIPTION
Fixes #984. However, the way I have done it requires `--incompatible_enable_cc_toolchain_resolution` and no longer supports `--crosstool_top=...`. I'm not sure how to support both at the same time. If that's necessary, can someone give me pointers on how to do it?