### PR TITLE
Optimize sandbox performance

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -35,23 +35,34 @@ config_setting(
 filegroup(name = "empty")
 
 alias(
-    name = "binaries",
+    name = "compiler_files",
     actual = select({
-        ":linux": "@emscripten_bin_linux//:all",
-        ":macos": "@emscripten_bin_mac//:all",
-        ":macos_arm64": "@emscripten_bin_mac_arm64//:all",
-        ":windows": "@emscripten_bin_win//:all",
+        ":linux": "@emscripten_bin_linux//:compiler_files",
+        ":macos": "@emscripten_bin_mac//:compiler_files",
+        ":macos_arm64": "@emscripten_bin_mac_arm64//:compiler_files",
+        ":windows": "@emscripten_bin_win//:compiler_files",
         "//conditions:default": ":empty",
     }),
 )
 
 alias(
-    name = "node_modules",
+    name = "linker_files",
     actual = select({
-        ":linux": "@emscripten_npm_linux//:node_modules",
-        ":macos": "@emscripten_npm_mac//:node_modules",
-        ":macos_arm64": "@emscripten_npm_mac//:node_modules",
-        ":windows": "@emscripten_npm_win//:node_modules",
+        ":linux": "@emscripten_bin_linux//:linker_files",
+        ":macos": "@emscripten_bin_mac//:linker_files",
+        ":macos_arm64": "@emscripten_bin_mac_arm64//:linker_files",
+        ":windows": "@emscripten_bin_win//:linker_files",
+        "//conditions:default": ":empty",
+    }),
+)
+
+alias(
+    name = "ar_files",
+    actual = select({
+        ":linux": "@emscripten_bin_linux//:ar_files",
+        ":macos": "@emscripten_bin_mac//:ar_files",
+        ":macos_arm64": "@emscripten_bin_mac_arm64//:ar_files",
+        ":windows": "@emscripten_bin_win//:ar_files",
         "//conditions:default": ":empty",
     }),
 )

--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -8,44 +8,52 @@ package(default_visibility = ["//visibility:public"])
 node_files = "@nodejs_host//:node_files" if existing_rule("@nodejs_host//:node_files") else "@nodejs//:node_files"
 
 filegroup(
-    name = "common-script-includes",
+    name = "common_files",
     srcs = [
-        "emar.sh",
-        "emar.bat",
-        "emcc.sh",
-        "emcc.bat",
         "emscripten_config",
         "env.sh",
         "env.bat",
-        "@emsdk//:binaries",
-        "@emsdk//:node_modules",
         node_files,
     ],
 )
 
 filegroup(
-    name = "compile-emscripten",
-    srcs = [":common-script-includes"],
+    name = "compiler_files",
+    srcs = [
+        "emcc.sh",
+        "emcc.bat",
+        "@emsdk//:compiler_files",
+        ":common_files",
+    ],
 )
 
 filegroup(
-    name = "link-emscripten",
+    name = "linker_files",
     srcs = [
         "emcc_link.sh",
         "emcc_link.bat",
         "link_wrapper.py",
-        ":common-script-includes",
-        "@emsdk//:binaries",
-        node_files,
+        "@emsdk//:linker_files",
+        ":common_files",
     ],
 )
 
 filegroup(
-    name = "every-file",
+    name = "ar_files",
     srcs = [
-        ":compile-emscripten",
-        ":link-emscripten",
-        "@emsdk//:binaries",
+        "emar.sh",
+        "emar.bat",
+        "@emsdk//:ar_files",
+        ":common_files",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":compiler_files",
+        ":linker_files",
+        ":ar_files",
         node_files,
     ],
 )
@@ -59,7 +67,7 @@ emscripten_cc_toolchain_config_rule(
     name = "wasm",
     cpu = "wasm",
     em_config = "emscripten_config",
-    emscripten_binaries = "@emsdk//:binaries",
+    emscripten_binaries = "@emsdk//:compiler_files",
     script_extension = select({
         "@bazel_tools//src/conditions:host_windows": "bat",
         "//conditions:default": "sh",
@@ -68,12 +76,12 @@ emscripten_cc_toolchain_config_rule(
 
 cc_toolchain(
     name = "cc-compiler-wasm",
-    all_files = ":every-file",
-    ar_files = ":common-script-includes",
+    all_files = ":all_files",
+    ar_files = ":ar_files",
     as_files = ":empty",
-    compiler_files = ":compile-emscripten",
+    compiler_files = ":compiler_files",
     dwp_files = ":empty",
-    linker_files = ":link-emscripten",
+    linker_files = ":linker_files",
     objcopy_files = ":empty",
     strip_files = ":empty",
     toolchain_config = "wasm",

--- a/bazel/emscripten_toolchain/emscripten.BUILD
+++ b/bazel/emscripten_toolchain/emscripten.BUILD
@@ -1,6 +1,41 @@
 package(default_visibility = ['//visibility:public'])
 
 filegroup(
-    name = "all",
-    srcs = glob(["**"]),
+    name = "includes",
+    srcs = glob([
+        "emscripten/cache/sysroot/include/c++/v1/**",
+        "emscripten/cache/sysroot/include/compat/**",
+        "emscripten/cache/sysroot/include/**",
+        "lib/clang/15.0.0/include/**",
+    ]),
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        "emscripten/emcc.py",
+        "bin/clang",
+        "bin/clang++",
+        ":includes",
+    ],
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        "emscripten/emcc.py",
+        "bin/llvm-nm",
+        "bin/llvm-objcopy",
+        "bin/wasm-emscripten-finalize",
+        "bin/wasm-ld",
+        "bin/wasm-opt",
+   ],
+)
+
+filegroup(
+    name = "ar_files",
+    srcs = [
+        "emscripten/emar.py",
+        "bin/llvm-ar",
+   ],
 )


### PR DESCRIPTION
Link just the files needed to compile, link, or archive, rather than the entire directory tree. This drastically improves build times on macOS, where the sandbox is known to be slow (https://github.com/bazelbuild/bazel/issues/8230).

Fixes https://github.com/emscripten-core/emsdk/issues/1026