### PR TITLE
Using bazelisk on macOS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,9 +201,9 @@ jobs:
       - checkout
       - run: brew install grep
       - run:
-          name: install bazel
+          name: install bazelisk
           command: |
-            brew install bazel
+            brew install bazelisk
       - run: test/test_bazel_mac.sh
 
   test-bazel-windows:


### PR DESCRIPTION
Using `bazelisk` instead of an outdated version of bazel on macOS should unblock CI failures for #1036 and #1047