### PR TITLE
Add additional files necessary for building with closure and on RBE

### DIFF
--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -70,6 +70,7 @@ filegroup(
             "emscripten/src/**",
         ],
     ),
+)
 
 filegroup(
     name = "ar_files",

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -19,11 +19,32 @@ filegroup(
 )
 
 filegroup(
+    name = "emcc",
+    srcs = [
+        "emscripten/emcc.py",
+        "emscripten/emscripten.py",
+        "emscripten/emscripten-version.txt",
+        "emscripten/cache/sysroot_install.stamp",
+        "emscripten/src/settings.js",
+        "emscripten/src/settings_internal.js",
+    ] + glob(
+        include = [
+            "emscripten/third_party/**",
+            "emscripten/tools/**",
+        ],
+        exclude = [
+            "**/__pycache__/**",
+        ],
+    ),
+)
+
+filegroup(
     name = "compiler_files",
     srcs = [
         "emscripten/emcc.py",
         "bin/clang{bin_extension}",
         "bin/clang++{bin_extension}",
+        ":emcc",
         ":includes",
     ],
 )
@@ -40,15 +61,32 @@ filegroup(
         "bin/wasm-emscripten-finalize{bin_extension}",
         "bin/wasm-ld{bin_extension}",
         "bin/wasm-opt{bin_extension}",
-   ] + glob(["emscripten/node_modules/**"]),
-)
+        "bin/wasm-metadce{bin_extension}",
+        ":emcc",
+    ] + glob(
+        include = [
+            "emscripten/cache/sysroot/lib/**",
+            "emscripten/node_modules/**",
+            "emscripten/src/**",
+        ],
+    ),
 
 filegroup(
     name = "ar_files",
     srcs = [
-        "emscripten/emar.py",
         "bin/llvm-ar{bin_extension}",
-   ],
+        "emscripten/emar.py",
+        "emscripten/emscripten-version.txt",
+        "emscripten/src/settings.js",
+        "emscripten/src/settings_internal.js",
+    ] + glob(
+        include = [
+            "emscripten/tools/**",
+        ],
+        exclude = [
+            "**/__pycache__/**",
+        ],
+    ),
 )
 """
 

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -41,7 +41,6 @@ filegroup(
 filegroup(
     name = "compiler_files",
     srcs = [
-        "emscripten/emcc.py",
         "bin/clang{bin_extension}",
         "bin/clang++{bin_extension}",
         ":emcc",
@@ -52,7 +51,6 @@ filegroup(
 filegroup(
     name = "linker_files",
     srcs = [
-        "emscripten/emcc.py",
         "bin/clang{bin_extension}",
         "bin/llc{bin_extension}",
         "bin/llvm-ar{bin_extension}",

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -19,7 +19,7 @@ filegroup(
 )
 
 filegroup(
-    name = "emcc",
+    name = "emcc_common",
     srcs = [
         "emscripten/emcc.py",
         "emscripten/emscripten.py",
@@ -43,7 +43,7 @@ filegroup(
     srcs = [
         "bin/clang{bin_extension}",
         "bin/clang++{bin_extension}",
-        ":emcc",
+        ":emcc_common",
         ":includes",
     ],
 )
@@ -60,7 +60,7 @@ filegroup(
         "bin/wasm-ld{bin_extension}",
         "bin/wasm-opt{bin_extension}",
         "bin/wasm-metadce{bin_extension}",
-        ":emcc",
+        ":emcc_common",
     ] + glob(
         include = [
             "emscripten/cache/sysroot/lib/**",


### PR DESCRIPTION
With emsdk 3.1.13, I was unable to use Bazel compile [CanvasKit](https://github.com/google/skia/blob/main/modules/canvaskit/BUILD.bazel) locally in release mode or remotely in either debug or release mode.

Some files were missing from the specification, as [mentioned here](https://github.com/emscripten-core/emsdk/pull/1045#issuecomment-1121444545).

By specifying a few more files, it now works locally and remotely, while still being significantly faster than 3.1.0 (before #1045 landed).