### PR TITLE
Exclude msys from path fix function.

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -529,6 +529,8 @@ def untargz(source_filename, dest_dir):
 def fix_potentially_long_windows_pathname(pathname):
   if not WINDOWS:
     return pathname
+  if MSYS:
+    return pathname
   # Test if emsdk calls fix_potentially_long_windows_pathname() with long
   # relative paths (which is problematic)
   if not os.path.isabs(pathname) and len(pathname) > 200:

--- a/emsdk.py
+++ b/emsdk.py
@@ -527,9 +527,7 @@ def untargz(source_filename, dest_dir):
 # See https://msdn.microsoft.com/en-us/library/aa365247.aspx#maxpath and http://stackoverflow.com/questions/3555527/python-win32-filename-length-workaround
 # In that mode, forward slashes cannot be used as delimiters.
 def fix_potentially_long_windows_pathname(pathname):
-  if not WINDOWS:
-    return pathname
-  if MSYS:
+  if not WINDOWS or MSYS:
     return pathname
   # Test if emsdk calls fix_potentially_long_windows_pathname() with long
   # relative paths (which is problematic)


### PR DESCRIPTION
The `//?/` prefix does not work in the MSYS environment.
Excluding MSYS from the windows fix worked for me to install emscripten.