### PR TITLE
Add missing binaries for bazel

### DIFF
--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -53,12 +53,16 @@ filegroup(
     srcs = [
         "bin/clang{bin_extension}",
         "bin/llvm-ar{bin_extension}",
+        "bin/llvm-dwarfdump{bin_extension}",
         "bin/llvm-nm{bin_extension}",
         "bin/llvm-objcopy{bin_extension}",
+        "bin/wasm-ctor-eval{bin_extension}",
         "bin/wasm-emscripten-finalize{bin_extension}",
         "bin/wasm-ld{bin_extension}",
-        "bin/wasm-opt{bin_extension}",
         "bin/wasm-metadce{bin_extension}",
+        "bin/wasm-opt{bin_extension}",
+        "bin/wasm-split{bin_extension}",
+        "bin/wasm2js{bin_extension}",
         ":emcc_common",
     ] + glob(
         include = [


### PR DESCRIPTION
Added some files to linker filegroup so that Bazel can build successfully in certain scenarios.

- llvm-dwarfdump (needed for `-gsource-map`)
- llvm-mc (`--embed-file`)
- wasm-ctor-eval (`-sEVAL_CTORS=1`)
- wasm-split (`-sSPLIT_MODULE=1`)
- wasm2js (`-sWASM=0`)