### PR TITLE
Version 3.1.18 update

### DIFF
--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -2,7 +2,7 @@
 # DO NOT MODIFY
 
 EMSCRIPTEN_TAGS = {
-    "3.1.19": struct(
+    "3.1.18-2": struct(
         hash = "49d45744895c7d7e28acd94a385d7ee361653b4a",
         sha_linux = "6ef373c4ff3cdf33d7beecea47d4eaee7795693f8ca9469f33785cb9c54f40bb",
         sha_mac = "ad0e645abdb6d3f0b6c6ad0ee70761010a712949c9b0b193aefc78ecbc3f1710",

--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -2,19 +2,12 @@
 # DO NOT MODIFY
 
 EMSCRIPTEN_TAGS = {
-    "3.1.18-2": struct(
+    "3.1.18": struct(
         hash = "49d45744895c7d7e28acd94a385d7ee361653b4a",
         sha_linux = "6ef373c4ff3cdf33d7beecea47d4eaee7795693f8ca9469f33785cb9c54f40bb",
         sha_mac = "ad0e645abdb6d3f0b6c6ad0ee70761010a712949c9b0b193aefc78ecbc3f1710",
         sha_mac_arm64 = "68d0a1ec3e83e0415e24133c59e64206b83686712434c8c2e6792547cf654b1c",
         sha_win = "96829a228f7c08fabd37833f7361614785aa39aa865beef06890ee8ede58dc66",
-    ),
-    "3.1.18": struct(
-        hash = "56271c44baca883fddb4a58d0ebc137f9ae43d1a",
-        sha_linux = "4554ce1c3c77c905737452ec377abd412a97ab66bdf8d7c411ab020a6ee2873e",
-        sha_mac = "d18e5e36c24638c15b302f41a3e76370a3ec0e6410f97556bd731d762a3ce07a",
-        sha_mac_arm64 = "9e39b53c4c1c8fcdfbe0fd7e86d2aafd4fba79251d7ca3e3307774cb2734f88b",
-        sha_win = "b78a30b5efb53076898457b501370ad79403bfa1273e0a7f28ee791362a707c5",
     ),
     "3.1.17": struct(
         hash = "d27fef2070c86a218965da8b8b5df8b4425aa3bb",

--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -2,6 +2,13 @@
 # DO NOT MODIFY
 
 EMSCRIPTEN_TAGS = {
+    "3.1.19": struct(
+        hash = "49d45744895c7d7e28acd94a385d7ee361653b4a",
+        sha_linux = "6ef373c4ff3cdf33d7beecea47d4eaee7795693f8ca9469f33785cb9c54f40bb",
+        sha_mac = "ad0e645abdb6d3f0b6c6ad0ee70761010a712949c9b0b193aefc78ecbc3f1710",
+        sha_mac_arm64 = "68d0a1ec3e83e0415e24133c59e64206b83686712434c8c2e6792547cf654b1c",
+        sha_win = "96829a228f7c08fabd37833f7361614785aa39aa865beef06890ee8ede58dc66",
+    ),
     "3.1.18": struct(
         hash = "56271c44baca883fddb4a58d0ebc137f9ae43d1a",
         sha_linux = "4554ce1c3c77c905737452ec377abd412a97ab66bdf8d7c411ab020a6ee2873e",

--- a/emscripten-releases-tags.json
+++ b/emscripten-releases-tags.json
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "latest": "3.1.19",
+    "latest": "3.1.18-2",
     "latest-sdk": "latest",
     "latest-arm64-linux": "3.1.9",
     "latest-64bit": "latest",
@@ -10,8 +10,8 @@
     "latest-releases-upstream": "latest"
   },
   "releases": {
-    "3.1.19": "49d45744895c7d7e28acd94a385d7ee361653b4a",
-    "3.1.19-asserts": "cb7fa1dce4b04e35b78ec43499a7759f24c1e64d",
+    "3.1.18-2": "49d45744895c7d7e28acd94a385d7ee361653b4a",
+    "3.1.18-2-asserts": "cb7fa1dce4b04e35b78ec43499a7759f24c1e64d",
     "3.1.18": "56271c44baca883fddb4a58d0ebc137f9ae43d1a",
     "3.1.18-asserts": "1b72e32b38349f75cc42926a0b4875ff99632cf6",
     "3.1.17": "d27fef2070c86a218965da8b8b5df8b4425aa3bb",

--- a/emscripten-releases-tags.json
+++ b/emscripten-releases-tags.json
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "latest": "3.1.18-2",
+    "latest": "3.1.18",
     "latest-sdk": "latest",
     "latest-arm64-linux": "3.1.9",
     "latest-64bit": "latest",
@@ -10,10 +10,8 @@
     "latest-releases-upstream": "latest"
   },
   "releases": {
-    "3.1.18-2": "49d45744895c7d7e28acd94a385d7ee361653b4a",
-    "3.1.18-2-asserts": "cb7fa1dce4b04e35b78ec43499a7759f24c1e64d",
-    "3.1.18": "56271c44baca883fddb4a58d0ebc137f9ae43d1a",
-    "3.1.18-asserts": "1b72e32b38349f75cc42926a0b4875ff99632cf6",
+    "3.1.18": "49d45744895c7d7e28acd94a385d7ee361653b4a",
+    "3.1.18-asserts": "cb7fa1dce4b04e35b78ec43499a7759f24c1e64d",
     "3.1.17": "d27fef2070c86a218965da8b8b5df8b4425aa3bb",
     "3.1.17-asserts": "19aab28a81be09863e86aba8ee4e20feaee31f6b",
     "3.1.16": "fb1baf00423818052359cf9126e94bc71c39feb5",

--- a/emscripten-releases-tags.json
+++ b/emscripten-releases-tags.json
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "latest": "3.1.18",
+    "latest": "3.1.19",
     "latest-sdk": "latest",
     "latest-arm64-linux": "3.1.9",
     "latest-64bit": "latest",
@@ -10,6 +10,8 @@
     "latest-releases-upstream": "latest"
   },
   "releases": {
+    "3.1.19": "49d45744895c7d7e28acd94a385d7ee361653b4a",
+    "3.1.19-asserts": "cb7fa1dce4b04e35b78ec43499a7759f24c1e64d",
     "3.1.18": "56271c44baca883fddb4a58d0ebc137f9ae43d1a",
     "3.1.18-asserts": "1b72e32b38349f75cc42926a0b4875ff99632cf6",
     "3.1.17": "d27fef2070c86a218965da8b8b5df8b4425aa3bb",


### PR DESCRIPTION
3.1.18 had a bad release binary on ARM64 Mac so push an updated version of the release.