### PR TITLE
Add double quotes to allow spaces in path

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -8,14 +8,14 @@
 
 # First look for python bundled in Emsdk
 if [ -z "$EMSDK_PYTHON" ]; then
-  PYTHON3=$(dirname $0)/python/3.9.2-1_64bit/bin/python3
-  PYTHON3_CERT_FILE=$(dirname $0)/python/3.9.2-1_64bit/lib/python3.9/site-packages/certifi/cacert.pem
-  if [ ! -f $PYTHON3 ]; then
-    PYTHON3=$(dirname $0)/python/3.7.4-2_64bit/bin/python3
-    PYTHON3_CERT_FILE=$(dirname $0)/python/3.7.4-2_64bit/lib/python3.7/site-packages/certifi/cacert.pem
+  PYTHON3="$(dirname "$0")/python/3.9.2-1_64bit/bin/python3"
+  PYTHON3_CERT_FILE="$(dirname "$0")/python/3.9.2-1_64bit/lib/python3.9/site-packages/certifi/cacert.pem"
+  if [ ! -f "$PYTHON3" ]; then
+    PYTHON3="$(dirname "$0")/python/3.7.4-2_64bit/bin/python3"
+    PYTHON3_CERT_FILE="$(dirname "$0")/python/3.7.4-2_64bit/lib/python3.7/site-packages/certifi/cacert.pem"
   fi
-  if [ -f $PYTHON3 ]; then
-    EMSDK_PYTHON=$PYTHON3
+  if [ -f "$PYTHON3" ]; then
+    EMSDK_PYTHON="$PYTHON3"
 
     # When using our bundled python we never want the users
     # PYTHONHOME or PYTHONPATH
@@ -26,15 +26,14 @@ if [ -z "$EMSDK_PYTHON" ]; then
     # This is needed for MacOS.  Without this, the urlopen
     # code will try to use /usr/local/etc/openssl/cert.pem
     # which may or may not exist on the system.
-    export SSL_CERT_FILE=$PYTHON3_CERT_FILE
+    export SSL_CERT_FILE="$PYTHON3_CERT_FILE"
   fi
 fi
 
 # If bundled python is not found, look for `python3` in PATH.  This is especially important on macOS (See:
 # https://github.com/emscripten-core/emsdk/pull/273)
 if [ -z "$EMSDK_PYTHON" ]; then
-  PYTHON3=$(which python3 2> /dev/null)
-  if [ $? = 0 ]; then
+  if PYTHON3="$(which python3 2>/dev/null)"; then
     EMSDK_PYTHON=$PYTHON3
   fi
 fi

--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -69,5 +69,5 @@ if [ ! -f "$DIR/emsdk.py" ]; then
 fi
 
 # Force emsdk to use bash syntax so that this works in windows + bash too
-eval `EMSDK_BASH=1 $DIR/emsdk construct_env`
+eval `EMSDK_BASH=1 "$DIR/emsdk" construct_env`
 unset DIR


### PR DESCRIPTION
Minimal fixes to allow spaces in path when using shell scripts. #1096 