### PR TITLE
Avoid exporting EM_CONFIG for modern SDK versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,6 @@ COPY --from=stage_build /emsdk /emsdk
 # This will let use tools offered by this image inside other Docker images
 # (sub-stages) or with custom / no entrypoint
 ENV EMSDK=/emsdk \
-    EM_CONFIG=/emsdk/.emscripten \
     EMSDK_NODE=/emsdk/node/14.18.2_64bit/bin/node \
     PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/14.18.2_64bit/bin:${PATH}"
 

--- a/test/test.py
+++ b/test/test.py
@@ -10,9 +10,9 @@ import unittest
 WINDOWS = sys.platform.startswith('win')
 MACOS = sys.platform == 'darwin'
 
-assert 'EM_CONFIG' in os.environ, "emsdk should be activated before running this script"
+emconfig = os.path.abspath('.emscripten')
+assert os.path.exists(emconfig)
 
-emconfig = os.environ['EM_CONFIG']
 upstream_emcc = os.path.join('upstream', 'emscripten', 'emcc')
 fastcomp_emcc = os.path.join('fastcomp', 'emscripten', 'emcc')
 emsdk = './emsdk'

--- a/test/test_activation.ps1
+++ b/test/test_activation.ps1
@@ -28,7 +28,6 @@ try {
     }
 
     $EMSDK = [System.Environment]::GetEnvironmentVariable("EMSDK", $env_type)
-    $EM_CONFIG = [System.Environment]::GetEnvironmentVariable("EM_CONFIG", $env_type)
     $EMSDK_NODE = [System.Environment]::GetEnvironmentVariable("EMSDK_NODE", $env_type)
     $EMSDK_PYTHON = [System.Environment]::GetEnvironmentVariable("EMSDK_PYTHON", $env_type)
     $JAVA_HOME = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", $env_type)
@@ -36,9 +35,6 @@ try {
 
     if (!$EMSDK) {
         throw "EMSDK is not set for the user"
-    }
-    if (!$EM_CONFIG) {
-        throw "EM_CONFIG is not set for the user"
     }
     if (!$EMSDK_NODE) {
         throw "EMSDK_NODE is not set for the user"
@@ -83,14 +79,12 @@ finally {
 
     # Recover pre activation env variables
     [Environment]::SetEnvironmentVariable("EMSDK", $null, "User")
-    [Environment]::SetEnvironmentVariable("EM_CONFIG", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "User")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "User")
 
     try {
         [Environment]::SetEnvironmentVariable("EMSDK", $null, "Machine")
-        [Environment]::SetEnvironmentVariable("EM_CONFIG", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Machine")
         [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
@@ -98,7 +92,6 @@ finally {
 
 
     [Environment]::SetEnvironmentVariable("EMSDK", $null, "Process")
-    [Environment]::SetEnvironmentVariable("EM_CONFIG", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Process")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Process")

--- a/test/test_path_preservation.ps1
+++ b/test/test_path_preservation.ps1
@@ -123,14 +123,12 @@ finally {
 
     # Recover pre activation env variables
     [Environment]::SetEnvironmentVariable("EMSDK", $null, "User")
-    [Environment]::SetEnvironmentVariable("EM_CONFIG", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "User")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "User")
 
     try {
         [Environment]::SetEnvironmentVariable("EMSDK", $null, "Machine")
-        [Environment]::SetEnvironmentVariable("EM_CONFIG", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Machine")
         [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
@@ -138,7 +136,6 @@ finally {
 
 
     [Environment]::SetEnvironmentVariable("EMSDK", $null, "Process")
-    [Environment]::SetEnvironmentVariable("EM_CONFIG", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Process")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Process")


### PR DESCRIPTION
Newer versions of emscipten, starting all the way back in 1.39.13, can automatically locate the `.emscripten` config file that emsdk creates so there is no need for the explicit EM_CONFIG environment variable.  Its redundant and adds unnessary noisce/complexity.

Really, adding emcc to the PATH is all the is needed these days.

One nice thing about this change is that it allows folks to run whichever emcc they want to and have it just work, even if they have
configured emsdk.   Without this change, if I activate emsdk and I run
`some/other/emcc` then emsdk's `EM_CONFIG` will still be present and
override the configuration embedded in `some/other/emcc`.

e.g. in the same shell, with emsdk activated, I can run both these commands and have them both just work as expected.

```
$ emcc --version
$ /path/to/my/emcc --version
```

Without this change the second command gets confused because it tries to use the emsdk's `EM_CONFIG`.