### PR TITLE
Use x64 version for Windows on Arm

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -142,6 +142,9 @@ elif machine.endswith('86'):
   ARCH = 'x86'
 elif machine.startswith('aarch64') or machine.lower().startswith('arm64'):
   ARCH = 'aarch64'
+  if WINDOWS:
+      errlog('No support for Windows on Arm, fallback to x64')
+      ARCH = 'x86_64'
 elif machine.startswith('arm'):
   ARCH = 'arm'
 else:


### PR DESCRIPTION
At Linaro, [Windows on Arm](https://www.linaro.org/windows-on-arm/) team is helping open source projects to enable this platform. We spent some time to work on dart-sdk.

A few days ago, a regression was found. [Dart](https://github.com/dart-lang/sdk) started to use emscripten for their dart2wasm module.

This fail to build under Windows on Arm, because emsdk can't find a toolchain to download (when having an arm64 python on the PATH). This PR adds a fallback to download an x64 version instead (supported via emulation from windows 11).