### PR TITLE
Change base to Ubuntu 22.04 LTS (jammy)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal AS stage_build
+FROM ubuntu:jammy AS stage_build
 
 ARG EMSCRIPTEN_VERSION=tot
 ENV EMSDK /emsdk
@@ -56,7 +56,7 @@ RUN echo "## Aggressive optimization: Remove debug symbols" \
 # -------------------------------- STAGE DEPLOY --------------------------------
 # ------------------------------------------------------------------------------
 
-FROM ubuntu:focal AS stage_deploy
+FROM ubuntu:jammy AS stage_deploy
 
 COPY --from=stage_build /emsdk /emsdk
 
@@ -105,7 +105,7 @@ RUN echo "## Update and install packages" \
         build-essential \
         make \
         ant \
-        libidn11 \
+        libidn12 \
         cmake \
         openjdk-11-jre-headless \
     # Standard Cleanup on Debian images


### PR DESCRIPTION
Done to upgrade CMake from [3.16.3](https://packages.ubuntu.com/focal/cmake) to [3.22.1](https://packages.ubuntu.com/jammy/cmake).

Motiation: [CMake 3.21 or newer](https://doc.qt.io/qt-6/cmake-get-started.html) is needed to build the Qt 6 sources with emscripten.

### CI problem
CI is failing with a code signing error. I suspect that this is due to https://github.com/docker/docker-install/issues/244, which is fixed by updating the  Docker version on the CI node.