### PR TITLE
Add standalone_wasm feature to bazel emscripten_toolchain

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -441,6 +441,9 @@ def _impl(ctx):
             name = "output_format_js",
             enabled = True,
         ),
+        feature(
+            name = "standalone_wasm",
+        ),
     ]
 
     crosstool_default_flag_sets = [
@@ -1014,6 +1017,11 @@ def _impl(ctx):
             actions = all_compile_actions,
             flags = ["-Werror"],
             features = ["wasm_warnings_as_errors"],
+        ),
+        flag_set(
+            actions = all_link_actions,
+            flags = ["-s", "STANDALONE_WASM"],
+            features = ["standalone_wasm"],
         ),
     ]
 

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -442,7 +442,7 @@ def _impl(ctx):
             enabled = True,
         ),
         feature(
-            name = "standalone_wasm",
+            name = "wasm_standalone",
         ),
     ]
 
@@ -1021,7 +1021,7 @@ def _impl(ctx):
         flag_set(
             actions = all_link_actions,
             flags = ["-sSTANDALONE_WASM"],
-            features = ["standalone_wasm"],
+            features = ["wasm_standalone"],
         ),
     ]
 

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -1020,7 +1020,7 @@ def _impl(ctx):
         ),
         flag_set(
             actions = all_link_actions,
-            flags = ["-s", "STANDALONE_WASM"],
+            flags = ["-sSTANDALONE_WASM"],
             features = ["standalone_wasm"],
         ),
     ]

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -25,6 +25,9 @@ def _wasm_transition_impl(settings, attr):
     if attr.simd:
         features.append("wasm_simd")
 
+    if attr.standalone:
+        features.append("wasm_standalone")
+
     return {
         "//command_line_option:compiler": "emscripten",
         "//command_line_option:crosstool_top": "@emsdk//emscripten_toolchain:everything",
@@ -84,6 +87,9 @@ _WASM_BINARY_COMMON_ATTRS = {
         values = ["_default", "emscripten", "off"],
     ),
     "simd": attr.bool(
+        default = False,
+    ),
+    "standalone": attr.bool(
         default = False,
     ),
     "_allowlist_function_transition": attr.label(


### PR DESCRIPTION
This allows building with `--features=standalone_wasm` into a WASI binary.