### PR TITLE
Draft: add support for weak dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ COPY . ${EMSDK}
 
 RUN echo "## Install Emscripten" \
     && cd ${EMSDK} \
-    && ./emsdk install ${EMSCRIPTEN_VERSION} \
+    && ./emsdk install ${EMSCRIPTEN_VERSION} --no-install-recommends \
     && echo "## Done"
 
 # This generates configuration that contains all valid paths according to installed SDK
@@ -42,8 +42,6 @@ RUN cd ${EMSDK} \
 # Cleanup Emscripten installation and strip some symbols
 RUN echo "## Aggressive optimization: Remove debug symbols" \
     && cd ${EMSDK} && . ./emsdk_env.sh \
-    # Remove debugging symbols from embedded node (extra 7MB)
-    && strip -s `which node` \
     # Tests consume ~80MB disc space
     && rm -fr ${EMSDK}/upstream/emscripten/tests \
     # Fastcomp is not supported
@@ -64,8 +62,7 @@ COPY --from=stage_build /emsdk /emsdk
 # This will let use tools offered by this image inside other Docker images
 # (sub-stages) or with custom / no entrypoint
 ENV EMSDK=/emsdk \
-    EMSDK_NODE=/emsdk/node/14.18.2_64bit/bin/node \
-    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/14.18.2_64bit/bin:${PATH}"
+    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:${PATH}"
 
 # ------------------------------------------------------------------------------
 # Create a 'standard` 1000:1000 user
@@ -108,6 +105,9 @@ RUN echo "## Update and install packages" \
         libidn12 \
         cmake \
         openjdk-11-jre-headless \
+    # Install the latest LTS version of Node.js from NodeSource
+    && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -qqy nodejs \
     # Standard Cleanup on Debian images
     && apt-get -y clean \
     && apt-get -y autoclean \

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -654,19 +654,22 @@
   {
     "version": "upstream-main",
     "bitness": 64,
-    "requires": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "requires": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "win"
   },
   {
     "version": "upstream-main",
     "bitness": 64,
-    "requires": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "requires": ["python-3.9.2-64bit", "llvm-git-main-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "macos"
   },
   {
     "version": "upstream-main",
     "bitness": 64,
-    "requires": ["llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "requires": ["llvm-git-main-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "linux"
   },
   {
@@ -678,7 +681,8 @@
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 32,
-    "requires": ["fastcomp-clang-tag-e%tag%-32bit", "node-8.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
+    "requires": ["fastcomp-clang-tag-e%tag%-32bit", "python-2.7.13.1-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
+    "recommends": ["node-8.9.1-32bit", "java-8.152-32bit"],
     "os": "win",
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
@@ -687,7 +691,8 @@
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 64,
-    "requires": ["fastcomp-clang-tag-e%tag%-64bit", "node-8.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
+    "requires": ["fastcomp-clang-tag-e%tag%-64bit", "python-2.7.13.1-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
+    "recommends": ["node-8.9.1-64bit", "java-8.152-64bit"],
     "os": "win",
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
@@ -696,7 +701,8 @@
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 32,
-    "requires": ["fastcomp-clang-tag-e%tag%-32bit", "node-8.9.1-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
+    "requires": ["fastcomp-clang-tag-e%tag%-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
+    "recommends": ["node-8.9.1-32bit"],
     "os": "linux",
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
@@ -705,7 +711,8 @@
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 64,
-    "requires": ["fastcomp-clang-tag-e%tag%-64bit", "node-8.9.1-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
+    "requires": ["fastcomp-clang-tag-e%tag%-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
+    "recommends": ["node-8.9.1-64bit"],
     "os": "unix",
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
@@ -714,14 +721,16 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "requires": ["node-14.18.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "requires": ["releases-upstream-%releases-tag%-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "requires": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "requires": ["python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -729,7 +738,8 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "requires": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "requires": ["python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
@@ -737,21 +747,24 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "requires": ["node-14.18.2-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "requires": ["python-3.9.2-nuget-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "recommends": ["node-14.18.2-64bit", "java-8.152-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "requires": ["node-14.18.2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "requires": ["releases-fastcomp-%releases-tag%-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "requires": ["node-14.18.2-64bit", "python-3.7.4-2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "requires": ["python-3.7.4-2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -759,7 +772,8 @@
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "requires": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "requires": ["python-3.9.2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "recommends": ["node-14.18.2-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
@@ -767,14 +781,16 @@
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "requires": ["node-14.18.2-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "requires": ["python-3.7.4-pywin32-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "recommends": ["node-14.18.2-64bit", "java-8.152-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "fastcomp-%precompiled_tag32%",
     "bitness": 32,
-    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-%precompiled_tag32%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "python-2.7.13.1-32bit", "emscripten-%precompiled_tag32%"],
+    "recommends": ["node-8.9.1-32bit", "java-8.152-32bit"],
     "os": "win",
     "version_filter": [
       ["%precompiled_tag32%", ">", "1.37.22"]
@@ -783,7 +799,8 @@
   {
     "version": "fastcomp-%precompiled_tag64%",
     "bitness": 64,
-    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-%precompiled_tag64%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "python-2.7.13.1-64bit", "emscripten-%precompiled_tag64%"],
+    "recommends": ["node-8.9.1-64bit", "java-8.152-64bit"],
     "os": "win",
     "version_filter": [
       ["%precompiled_tag64%", ">", "1.37.22"]
@@ -792,7 +809,8 @@
   {
     "version": "fastcomp-%precompiled_tag32%",
     "bitness": 32,
-    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "emscripten-%precompiled_tag32%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "emscripten-%precompiled_tag32%"],
+    "recommends": ["node-8.9.1-32bit"],
     "os": "linux",
     "version_filter": [
       ["%precompiled_tag32%", ">", "1.37.22"]
@@ -801,7 +819,8 @@
   {
     "version": "fastcomp-%precompiled_tag64%",
     "bitness": 64,
-    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "emscripten-%precompiled_tag64%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "emscripten-%precompiled_tag64%"],
+    "recommends": ["node-8.9.1-64bit"],
     "os": "linux",
     "version_filter": [
       ["%precompiled_tag64%", ">", "1.37.22"]
@@ -810,7 +829,8 @@
   {
     "version": "fastcomp-%precompiled_tag32%",
     "bitness": 32,
-    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag32%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag32%"],
+    "recommends": ["node-8.9.1-32bit"],
     "os": "macos",
     "arch": "x86_64",
     "version_filter": [
@@ -820,7 +840,8 @@
   {
     "version": "fastcomp-%precompiled_tag64%",
     "bitness": 64,
-    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag64%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag64%"],
+    "recommends": ["node-8.9.1-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "version_filter": [

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -654,31 +654,31 @@
   {
     "version": "upstream-main",
     "bitness": 64,
-    "uses": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "requires": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
     "version": "upstream-main",
     "bitness": 64,
-    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "requires": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "upstream-main",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "requires": ["llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
     "version": "upstream-main",
     "bitness": 32,
-    "uses": ["llvm-git-main-32bit", "emscripten-main-32bit", "binaryen-main-32bit"],
+    "requires": ["llvm-git-main-32bit", "emscripten-main-32bit", "binaryen-main-32bit"],
     "os": "linux"
   },
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 32,
-    "uses": ["fastcomp-clang-tag-e%tag%-32bit", "node-8.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
+    "requires": ["fastcomp-clang-tag-e%tag%-32bit", "node-8.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
     "os": "win",
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
@@ -687,7 +687,7 @@
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 64,
-    "uses": ["fastcomp-clang-tag-e%tag%-64bit", "node-8.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
+    "requires": ["fastcomp-clang-tag-e%tag%-64bit", "node-8.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
     "os": "win",
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
@@ -696,7 +696,7 @@
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 32,
-    "uses": ["fastcomp-clang-tag-e%tag%-32bit", "node-8.9.1-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
+    "requires": ["fastcomp-clang-tag-e%tag%-32bit", "node-8.9.1-32bit", "emscripten-tag-%tag%-32bit", "binaryen-tag-%tag%-32bit"],
     "os": "linux",
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
@@ -705,7 +705,7 @@
   {
     "version": "fastcomp-tag-%tag%",
     "bitness": 64,
-    "uses": ["fastcomp-clang-tag-e%tag%-64bit", "node-8.9.1-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
+    "requires": ["fastcomp-clang-tag-e%tag%-64bit", "node-8.9.1-64bit", "emscripten-tag-%tag%-64bit", "binaryen-tag-%tag%-64bit"],
     "os": "unix",
     "version_filter": [
       ["%tag%", ">", "1.37.22"]
@@ -714,14 +714,14 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "requires": ["node-14.18.2-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "requires": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -729,7 +729,7 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "requires": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
@@ -737,21 +737,21 @@
   {
     "version": "releases-upstream-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "requires": ["node-14.18.2-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "requires": ["node-14.18.2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.7.4-2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "requires": ["node-14.18.2-64bit", "python-3.7.4-2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -759,7 +759,7 @@
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "requires": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
@@ -767,14 +767,14 @@
   {
     "version": "releases-fastcomp-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "releases-fastcomp-%releases-tag%-64bit"],
+    "requires": ["node-14.18.2-64bit", "python-3.7.4-pywin32-64bit", "java-8.152-64bit", "releases-fastcomp-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "fastcomp-%precompiled_tag32%",
     "bitness": 32,
-    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-%precompiled_tag32%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-2.7.13.1-32bit", "java-8.152-32bit", "emscripten-%precompiled_tag32%"],
     "os": "win",
     "version_filter": [
       ["%precompiled_tag32%", ">", "1.37.22"]
@@ -783,7 +783,7 @@
   {
     "version": "fastcomp-%precompiled_tag64%",
     "bitness": 64,
-    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-%precompiled_tag64%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-2.7.13.1-64bit", "java-8.152-64bit", "emscripten-%precompiled_tag64%"],
     "os": "win",
     "version_filter": [
       ["%precompiled_tag64%", ">", "1.37.22"]
@@ -792,7 +792,7 @@
   {
     "version": "fastcomp-%precompiled_tag32%",
     "bitness": 32,
-    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "emscripten-%precompiled_tag32%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "emscripten-%precompiled_tag32%"],
     "os": "linux",
     "version_filter": [
       ["%precompiled_tag32%", ">", "1.37.22"]
@@ -801,7 +801,7 @@
   {
     "version": "fastcomp-%precompiled_tag64%",
     "bitness": 64,
-    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "emscripten-%precompiled_tag64%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "emscripten-%precompiled_tag64%"],
     "os": "linux",
     "version_filter": [
       ["%precompiled_tag64%", ">", "1.37.22"]
@@ -810,7 +810,7 @@
   {
     "version": "fastcomp-%precompiled_tag32%",
     "bitness": 32,
-    "uses": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag32%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag32%-32bit", "node-8.9.1-32bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag32%"],
     "os": "macos",
     "arch": "x86_64",
     "version_filter": [
@@ -820,7 +820,7 @@
   {
     "version": "fastcomp-%precompiled_tag64%",
     "bitness": 64,
-    "uses": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag64%"],
+    "requires": ["fastcomp-clang-e%precompiled_tag64%-64bit", "node-8.9.1-64bit", "python-3.7.4-2-64bit", "emscripten-%precompiled_tag64%"],
     "os": "macos",
     "arch": "x86_64",
     "version_filter": [


### PR DESCRIPTION
Allowing users to easily install, activate and use the Emscripten toolchain in combination with a system-installed version of Node.js.

This can be useful since emsdk currently provides Node.js 14.x, whose active support ended a year ago.

Current (and unchanged) behavior:
```console
$ ./emsdk install latest
$ ./emsdk activate latest
$ source ./emsdk_env.sh

$ which node
/home/kleisauke/emsdk/node/14.18.2_64bit/bin/node
$ node -v
v14.18.2
```

Behavior with the optional `--no-install-recommends` flag:
```console
$ ./emsdk install latest --no-install-recommends
$ ./emsdk activate latest
$ source ./emsdk_env.sh

$ which node
/usr/bin/node
$ node -v
v18.12.1
```

This PR also allows uninstalling the bundled Node.js version before the `activate` phase (this would previously fail with the `tool is not installed and therefore cannot be activated` error).
```console
$ ./emsdk install latest
$ ./emsdk uninstall node-14.18.2-64bit
$ ./emsdk activate latest
$ source ./emsdk_env.sh

$ which node
/usr/bin/node
$ node -v
v18.12.1
```

Marked this PR as draft due to these TODO-items:
- [ ] Rename this flag? It's basically the same flag as used by the APT package manager (I can't think of a better name for it).
- [ ] Split the commits in multiple PRs?
- [ ] Add documentation and tests for this flag.

(since this is considered a draft, I deliberately did not link any issues to this PR)