### PR TITLE
Allow emscripten-releases-tags/aliases to work be used without SDK deps

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -252,6 +252,12 @@ int main() {
     # Test that its possible to install emscripten as tool instead of SDK
     checked_call_with_output(emsdk + ' install releases-77b065ace39e6ab21446e13f92897f956c80476a', unexpected='Installing SDK')
 
+  def test_install_alias(self):
+    # 3.1.18 is 49d45744895c7d7e28acd94a385d7ee361653b4a
+    run_emsdk('install 3.1.18-base')
+    checked_call_with_output(emsdk + ' install install 3.1.18-base', unexpected='Installing SDK')
+    checked_call_with_output(emsdk + ' install install releases-upstream-49d45744895c7d7e28acd94a385d7ee361653b4a', unexpected='already downloaded, skipping', unexpected='Downloading:')
+
   def test_activate_missing(self):
     run_emsdk('install latest')
     failing_call_with_output(emsdk + ' activate 2.0.1', expected="error: tool is not installed and therefore cannot be activated: 'releases-13e29bd55185e3c12802bc090b4507901856b2ba-64bit'")


### PR DESCRIPTION
This change means that aliases such as `latest` and `3.10.2` can be used to install jsut the emscipten-releases packages and not the full SDK with all the dependencies.

This allows uses who do not want to install dependencies such as node, python or java to still use this package.

These packages were already available to install on their own via their full names such as:

```
$ ./emsdk install releases-upstream-48ce0b44015d0182fc8c27aa9fbc0a4474b55982-64bi
```

Now these base packages can also be install via:

```
$ ./emsdk install latest-base
```

Fixes: #1142