### PR TITLE
Get node binary via @nodejs//:node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,7 @@ jobs:
     environment:
       PYTHONUNBUFFERED: "1"
       EMSDK_NOTTY: "1"
+      USE_BAZEL_VERSION: "5.4.0"
     steps:
       - checkout
       - run:

--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -62,7 +62,10 @@ emscripten_cc_toolchain_config_rule(
         "@bazel_tools//src/conditions:host_windows": "bat",
         "//conditions:default": "sh",
     }),
-    node_binary = "@nodejs//:node",
+    node_binary = select({
+        "@bazel_tools//src/conditions:host_windows": "@nodejs//:node_bin",
+        "//conditions:default": "@nodejs//:node",
+    }),
 )
 
 cc_toolchain(

--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -62,6 +62,7 @@ emscripten_cc_toolchain_config_rule(
         "@bazel_tools//src/conditions:host_windows": "bat",
         "//conditions:default": "sh",
     }),
+    node_binary = "@nodejs//:node",
 )
 
 cc_toolchain(

--- a/bazel/emscripten_toolchain/emscripten_config
+++ b/bazel/emscripten_toolchain/emscripten_config
@@ -6,18 +6,12 @@ EMSCRIPTEN_ROOT = os.environ["EMSCRIPTEN"]
 BINARYEN_ROOT = os.path.join(ROOT_DIR, os.environ["EM_BIN_PATH"])
 LLVM_ROOT = os.path.join(BINARYEN_ROOT, "bin")
 FROZEN_CACHE = True
-
-system = platform.system()
-
-machine = "arm64" if platform.machine() == "arm64" else "amd64"
-nodejs_binary = "bin/nodejs/node.exe" if(system =="Windows") else "bin/node"
-NODE_JS = ROOT_DIR + "/external/nodejs_{}_{}/{}".format(system.lower(), machine, nodejs_binary)
-
+NODE_JS = os.path.join(ROOT_DIR, os.environ["NODE_JS"])
 
 # This works around an issue with Bazel RBE where the symlinks in node_modules/.bin
 # are uploaded as the linked files, which means the cli.js cannot load its
 # dependencies from the expected locations.
 # See https://github.com/emscripten-core/emscripten/pull/16640 for more
-if system != "Windows":
+if platform.system() != "Windows":
     CLOSURE_COMPILER = [NODE_JS, os.path.join(EMSCRIPTEN_ROOT, "node_modules",
                                               "google-closure-compiler", "cli.js")]

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -1040,6 +1040,10 @@ def _impl(ctx):
                     key = "EM_CONFIG_PATH",
                     value = ctx.file.em_config.path,
                 ),
+                env_entry(
+                    key = "NODE_JS",
+                    value = ctx.file.node_binary.path,
+                )
             ],
         ),
         # Use llvm backend.  Off by default, enabled via --features=llvm_backend
@@ -1115,6 +1119,7 @@ emscripten_cc_toolchain_config_rule = rule(
         "em_config": attr.label(mandatory = True, allow_single_file = True),
         "emscripten_binaries": attr.label(mandatory = True, cfg = "exec"),
         "script_extension": attr.string(mandatory = True, values = ["sh", "bat"]),
+        "node_binary": attr.label(mandatory = True, allow_single_file = True, cfg = "exec"),
     },
     provides = [CcToolchainConfigInfo],
 )


### PR DESCRIPTION
I had a colleague using an arm64 mac whose builds were failing because `platform.machine()` was returning amd64 for some reason (my guess is the python toolchain was running under Rosetta). Then emscripten_config looked for the node binary in a nonexistent directory -- nodejs_darwin_amd64 rather than nodejs_darwin_arm64.

This switches to a public rules_nodejs API for obtaining the binary, so should always work.