### PR TITLE
Add linux/arm64 support to bazel rules

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -9,6 +9,14 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
     name = "macos",
     constraint_values = [
         "@platforms//os:macos",
@@ -38,6 +46,7 @@ alias(
     name = "compiler_files",
     actual = select({
         ":linux": "@emscripten_bin_linux//:compiler_files",
+        ":linux_arm64": "@emscripten_bin_linux_arm64//:compiler_files",
         ":macos": "@emscripten_bin_mac//:compiler_files",
         ":macos_arm64": "@emscripten_bin_mac_arm64//:compiler_files",
         ":windows": "@emscripten_bin_win//:compiler_files",
@@ -49,6 +58,7 @@ alias(
     name = "linker_files",
     actual = select({
         ":linux": "@emscripten_bin_linux//:linker_files",
+        ":linux_arm64": "@emscripten_bin_linux_arm64//:linker_files",
         ":macos": "@emscripten_bin_mac//:linker_files",
         ":macos_arm64": "@emscripten_bin_mac_arm64//:linker_files",
         ":windows": "@emscripten_bin_win//:linker_files",
@@ -60,6 +70,7 @@ alias(
     name = "ar_files",
     actual = select({
         ":linux": "@emscripten_bin_linux//:ar_files",
+        ":linux_arm64": "@emscripten_bin_linux_arm64//:ar_files",
         ":macos": "@emscripten_bin_mac//:ar_files",
         ":macos_arm64": "@emscripten_bin_mac_arm64//:ar_files",
         ":windows": "@emscripten_bin_win//:ar_files",

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -128,7 +128,8 @@ def emscripten_deps(emscripten_version = "latest"):
             name = "emscripten_bin_linux_arm64",
             strip_prefix = "install",
             url = emscripten_url.format("linux", revision.hash, "-arm64", "tbz2"),
-            sha256 = revision.sha_linux_arm64,
+            # Not all versions have a linux/arm64 release: https://github.com/emscripten-core/emsdk/issues/547
+            sha256 = getattr(revision, "sha_linux_arm64", None),
             build_file_content = BUILD_FILE_CONTENT_TEMPLATE.format(bin_extension = ""),
             type = "tar.bz2",
         )

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -123,6 +123,16 @@ def emscripten_deps(emscripten_version = "latest"):
             type = "tar.bz2",
         )
 
+    if "emscripten_bin_linux_arm64" not in excludes:
+        http_archive(
+            name = "emscripten_bin_linux_arm64",
+            strip_prefix = "install",
+            url = emscripten_url.format("linux", revision.hash, "-arm64", "tbz2"),
+            sha256 = revision.sha_linux_arm64,
+            build_file_content = BUILD_FILE_CONTENT_TEMPLATE.format(bin_extension = ""),
+            type = "tar.bz2",
+        )
+
     if "emscripten_bin_mac" not in excludes:
         http_archive(
             name = "emscripten_bin_mac",
@@ -158,6 +168,13 @@ def emscripten_deps(emscripten_version = "latest"):
             name = "emscripten_npm_linux",
             package_json = "@emscripten_bin_linux//:emscripten/package.json",
             package_lock_json = "@emscripten_bin_linux//:emscripten/package-lock.json",
+        )
+
+    if "emscripten_npm_linux_arm64" not in excludes:
+        npm_install(
+            name = "emscripten_npm_linux_arm64",
+            package_json = "@emscripten_bin_linux_arm64//:emscripten/package.json",
+            package_lock_json = "@emscripten_bin_linux_arm64//:emscripten/package-lock.json",
         )
 
     if "emscripten_npm_mac" not in excludes:

--- a/bazel/emscripten_toolchain/emscripten_config
+++ b/bazel/emscripten_toolchain/emscripten_config
@@ -9,7 +9,7 @@ FROZEN_CACHE = True
 
 system = platform.system()
 
-machine = "arm64" if platform.machine() == "arm64" else "amd64"
+machine = "arm64" if (platform.machine() == "arm64" or platform.machine() == "aarch64") else "amd64"
 nodejs_binary = "bin/nodejs/node.exe" if(system =="Windows") else "bin/node"
 NODE_JS = ROOT_DIR + "/external/nodejs_{}_{}/{}".format(system.lower(), machine, nodejs_binary)
 

--- a/bazel/emscripten_toolchain/emscripten_config
+++ b/bazel/emscripten_toolchain/emscripten_config
@@ -9,7 +9,7 @@ FROZEN_CACHE = True
 
 system = platform.system()
 
-machine = "arm64" if (platform.machine() == "arm64" or platform.machine() == "aarch64") else "amd64"
+machine = "arm64" if platform.machine() in ('arm64', 'aarch64') else "amd64"
 nodejs_binary = "bin/nodejs/node.exe" if(system =="Windows") else "bin/node"
 NODE_JS = ROOT_DIR + "/external/nodejs_{}_{}/{}".format(system.lower(), machine, nodejs_binary)
 

--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -12,6 +12,7 @@ EMSCRIPTEN_TAGS = {
     "3.1.33": struct(
         hash = "49b960bd03b3a9da478a08541ce6eafe792a58a8",
         sha_linux = "eab02b3f4b7c076974452ba602f908a36adf597afa15b16095b441f191ede1bb",
+        sha_linux_arm64 = "5e15af6affcf37c9ce6c304b4aeccb87a2758e1ef029dbc996f9d77d7444378e",
         sha_mac = "b8dad3cddb19c1daf9dae99020bd17b903ae9649cfc58e433ea4951e758804de",
         sha_mac_arm64 = "fbf03d06c7503f091191e440b8ea577d65b3261167cdb47359d053f12888974b",
         sha_win = "031f951668eaeea39bd9363abb3f514efc3401506374984fa9b1d7ba3130a62f",

--- a/bazel/revisions.bzl
+++ b/bazel/revisions.bzl
@@ -54,6 +54,7 @@ EMSCRIPTEN_TAGS = {
     "3.1.21": struct(
         hash = "a16a8bca2466eb144f7c93fa899c0272c8815dc3",
         sha_linux = "7045ddb3b37a2cc63cb1cf976019a6a3b7f8dbdc71254db0eee5b0452f94e9e7",
+        sha_linux_arm64 = "2852c8b108ec748d52d31dab3f4854bc6022df008019daff1c7e31ac00363b3f",
         sha_mac = "2a8d3d3ad721fec81ca1a4a581e4183b6e732e9905beb874531851846a05a367",
         sha_mac_arm64 = "cf788a7bdc38bb40d01f94b2d46acafb0e2f02d8ee3b3d69541c114e467ee37f",
         sha_win = "81518bba13f41717ffe6990b6d4a5af635d0c9d0f71a8d3bc0980cd0bc8f5f66",


### PR DESCRIPTION
I could find that there are some prebuilt Linux/arm64 binaries out there, but that their version trails a bit behind and not supported in the bazel rules. This pr aims to change the latter bit.

My usecase is a bazel+emsdk build in a Docker build (unfortunatly can't just build the container directly from bazel). While this works fine in our CI system, locally I'd have to build with docker's `--platform=linux/amd64` which is unbearably slow with bazel in it. Since there are arm64 binaries for linux, I'd like to be able to use those!