### PR TITLE
Pin Windows CI to Bazel 5.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,7 @@ jobs:
     environment:
       PYTHONUNBUFFERED: "1"
       EMSDK_NOTTY: "1"
+      USE_BAZEL_VERSION: "5.4.0"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Workaround for https://github.com/emscripten-core/emsdk/issues/1153.