### PR TITLE
Remove `-upstream` component of SDK names

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2111,15 +2111,15 @@ def resolve_sdk_aliases(name, verbose=False):
   return name
 
 
-def find_latest_sdk(which):
-  return 'sdk-releases-%s-%s-64bit' % (which, find_latest_hash())
+def find_latest_sdk():
+  return 'sdk-releases-%s-64bit' % (find_latest_hash())
 
 
 def find_tot_sdk():
   debug_print('Fetching emscripten-releases repository...')
   global extra_release_tag
   extra_release_tag = get_emscripten_releases_tot()
-  return 'sdk-releases-upstream-%s-64bit' % (extra_release_tag)
+  return 'sdk-releases-%s-64bit' % (extra_release_tag)
 
 
 def parse_emscripten_version(emscripten_root):
@@ -2249,7 +2249,7 @@ def get_installed_sdk_version():
     return None
   with open(version_file) as f:
     version = f.read()
-  return version.split('-')[2]
+  return version.split('-')[1]
 
 
 # Get a list of tags for emscripten-releases.
@@ -2686,8 +2686,8 @@ def error_on_missing_tool(name):
 
 def expand_sdk_name(name, activating):
   if 'upstream-master' in name:
-    errlog('upstream-master SDK has been renamed upstream-main')
-    name = name.replace('upstream-master', 'upstream-main')
+    errlog('upstream-master SDK has been renamed main')
+    name = name.replace('upstream-master', 'main')
   if 'fastcomp' in name:
     exit_with_error('the fastcomp backend is no longer supported.  Please use an older version of emsdk (for example 3.1.29) if you want to install the old fastcomp-based SDK')
   if name in ('tot', 'sdk-tot', 'tot-upstream'):
@@ -2699,34 +2699,34 @@ def expand_sdk_name(name, activating):
       installed = get_installed_sdk_version()
       if installed:
         debug_print('activating currently installed SDK; not updating tot version')
-        return 'sdk-releases-upstream-%s-64bit' % installed
+        return 'sdk-releases-%s-64bit' % installed
     return str(find_tot_sdk())
+
+  if '-upstream' in name:
+    name = name.replace('-upstream', '')
 
   name = resolve_sdk_aliases(name, verbose=True)
 
   # check if it's a release handled by an emscripten-releases version,
   # and if so use that by using the right hash. we support a few notations,
-  #   x.y.z[-upstream]
-  #   sdk-x.y.z[-upstream]-64bit
+  #   x.y.z
+  #   sdk-x.y.z-64bit
   # TODO: support short notation for old builds too?
-  backend = 'upstream'
   fullname = name
-  if '-upstream' in fullname:
-    fullname = name.replace('-upstream', '')
   version = fullname.replace('sdk-', '').replace('releases-', '').replace('-64bit', '').replace('tag-', '')
   sdk = 'sdk-' if not name.startswith('releases-') else ''
   releases_info = load_releases_info()['releases']
   release_hash = get_release_hash(version, releases_info)
   if release_hash:
     # Known release hash
-    full_name = '%sreleases-%s-%s-64bit' % (sdk, backend, release_hash)
+    full_name = '%sreleases-%s-64bit' % (sdk, release_hash)
     print("Resolving SDK version '%s' to '%s'" % (version, full_name))
     return full_name
 
   if len(version) == 40:
     global extra_release_tag
     extra_release_tag = version
-    return '%sreleases-%s-%s-64bit' % (sdk, backend, version)
+    return '%sreleases-%s-64bit' % (sdk, version)
 
   return name
 
@@ -2961,7 +2961,7 @@ def main(args):
       print('         latest')
       print('')
       print('This is equivalent to installing/activating:')
-      print('         %s             %s' % (find_latest_version(), installed_sdk_text(find_latest_sdk('upstream'))))
+      print('         %s             %s' % (find_latest_version(), installed_sdk_text(find_latest_sdk())))
       print('')
     else:
       print('Warning: your platform does not have precompiled SDKs available.')
@@ -2976,7 +2976,7 @@ def main(args):
     )
     releases_info = load_releases_info()['releases']
     for ver in releases_versions:
-      print('         %s    %s' % (ver, installed_sdk_text('sdk-releases-upstream-%s-64bit' % get_release_hash(ver, releases_info))))
+      print('         %s    %s' % (ver, installed_sdk_text('sdk-releases-%s-64bit' % get_release_hash(ver, releases_info))))
     print()
 
     # Use array to work around the lack of being able to mutate from enclosing

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -31,7 +31,7 @@
 
   {
     "id": "releases",
-    "version": "upstream-%releases-tag%",
+    "version": "%releases-tag%",
     "bitness": 64,
     "arch": "x86_64",
     "linux_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/linux/%releases-tag%/wasm-binaries.tbz2",
@@ -45,7 +45,7 @@
   },
   {
     "id": "releases",
-    "version": "upstream-%releases-tag%",
+    "version": "%releases-tag%",
     "bitness": 64,
     "arch": "aarch64",
     "macos_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/mac/%releases-tag%/wasm-binaries-arm64.tbz2",
@@ -543,56 +543,56 @@
 
   "sdks": [
   {
-    "version": "upstream-main",
+    "version": "main",
     "bitness": 64,
     "uses": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
-    "version": "upstream-main",
+    "version": "main",
     "bitness": 64,
     "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
-    "version": "upstream-main",
+    "version": "main",
     "bitness": 64,
     "uses": ["llvm-git-main-64bit", "node-14.18.2-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
-    "version": "upstream-main",
+    "version": "main",
     "bitness": 32,
     "uses": ["llvm-git-main-32bit", "emscripten-main-32bit", "binaryen-main-32bit"],
     "os": "linux"
   },
   {
-    "version": "releases-upstream-%releases-tag%",
+    "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "releases-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
-    "version": "releases-upstream-%releases-tag%",
+    "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
   },
   {
-    "version": "releases-upstream-%releases-tag%",
+    "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
   },
   {
-    "version": "releases-upstream-%releases-tag%",
+    "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-14.18.2-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
+    "uses": ["node-14.18.2-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   }

--- a/test/test.py
+++ b/test/test.py
@@ -205,8 +205,8 @@ int main() {
 
   def test_specific_version_full(self):
     print('test specific release (new, full name)')
-    run_emsdk('install sdk-1.38.33-upstream-64bit')
-    run_emsdk('activate sdk-1.38.33-upstream-64bit')
+    run_emsdk('install sdk-1.38.33-64bit')
+    run_emsdk('activate sdk-1.38.33-64bit')
     print('test specific release (new, tag name)')
     run_emsdk('install sdk-tag-1.38.33-64bit')
     run_emsdk('activate sdk-tag-1.38.33-64bit')
@@ -250,11 +250,11 @@ int main() {
 
   def test_install_tool(self):
     # Test that its possible to install emscripten as tool instead of SDK
-    checked_call_with_output(emsdk + ' install releases-upstream-77b065ace39e6ab21446e13f92897f956c80476a', unexpected='Installing SDK')
+    checked_call_with_output(emsdk + ' install releases-77b065ace39e6ab21446e13f92897f956c80476a', unexpected='Installing SDK')
 
   def test_activate_missing(self):
     run_emsdk('install latest')
-    failing_call_with_output(emsdk + ' activate 2.0.1', expected="error: tool is not installed and therefore cannot be activated: 'releases-upstream-13e29bd55185e3c12802bc090b4507901856b2ba-64bit'")
+    failing_call_with_output(emsdk + ' activate 2.0.1', expected="error: tool is not installed and therefore cannot be activated: 'releases-13e29bd55185e3c12802bc090b4507901856b2ba-64bit'")
 
   def test_keep_downloads(self):
     env = os.environ.copy()


### PR DESCRIPTION
This name existed to distinguish the SDK from fastcomp, but as of #1165, we no longer support fastcomp.