### PR TITLE
Fix args ordering in LLVM build from previous commit

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1070,15 +1070,16 @@ def build_llvm(tool):
     targets_to_build = 'WebAssembly;AArch64'
   else:
     targets_to_build = 'WebAssembly'
-  args = ['-DLLVM_TARGETS_TO_BUILD=' + targets_to_build,
-          '-DLLVM_INCLUDE_EXAMPLES=OFF',
-          '-DLLVM_INCLUDE_TESTS=' + tests_arg,
-          '-DCLANG_INCLUDE_TESTS=' + tests_arg,
-          '-DLLVM_ENABLE_ASSERTIONS=' + ('ON' if enable_assertions else 'OFF'),
-          # Disable optional LLVM dependencies, these can cause unwanted .so dependencies
-          # that prevent distributing the generated compiler for end users.
-          '-DLLVM_ENABLE_LIBXML2=OFF', '-DLLVM_ENABLE_TERMINFO=OFF', '-DLLDB_ENABLE_LIBEDIT=OFF',
-          '-DLLVM_ENABLE_LIBEDIT=OFF', '-DLLVM_ENABLE_LIBPFM=OFF']
+  cmake_generator, args = get_generator_and_config_args(tool)
+  args += ['-DLLVM_TARGETS_TO_BUILD=' + targets_to_build,
+           '-DLLVM_INCLUDE_EXAMPLES=OFF',
+           '-DLLVM_INCLUDE_TESTS=' + tests_arg,
+           '-DCLANG_INCLUDE_TESTS=' + tests_arg,
+           '-DLLVM_ENABLE_ASSERTIONS=' + ('ON' if enable_assertions else 'OFF'),
+           # Disable optional LLVM dependencies, these can cause unwanted .so dependencies
+           # that prevent distributing the generated compiler for end users.
+           '-DLLVM_ENABLE_LIBXML2=OFF', '-DLLVM_ENABLE_TERMINFO=OFF', '-DLLDB_ENABLE_LIBEDIT=OFF',
+           '-DLLVM_ENABLE_LIBEDIT=OFF', '-DLLVM_ENABLE_LIBPFM=OFF']
   # LLVM build system bug: compiler-rt does not build on Windows. It insists on performing a CMake install step that writes to C:\Program Files. Attempting
   # to reroute that to build_root directory then fails on an error
   #  file INSTALL cannot find
@@ -1086,7 +1087,6 @@ def build_llvm(tool):
   # (there instead of $(Configuration), one would need ${CMAKE_BUILD_TYPE} ?)
   # It looks like compiler-rt is not compatible to build on Windows?
   args += ['-DLLVM_ENABLE_PROJECTS=clang;lld']
-  cmake_generator, args = get_generator_and_config_args(tool)
 
   if os.getenv('LLVM_CMAKE_ARGS'):
     extra_args = os.environ['LLVM_CMAKE_ARGS'].split(',')


### PR DESCRIPTION
Looks like the CI did not fail on an error from the previous PR, but just left the tasks hung. I misinterpreted the two copies of each task (one green, another yellow hung) as a CI fluke, but it might be caused by this typo in refactor.