### PR TITLE
Improve ordering in `emsdk list`

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2845,11 +2845,7 @@ def main(args):
       print('')
 
     print('All recent (non-legacy) installable versions are:')
-    releases_versions = sorted(
-      load_releases_versions(),
-      key=lambda x: [int(v) if v.isdigit() else -1 for v in x.split('.')],
-      reverse=True,
-    )
+    releases_versions = sorted(load_releases_versions(), key=version_key, reverse=True)
     releases_info = load_releases_info()['releases']
     for ver in releases_versions:
       print('         %s    %s' % (ver, installed_sdk_text('sdk-releases-%s-64bit' % get_release_hash(ver, releases_info))))


### PR DESCRIPTION
We have an existing `version_key` helper function for sorting versions.

It also does a better job, producing output like:

```
All recent (non-legacy) installable versions are:
         3.1.31
         3.1.31-asserts
         3.1.30
         3.1.30-asserts
         3.1.29
         3.1.29-asserts
```

Rather than:

```
All recent (non-legacy) installable versions are:
         3.1.31
         3.1.30
         3.1.29
         3.1.28
         3.1.27
```

(with -assert versions listed after 3.1.0)