### PR TITLE
Only add node/bin to user's PATH if one is not already found

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1433,6 +1433,8 @@ def get_required_path(active_tools):
   path_add = [to_native_path(EMSDK_PATH)]
   for tool in active_tools:
     if hasattr(tool, 'activated_path'):
+      if hasattr(tool, 'activated_path_skip') and which(tool.activated_path_skip):
+        continue
       path = to_native_path(tool.expand_vars(tool.activated_path))
       path_add.append(path)
   return path_add

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -204,6 +204,7 @@
     "arch": "x86",
     "windows_url": "node-v14.15.5-win-x86.zip",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
@@ -214,6 +215,7 @@
     "bitness": 32,
     "linux_url": "node-v14.15.5-linux-armv7l.tar.xz",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
@@ -226,6 +228,7 @@
     "windows_url": "node-v14.15.5-win-x64.zip",
     "linux_url": "node-v14.15.5-linux-x64.tar.xz",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
@@ -237,6 +240,7 @@
     "macos_url": "node-v14.15.5-darwin-x64.tar.gz",
     "linux_url": "node-v14.15.5-linux-arm64.tar.xz",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },


### PR DESCRIPTION
If the user already has a version of node in their PATH don't clobber it.  This doesn't effect emscripten since the version of node we use there is controlled via the config file, not via PATH.

This change was originally proposed in #714 and we decided against it because there was some danger that it might confuse some users.  However since we closes #714 more and more users have been frustrated buy the status quo.  I also looked into several options for allowing users to opt out explicitly, but they all seems to have the same problem which is that the users don't want their version of node shadowed in the default case.

Part of fix for #705.