### PR TITLE
Update some stale information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,14 @@ important concepts to help understanding the internals of the SDK:
 * **SDK**: A set of tools. For example, 'sdk-1.5.6-32bit' is an SDK consisting
   of the tools `clang-3.2-32bit`, `node-0.10.17-32bit`, `python-2.7.5.1-32bit`
   and `emscripten-1.5.6`.
-* **Active Tool/SDK**: Emscripten stores compiler configuration in a
-  user-specific file **~/.emscripten**. This file points to paths for
-  Emscripten, Python, Clang and so on. If the file ~/.emscripten is configured
-  to point to a Tool in a specific directory, then that tool is denoted as being
-  **active**. The Emscripten Command Prompt always gives access to the currently
-  active Tools. This mechanism allows switching between different installed SDK
-  versions easily.
+* **Active Tool/SDK**: Emscripten SDK stores compiler configuration in a file
+  called `.emscripten` within the emsdk directory. This file points to paths
+  for Emscripten, Python, Clang and so on. If the configuration file points to a
+  Tool in a specific directory, then that tool is denoted as being
+  **active**. This mechanism allows switching between different installed
+  tools and SDKs.
 * **emsdk**: This is the name of the manager script that Emscripten SDK is
-  accessed through. Most operations are of the form `emsdk command`. To access
-  the emsdk script, launch the Emscripten Command Prompt.
+  accessed through. Most operations are of the form `emsdk <command>`.
 
 ## System Requirements
 
@@ -178,18 +176,6 @@ You can toggle between different tools and SDK versions by running `emsdk
 activate <tool/sdk name>`. Activating a tool will set up `~/.emscripten` to
 point to that particular tool. On Windows, you can pass the option `--permanent` to
 the `activate` command to register the environment permanently for the current user. Use `--system` to do this for all users.
-
-### How do I build multiple projects with different SDK versions in parallel?
-
-By default, Emscripten locates all configuration files in the home directory of
-the user. This may be a problem if you need to simultaneously build with
-multiple Emscripten compiler versions, since the user home directory can only be
-configured to point to one compiler at a time. This can be overcome by
-specifying the '--embedded' option as a parameter to 'emsdk activate', which
-will signal emsdk to generate the compiler configuration files inside the emsdk
-root directory instead of the user home directory. Use this option also when it
-is desirable to run emsdk in a fully portable mode that does not touch any files
-outside the emsdk directory.
 
 ### How do I track the latest Emscripten development with the SDK?
 


### PR DESCRIPTION
- Remove reference to `~/.emscripten`.  We no longer use the home directory to store config information by default, either in emscripten or in emsdk.
- Remove some references to `The Emscripten Command Prompt`.  While I suppose this is referring to the windows-only `emcmdprompt.bat`, and I suppose it means "any shell where `activate` has been run", I think its more clear to simply avoid using the term.