### PR TITLE
[WIP] Fix environment constructing in MSYS2 shell

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -129,7 +129,7 @@ if not CSH and not POWERSHELL and not BASH and not CMD:
   else:
     BASH = True
 
-if WINDOWS:
+if WINDOWS and not MSYS:
   ENVPATH_SEPARATOR = ';'
 else:
   ENVPATH_SEPARATOR = ':'


### PR DESCRIPTION
Without this fix, ``source `emsdk.py construct_env` `` or `.\emsdk_env.sh` corrupts `PATH` by remving the default system paths.