### PR TITLE
Docker: avoid sourcing `emsdk_env.sh` in interactive shells

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,7 @@ FROM ubuntu:jammy AS stage_deploy
 COPY --from=stage_build /emsdk /emsdk
 
 # Set up emsdk environment
+# This corresponds to the environment variables set during `source ./emsdk_env.sh`
 ENV EMSDK=/emsdk \
     EMSDK_NODE=/emsdk/node/15.14.0_64bit/bin/node \
     PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/15.14.0_64bit/bin:${PATH}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,9 +60,7 @@ FROM ubuntu:jammy AS stage_deploy
 
 COPY --from=stage_build /emsdk /emsdk
 
-# Fallback in case Emscripten isn't activated.
-# This will let use tools offered by this image inside other Docker images
-# (sub-stages) or with custom / no entrypoint
+# Set up emsdk environment
 ENV EMSDK=/emsdk \
     EMSDK_NODE=/emsdk/node/15.14.0_64bit/bin/node \
     PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/15.14.0_64bit/bin:${PATH}"
@@ -79,7 +77,6 @@ RUN echo "## Create emscripten user (1000:1000)" \
     && groupadd --gid 1000 emscripten \
     && useradd --uid 1000 --gid emscripten --shell /bin/bash --create-home emscripten \
     && echo "umask 0000" >> /etc/bash.bashrc \
-    && echo ". /emsdk/emsdk_env.sh" >> /etc/bash.bashrc \
     && echo "## Done"
 
 # ------------------------------------------------------------------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,6 @@ ENV EMSDK=/emsdk \
 RUN echo "## Create emscripten user (1000:1000)" \
     && groupadd --gid 1000 emscripten \
     && useradd --uid 1000 --gid emscripten --shell /bin/bash --create-home emscripten \
-    && echo "umask 0000" >> /etc/bash.bashrc \
     && echo "## Done"
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Instead, rely on the already set `PATH` environment variable.

---

This would ensure that a custom cache directory via `EM_CACHE` is honored rather than being ignored.

Current behavior: 
```console
$ docker run -it --rm -v $(pwd):/src -e EM_CACHE=/src/build/emcache emscripten/emsdk:3.1.39
...
Clearing existing environment variable: EM_CACHE
root@9c00b2231a23:/src# echo $EM_CACHE


```

New behavior: 
```console
$ docker run -it --rm -v $(pwd):/src -e EM_CACHE=/src/build/emcache emscripten/emsdk
root@7ed76e8b10f9:/src# echo $EM_CACHE
/src/build/emcache
```

Context: https://github.com/kleisauke/wasm-vips/issues/49.