### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+Please submit the report as a [security bug on the Chromium tracker](https://bugs.chromium.org/p/chromium/issues/entry?template=Security%20Bug).
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+- Make it clear that it's an Emscripten SDK bug.
+
+We ask that you give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #1223.

This PR adds a security policy to emsdk. This policy is almost identical to the [policy](https://github.com/emscripten-core/emscripten/blob/main/SECURITY.md) for the main emscripten repo.

Let me know if you don't believe the Chromium tracker is the best place for emsdk vulnerabilities.

Alternatively, to reduce duplication, the emscripten org could also create an https://github.com/emscripten/.github repository and place a single policy there. It'd then be visible in all of its repos.