### PR TITLE
Docker: use a entrypoint script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 # Ignore everything
 *
 
-# Allow to run the test script inside the Docker container
+# Allow the entrypoint/test script inside the Docker container
+!/docker/entrypoint.sh
 !/docker/test_dockerimage.sh
 
 # Allow license file

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ COPY --from=stage_build /emsdk /emsdk
 # using `--entrypoint /bin/bash` in CLI).
 # This corresponds to the env variables set during: `source ./emsdk_env.sh`
 ENV EMSDK=/emsdk \
-    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/16.20.0_64bit/bin:${PATH}"
+    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/node/16.20.0_64bit/bin:${PATH}"
 
 # ------------------------------------------------------------------------------
 # Create a 'standard` 1000:1000 user

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,9 +58,10 @@ FROM ubuntu:jammy AS stage_deploy
 
 COPY --from=stage_build /emsdk /emsdk
 
-# Fallback in case Emscripten isn't activated.
-# This will let use tools offered by this image inside other Docker images
-# (sub-stages) or with custom / no entrypoint
+# These fallback environment variables are intended for situations where the
+# entrypoint is not utilized (as in a derived image) or overridden (e.g. when
+# using `--entrypoint /bin/bash` in CLI).
+# This corresponds to the env variables set during: `source ./emsdk_env.sh`
 ENV EMSDK=/emsdk \
     PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/16.20.0_64bit/bin:${PATH}"
 
@@ -75,8 +76,6 @@ ENV EMSDK=/emsdk \
 RUN echo "## Create emscripten user (1000:1000)" \
     && groupadd --gid 1000 emscripten \
     && useradd --uid 1000 --gid emscripten --shell /bin/bash --create-home emscripten \
-    && echo "umask 0000" >> /etc/bash.bashrc \
-    && echo ". /emsdk/emsdk_env.sh" >> /etc/bash.bashrc \
     && echo "## Done"
 
 # ------------------------------------------------------------------------------
@@ -119,6 +118,8 @@ RUN echo "## Update and install packages" \
 # ------------------------------------------------------------------------------
 # Use commonly used /src as working directory
 WORKDIR /src
+
+ENTRYPOINT ["/emsdk/docker/entrypoint.sh"]
 
 LABEL maintainer="kontakt@trzeci.eu" \
       org.label-schema.name="emscripten" \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -17,8 +17,8 @@ build: Dockerfile .TEST
 
 test: test_dockerimage.sh .TEST
 	# test as non-root
-	docker run --rm -u `id -u`:`id -g` -w /emsdk/docker --net=host ${image_name}:${version} \
-		bash $<
+	# test fallback env variables by overriding the entrypoint
+	docker run --rm -u `id -u`:`id -g` -w /emsdk/docker --net=host --entrypoint /bin/bash ${image_name}:${version} $<
 
 push: .TEST
 	docker push ${image_name}:${version}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Set-up PATH and other environment variables
+EMSDK_QUIET=1 source /emsdk/emsdk_env.sh
+
+exec "$@"

--- a/docker/test_dockerimage.sh
+++ b/docker/test_dockerimage.sh
@@ -5,7 +5,6 @@ if [ $EUID -eq 0 ]; then
   sudo -u nobody `which emcc` --version
 fi
 
-which llvm-ar
 which emsdk
 node --version
 npm --version


### PR DESCRIPTION
In favor of `/etc/bash.bashrc`, which is only read for interactive shells.