### PR TITLE
Hash-pin docker images, set up dependabot to keep them up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy AS stage_build
+FROM ubuntu:jammy@sha256:6120be6a2b7ce665d0cbddc3ce6eae60fe94637c6a66985312d1f02f63cc0bcd AS stage_build
 
 ARG EMSCRIPTEN_VERSION=tot
 ENV EMSDK /emsdk
@@ -54,7 +54,7 @@ RUN echo "## Aggressive optimization: Remove debug symbols" \
 # -------------------------------- STAGE DEPLOY --------------------------------
 # ------------------------------------------------------------------------------
 
-FROM ubuntu:jammy AS stage_deploy
+FROM ubuntu:jammy@sha256:6120be6a2b7ce665d0cbddc3ce6eae60fe94637c6a66985312d1f02f63cc0bcd AS stage_deploy
 
 COPY --from=stage_build /emsdk /emsdk
 


### PR DESCRIPTION
Fixes #1243.

As described in the issue, this PR hash-pins the ubuntu:jammy image used in docker/Dockerfile. This prevents unexpected tampering with the image.

Keeping pinned images up-to-date can be a hassle, so I've also set up dependabot, which will periodically send a PR to bump the image's version.