### PR TITLE
bazel: add standalone defines during compile

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -1019,7 +1019,7 @@ def _impl(ctx):
             features = ["wasm_warnings_as_errors"],
         ),
         flag_set(
-            actions = ALL_COMPILE_ACTIONS,
+            actions = all_compile_actions,
             flags = ["-DSTANDALONE_WASM=1", "-DEMSCRIPTEN_STANDALONE_WASM=1"],
             features = ["wasm_standalone"],
         ),

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -1019,6 +1019,11 @@ def _impl(ctx):
             features = ["wasm_warnings_as_errors"],
         ),
         flag_set(
+            actions = ALL_COMPILE_ACTIONS,
+            flags = ["-DSTANDALONE_WASM=1", "-DEMSCRIPTEN_STANDALONE_WASM=1"],
+            features = ["wasm_standalone"],
+        ),
+        flag_set(
             actions = all_link_actions,
             flags = ["-sSTANDALONE_WASM"],
             features = ["wasm_standalone"],


### PR DESCRIPTION
specifically, define `STANDALONE_WASM` and `EMSCRIPTEN_STANDALONE_WASM` during compile actions for standalone mode