### PR TITLE
Define STANDALONE_WASM at compile time as well as link time

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -1019,6 +1019,11 @@ def _impl(ctx):
             features = ["wasm_warnings_as_errors"],
         ),
         flag_set(
+            actions = all_compile_actions,
+            flags = ["-DSTANDALONE_WASM"],
+            features = ["wasm_standalone"],
+        ),
+        flag_set(
             actions = all_link_actions,
             flags = ["-sSTANDALONE_WASM"],
             features = ["wasm_standalone"],


### PR DESCRIPTION
This fixes libraries using conditional dependencies, such as Abseil: https://github.com/search?q=repo%3Aabseil%2Fabseil-cpp+standalone_wasm&type=code