### PR TITLE
wasm_cc_binary: Specify a default OS. Allow users to override platform.

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -82,6 +82,13 @@ platform(
     name = "platform_wasm",
     constraint_values = [
         "@platforms//cpu:wasm32",
+    ],
+)
+
+platform(
+    name = "platform_wasi",
+    constraint_values = [
+        "@platforms//cpu:wasm32",
         "@platforms//os:wasi",
     ],
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -82,5 +82,6 @@ platform(
     name = "platform_wasm",
     constraint_values = [
         "@platforms//cpu:wasm32",
+        "@platforms//os:wasi",
     ],
 )

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -25,7 +25,9 @@ def _wasm_transition_impl(settings, attr):
     if attr.simd:
         features.append("wasm_simd")
 
+    platform = "@emsdk//:platform_wasm"
     if attr.standalone:
+        platform = "@emsdk//:platform_wasi"
         features.append("wasm_standalone")
 
     return {
@@ -35,7 +37,7 @@ def _wasm_transition_impl(settings, attr):
         "//command_line_option:features": features,
         "//command_line_option:dynamic_mode": "off",
         "//command_line_option:linkopt": linkopts,
-        "//command_line_option:platforms": [attr.platform],
+        "//command_line_option:platforms": [platform],
         "//command_line_option:custom_malloc": "@emsdk//emscripten_toolchain:malloc",
     }
 
@@ -81,9 +83,6 @@ _WASM_BINARY_COMMON_ATTRS = {
     ),
     "exit_runtime": attr.bool(
         default = False,
-    ),
-    "platform": attr.label(
-        default = "@emsdk//:platform_wasm",
     ),
     "threads": attr.string(
         default = "_default",

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -35,7 +35,7 @@ def _wasm_transition_impl(settings, attr):
         "//command_line_option:features": features,
         "//command_line_option:dynamic_mode": "off",
         "//command_line_option:linkopt": linkopts,
-        "//command_line_option:platforms": ["@emsdk//:platform_wasm"],
+        "//command_line_option:platforms": [attr.platform],
         "//command_line_option:custom_malloc": "@emsdk//emscripten_toolchain:malloc",
     }
 
@@ -81,6 +81,9 @@ _WASM_BINARY_COMMON_ATTRS = {
     ),
     "exit_runtime": attr.bool(
         default = False,
+    ),
+    "platform": attr.label(
+        default = "@emsdk//:platform_wasm",
     ),
     "threads": attr.string(
         default = "_default",


### PR DESCRIPTION
Problem: https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/pull/157#discussion_r1277763118

After discussion, we decided to target `@platforms//os:wasi` based on attr.standalone.