### PR TITLE
Fix the format of the .flake8 file, and exclude the script directory from the py2 linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: python3 -m pip install --upgrade pip
       - run: python2 -m pip install flake8==3.8
       - run: python3 -m pip install flake8==3.8
-      - run: python2 -m flake8 --show-source --statistics --extend-exclude=scripts/
+      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: python3 -m pip install --upgrade pip
       - run: python2 -m pip install flake8==3.8
       - run: python3 -m pip install flake8==3.8
-      - run: python2 -m flake8 --show-source --statistics --extend-excludeeee=./scripts
+      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: python3 -m pip install --upgrade pip
       - run: python2 -m pip install flake8==3.8
       - run: python3 -m pip install flake8==3.8
-      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts
+      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts/
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: python3 -m pip install --upgrade pip
       - run: python2 -m pip install flake8==3.9.2
       - run: python3 -m pip install flake8==3.9.2
-      - run: python2 -m flake8 --show-source --statistics --exclude=./scripts
+      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ jobs:
             apt-get install -q -y python-pip python3-pip
       - run: python2 -m pip install --upgrade pip
       - run: python3 -m pip install --upgrade pip
-      - run: python2 -m pip install flake8==4.0
-      - run: python3 -m pip install flake8==4.0
+      - run: python2 -m pip install flake8==3.9.2
+      - run: python3 -m pip install flake8==3.9.2
       - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts
       - run: python3 -m flake8 --show-source --statistics
   test-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,9 @@ jobs:
             apt-get install -q -y python-pip python3-pip
       - run: python2 -m pip install --upgrade pip
       - run: python3 -m pip install --upgrade pip
-      - run: python2 -m pip install flake8==3.8
-      - run: python3 -m pip install flake8==3.8
-      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts/
+      - run: python2 -m pip install flake8==4.0
+      - run: python3 -m pip install flake8==4.0
+      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ jobs:
             apt-get install -q -y python-pip python3-pip
       - run: python2 -m pip install --upgrade pip
       - run: python3 -m pip install --upgrade pip
-      - run: python2 -m pip install flake8==3.7.8
-      - run: python3 -m pip install flake8==3.7.8
+      - run: python2 -m pip install flake8==3.8
+      - run: python3 -m pip install flake8==3.8
       - run: python2 -m flake8 --show-source --statistics
       - run: python3 -m flake8 --show-source --statistics
   test-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: python3 -m pip install --upgrade pip
       - run: python2 -m pip install flake8==3.9.2
       - run: python3 -m pip install flake8==3.9.2
-      - run: python2 -m flake8 --show-source --statistics --extend-exclude=update*.py
+      - run: python2 -m flake8 --show-source --statistics --exclude=./scripts
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: python3 -m pip install --upgrade pip
       - run: python2 -m pip install flake8==3.8
       - run: python3 -m pip install flake8==3.8
-      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts
+      - run: python2 -m flake8 --show-source --statistics --extend-excludeeee=./scripts
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: python3 -m pip install --upgrade pip
       - run: python2 -m pip install flake8==3.9.2
       - run: python3 -m pip install flake8==3.9.2
-      - run: python2 -m flake8 --show-source --statistics --extend-exclude=./scripts
+      - run: python2 -m flake8 --show-source --statistics --extend-exclude=update*.py
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: python3 -m pip install --upgrade pip
       - run: python2 -m pip install flake8==3.8
       - run: python3 -m pip install flake8==3.8
-      - run: python2 -m flake8 --show-source --statistics
+      - run: python2 -m flake8 --show-source --statistics --extend-exclude=scripts/
       - run: python3 -m flake8 --show-source --statistics
   test-linux:
     executor: bionic

--- a/.flake8
+++ b/.flake8
@@ -21,3 +21,4 @@ exclude =
   ./temp
   ./downloads
   ./crunch
+  ./scripts

--- a/.flake8
+++ b/.flake8
@@ -22,4 +22,3 @@ exclude =
   ./temp
   ./downloads
   ./crunch
-  ./scripts

--- a/.flake8
+++ b/.flake8
@@ -7,18 +7,18 @@ ignore =
    E722  # bare excepts
    E741, # Variable names such as 'l', 'O', or 'I'
 exclude =
-  ./llvm
-  ./gnu
-  ./upstream
-  ./fastcomp
-  ./fastcomp-clang
-  ./releases
-  ./clang
-  ./emscripten
-  ./binaryen
-  ./git
-  ./node
-  ./python
-  ./temp
-  ./downloads
-  ./crunch
+  ./llvm,
+  ./gnu,
+  ./upstream,
+  ./fastcomp,
+  ./fastcomp-clang,
+  ./releases,
+  ./clang,
+  ./emscripten,
+  ./binaryen,
+  ./git,
+  ./node,
+  ./python,
+  ./temp,
+  ./downloads,
+  ./crunch,

--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,7 @@ ignore =
    E501, # Line too long
    E121, # Continuation line under-indented for hanging indent
    E722  # bare excepts
+   E741, # Variable names such as 'l', 'O', or 'I'
 exclude =
   ./llvm
   ./gnu

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -22,8 +22,7 @@ def version_key(version_string):
 
 def main(args):
   if subprocess.check_output(['git', 'status', '--porcelain'], cwd=root_dir).strip():
-    print(f'tree is not clean{asdf}')
-    # This is a bogus change
+    print('tree is not clean')
     sys.exit(1)
 
   release_info = emsdk.load_releases_info()

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -22,7 +22,7 @@ def version_key(version_string):
 
 def main(args):
   if subprocess.check_output(['git', 'status', '--porcelain'], cwd=root_dir).strip():
-    print('tree is not clean')
+    print(f'tree is not clean{asdf}')
     # This is a bogus change
     sys.exit(1)
 

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -23,6 +23,7 @@ def version_key(version_string):
 def main(args):
   if subprocess.check_output(['git', 'status', '--porcelain'], cwd=root_dir).strip():
     print('tree is not clean')
+    # This is a bogus change
     sys.exit(1)
 
   release_info = emsdk.load_releases_info()


### PR DESCRIPTION
Flake8's INI config file format requires commas after each line. Because our file didn't have them, the exclude list
wasn't set up correctly, and the `--extend-exclude` flag wasn't working. This PR fixes the .flake8 file.

Also, update flake8 to the latest version available (because version 3.8 is required to get the --extend-exclude flag)
and use the flag to exclude the files in the scripts/ directory from the python2 linter (since the scripts are python3).