### PR TITLE
[bazel] populate all_files

### DIFF
--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -43,6 +43,15 @@ filegroup(
     ],
 )
 
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":ar_files",
+        ":compiler_files",
+        ":linker_files",
+    ],
+)
+
 filegroup(name = "empty")
 
 # dlmalloc.bc is implictly added by the emscripten toolchain
@@ -61,7 +70,7 @@ emscripten_cc_toolchain_config_rule(
 
 cc_toolchain(
     name = "cc-compiler-wasm",
-    all_files = ":empty",
+    all_files = ":all_files",
     ar_files = ":ar_files",
     as_files = ":empty",
     compiler_files = ":compiler_files",


### PR DESCRIPTION
Fixes #1273. This was broken by #1045 with the comment "* all_files not needed?" They were needed.