### PR TITLE
Upgrade to Node.js 18.18.0

### DIFF
--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -112,9 +112,8 @@ def emscripten_deps(emscripten_version = "latest"):
     # dependencies that use different emscripten versions
     excludes = native.existing_rules().keys()
     if "nodejs_toolchains" not in excludes:
-        # Node 16 is the first version that supports darwin_arm64
         node_repositories(
-            node_version = "16.6.2",
+            node_version = "18.18.0",
         )
 
     if "emscripten_bin_linux" not in excludes:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ COPY --from=stage_build /emsdk /emsdk
 # using `--entrypoint /bin/bash` in CLI).
 # This corresponds to the env variables set during: `source ./emsdk_env.sh`
 ENV EMSDK=/emsdk \
-    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/node/16.20.0_64bit/bin:${PATH}"
+    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/node/18.18.0_64bit/bin:${PATH}"
 
 # ------------------------------------------------------------------------------
 # Create a 'standard` 1000:1000 user

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -346,6 +346,53 @@
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
 
+  {
+    "id": "node",
+    "version": "18.18.0",
+    "arch": "x86",
+    "bitness": 32,
+    "windows_url": "node-v18.18.0-win-x86.zip",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "18.18.0",
+    "arch": "arm",
+    "bitness": 32,
+    "linux_url": "node-v18.18.0-linux-armv7l.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "18.18.0",
+    "arch": "x86_64",
+    "bitness": 64,
+    "macos_url": "node-v18.18.0-darwin-x64.tar.gz",
+    "windows_url": "node-v18.18.0-win-x64.zip",
+    "linux_url": "node-v18.18.0-linux-x64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "18.18.0",
+    "arch": "arm64",
+    "bitness": 64,
+    "macos_url": "node-v18.18.0-darwin-arm64.tar.gz",
+    "linux_url": "node-v18.18.0-linux-arm64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
 
   {
     "id": "python",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -697,19 +697,19 @@
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-16.20.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-18.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-16.20.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-18.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-16.20.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-18.180-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
@@ -721,14 +721,14 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-16.20.0-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-18.18.0-64bit", "releases-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-16.20.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-18.18.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -736,7 +736,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-16.20.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-18.18.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "arm64",
     "custom_install_script": "emscripten_npm_install"
@@ -744,7 +744,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-16.20.0-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-18.18.0-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   }

--- a/scripts/update_node.py
+++ b/scripts/update_node.py
@@ -16,8 +16,8 @@ import subprocess
 import os
 import shutil
 
-version = '16.20.0'
-base = 'https://nodejs.org/dist/latest-v16.x/'
+version = '18.18.0'
+base = 'https://nodejs.org/dist/v18.18.0/'
 upload_base = 'gs://webassembly/emscripten-releases-builds/deps/'
 
 suffixes = [

--- a/test/test.py
+++ b/test/test.py
@@ -176,9 +176,9 @@ int main() {
 
     # Test the normal tools like node don't re-download on re-install
     print('another install must re-download')
-    checked_call_with_output(emsdk + ' uninstall node-15.14.0-64bit')
-    checked_call_with_output(emsdk + ' install node-15.14.0-64bit', expected='Downloading:', unexpected='already installed')
-    checked_call_with_output(emsdk + ' install node-15.14.0-64bit', unexpected='Downloading:', expected='already installed')
+    checked_call_with_output(emsdk + ' uninstall node-18.18.0-64bit')
+    checked_call_with_output(emsdk + ' install node-18.18.0-64bit', expected='Downloading:', unexpected='already installed')
+    checked_call_with_output(emsdk + ' install node-18.18.0-64bit', unexpected='Downloading:', expected='already installed')
 
   def test_tot_upstream(self):
     print('test update-tags')


### PR DESCRIPTION
This aims to update to [Node.js 18.18.0](https://nodejs.org/en/blog/release/v18.18.0), as discussed in #1173 . I'm not sure if it updates everything needed, but does update the manifest, as well all references. We'll need to do some aggressive testing to ensure it's correct.