### PR TITLE
[bazel] Add an :all target to binary repos

### DIFF
--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -9,6 +9,11 @@ BUILD_FILE_CONTENT_TEMPLATE = """
 package(default_visibility = ['//visibility:public'])
 
 filegroup(
+    name = "all",
+    srcs = glob(["**"]),
+)
+
+filegroup(
     name = "includes",
     srcs = glob([
         "emscripten/cache/sysroot/include/c++/v1/**",


### PR DESCRIPTION
This is the simplest solution to my problem described in #1294.

I'm happy to change this to something more specific, e.g. by exporting only the files I currently need, but it seems like having an :all target is the most future-proof way here.

Closes #1294.