### PR TITLE
Don't install java when installing windows sdk

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -193,24 +193,6 @@
     "activated_env": "EMSDK_PYTHON=%installation_dir%/bin/python3;SSL_CERT_FILE=%installation_dir%/lib/python3.9/site-packages/certifi/cacert.pem"
   },
   {
-    "id": "java",
-    "version": "8.152",
-    "bitness": 32,
-    "arch": "x86",
-    "windows_url": "portable_jre_8_update_152_32bit.zip",
-    "activated_env": "JAVA_HOME=%installation_dir%",
-    "activated_cfg": "JAVA='%installation_dir%/bin/java%.exe%'"
-  },
-  {
-    "id": "java",
-    "version": "8.152",
-    "bitness": 64,
-    "arch": "x86_64",
-    "windows_url": "portable_jre_8_update_152_64bit.zip",
-    "activated_env": "JAVA_HOME=%installation_dir%",
-    "activated_cfg": "JAVA='%installation_dir%/bin/java%.exe%'"
-  },
-  {
     "id": "emscripten",
     "version": "tag-%tag%",
     "bitness": 32,
@@ -415,7 +397,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-20.18.0-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-20.18.0-64bit", "python-3.9.2-nuget-64bit", "releases-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   }

--- a/test/test_activation.ps1
+++ b/test/test_activation.ps1
@@ -29,7 +29,6 @@ try {
     $EMSDK = [System.Environment]::GetEnvironmentVariable("EMSDK", $env_type)
     $EMSDK_NODE = [System.Environment]::GetEnvironmentVariable("EMSDK_NODE", $env_type)
     $EMSDK_PYTHON = [System.Environment]::GetEnvironmentVariable("EMSDK_PYTHON", $env_type)
-    $JAVA_HOME = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", $env_type)
     $PATH = [System.Environment]::GetEnvironmentVariable("PATH", $env_type)
 
     if (!$EMSDK) {
@@ -37,9 +36,6 @@ try {
     }
     if (!$EMSDK_NODE) {
         throw "EMSDK_NODE is not set for the user"
-    }
-    if (!$JAVA_HOME) {
-        throw "JAVA_HOME is not set for the user"
     }
     if (!$EMSDK_PYTHON) {
         throw "EMSDK_PYTHON is not set for the user"
@@ -76,20 +72,17 @@ finally {
     [Environment]::SetEnvironmentVariable("EMSDK", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "User")
-    [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "User")
 
     try {
         [Environment]::SetEnvironmentVariable("EMSDK", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Machine")
-        [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
     } catch {}
 
 
     [Environment]::SetEnvironmentVariable("EMSDK", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Process")
-    [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Process")
 
     refreshenv
 }

--- a/test/test_path_preservation.ps1
+++ b/test/test_path_preservation.ps1
@@ -125,20 +125,17 @@ finally {
     [Environment]::SetEnvironmentVariable("EMSDK", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "User")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "User")
-    [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "User")
 
     try {
         [Environment]::SetEnvironmentVariable("EMSDK", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Machine")
         [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Machine")
-        [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
     } catch {}
 
 
     [Environment]::SetEnvironmentVariable("EMSDK", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_NODE", $null, "Process")
     [Environment]::SetEnvironmentVariable("EMSDK_PYTHON", $null, "Process")
-    [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Process")
 
     refreshenv
 


### PR DESCRIPTION
We use the native version of closure compiler these days so we don't need to install java on windows IIUC.

See https://github.com/emscripten-core/emscripten/pull/20919