### PR TITLE
Prefer `curl` for downloading files over `urllib`

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -270,9 +270,9 @@ int main() {
     # install of 2.0.28, and again when we install 2.0.29, but not on the
     # second install of 2.0.28 because the zip should already be local.
     shutil.rmtree('downloads')
-    checked_call_with_output(emsdk + ' install 2.0.28', expected='Downloading:', env=env)
-    checked_call_with_output(emsdk + ' install 2.0.29', expected='Downloading:', env=env)
-    checked_call_with_output(emsdk + ' install 2.0.28', expected='already downloaded, skipping', unexpected='Downloading:', env=env)
+    checked_call_with_output(emsdk + ' install 3.1.54', expected='Downloading:', env=env)
+    checked_call_with_output(emsdk + ' install 3.1.55', expected='Downloading:', env=env)
+    checked_call_with_output(emsdk + ' install 3.1.54', expected='already downloaded, skipping', unexpected='Downloading:', env=env)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is especially important on macOS where `urllib` can fail to verify certificates.

See https://stackoverflow.com/questions/40684543/how-to-make-python-use-ca-certificates-from-mac-os-truststore

Fixes: #1207, #85, #1356, #1357, #1358