### PR TITLE
CI: Build `latest` docker image rather than `tot`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,13 +181,13 @@ jobs:
           name: install docker
           command: apt-get update -q && apt-get install -q -y docker.io
       - setup_remote_docker
-      # Build and test the tip-of-tree build of EMSDK
+      # Build the `latest` version of EMSDK as docker image
       - run:
           name: build
-          command: make -C ./docker version=tot build
+          command: make -C ./docker version=latest build
       - run:
           name: test
-          command: make -C ./docker version=tot test
+          command: make -C ./docker version=latest test
 
   publish-docker-image-x64:
     executor: bionic

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,7 +14,7 @@ ifndef version
 endif
 
 build: Dockerfile .TEST
-	cd .. && docker build --network host --build-arg=EMSCRIPTEN_VERSION=${version} -t ${image_name}:${version} -f docker/$< .
+	cd .. && docker build --progress=plain --network host --build-arg=EMSCRIPTEN_VERSION=${version} -t ${image_name}:${version} -f docker/$< .
 
 test: test_dockerimage.sh .TEST
 	# test as non-root


### PR DESCRIPTION
This means that CI run that update `latest` actually test the thing we are about to ship.

We recently had a case where `latest` was broken but `tot` was fixes and we accidentally shipped a broken SDK version (#1353).