### PR TITLE
(bazel) Set @platforms//os:emscripten for platform_wasm

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -82,6 +82,7 @@ platform(
     name = "platform_wasm",
     constraint_values = [
         "@platforms//cpu:wasm32",
+        "@platforms//os:emscripten",
     ],
 )
 

--- a/bazel/MODULE.bazel
+++ b/bazel/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "platforms", version = "0.0.9")

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -26,6 +26,11 @@ The SHA1 hash in the above `strip_prefix` and `url` parameters correspond to the
 newer versions, you'll need to update those. To make use of older versions, change the
 parameter of `emsdk_emscripten_deps()`. Supported versions are listed in `revisions.bzl`
 
+Bazel 7+ additionally requires `platforms` dependencies in the `MODULE.bazel` file.
+```starlark
+bazel_dep(name = "platforms", version = "0.0.9")
+```
+
 
 ## Building
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -4,6 +4,15 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 def deps():
     maybe(
         http_archive,
+        name = "platforms",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+        ],
+        sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
+    )
+    maybe(
+        http_archive,
         name = "bazel_skylib",
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
         urls = [

--- a/bazel/test_external/MODULE.bazel
+++ b/bazel/test_external/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "platforms", version = "0.0.9")


### PR DESCRIPTION
I noticed that @googlewalt added `@platforms//os:emscripten` [LINK](https://github.com/bazelbuild/platforms/commit/6b04b816a0edc09e1a3ad4a094177e181a2a1803), now we can update the `platform_wasm`.
