### PR TITLE
fix(bazel): use param file for compile

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -346,6 +346,16 @@ def _impl(ctx):
             provides = ["variant:crosstool_build_mode"],
         ),
 
+        # Feature to prevent 'command line too long' issues
+        feature(
+            name = "archive_param_file",
+            enabled = True,
+        ),
+        feature(
+            name = "compiler_param_file",
+            enabled = True,
+        ),
+
         #### User-settable features
 
         # Set if enabling exceptions.

--- a/bazel/test_external/long_command_line/BUILD.bazel
+++ b/bazel/test_external/long_command_line/BUILD.bazel
@@ -1,0 +1,61 @@
+load("@emsdk//emscripten_toolchain:wasm_rules.bzl", "wasm_cc_binary")
+
+_TEST_TARGETS = [
+    "long_command_line_file01",
+    "long_command_line_file02",
+    "long_command_line_file03",
+    "long_command_line_file04",
+    "long_command_line_file05",
+    "long_command_line_file06",
+    "long_command_line_file07",
+    "long_command_line_file08",
+    "long_command_line_file09",
+    "long_command_line_file10",
+    "long_command_line_file11",
+    "long_command_line_file12",
+    "long_command_line_file13",
+    "long_command_line_file14",
+    "long_command_line_file15",
+    "long_command_line_file16",
+    "long_command_line_file17",
+    "long_command_line_file18",
+    "long_command_line_file19",
+    "long_command_line_file20",
+]
+
+_TEST_TARGET_SUFFIXES = [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+]
+
+[cc_library(
+    name = "{}_{}".format(target, suffix),
+    hdrs = ["include/{}.hh".format(target)],
+    # stripping include prefix to create more flags passed to emcc
+    strip_include_prefix = "include",
+    srcs = ["{}.cc".format(target)],
+) for target in _TEST_TARGETS for suffix in _TEST_TARGET_SUFFIXES]
+
+cc_binary(
+    name = "long_command_line",
+    linkshared = True,
+    srcs = ["long_command_line.cc"],
+    deps = [":{}_{}".format(target, suffix) for target in _TEST_TARGETS for suffix in _TEST_TARGET_SUFFIXES],
+)
+
+wasm_cc_binary(
+    name = "long_command_line_wasm",
+    cc_target = ":long_command_line",
+    outputs = [
+        "long_command_line.js",
+        "long_command_line.wasm",
+    ],
+)

--- a/bazel/test_external/long_command_line/include/long_command_line_file01.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file01.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f1();

--- a/bazel/test_external/long_command_line/include/long_command_line_file02.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file02.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f2();

--- a/bazel/test_external/long_command_line/include/long_command_line_file03.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file03.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f3();

--- a/bazel/test_external/long_command_line/include/long_command_line_file04.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file04.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f4();

--- a/bazel/test_external/long_command_line/include/long_command_line_file05.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file05.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f5();

--- a/bazel/test_external/long_command_line/include/long_command_line_file06.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file06.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f6();

--- a/bazel/test_external/long_command_line/include/long_command_line_file07.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file07.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f7();

--- a/bazel/test_external/long_command_line/include/long_command_line_file08.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file08.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f8();

--- a/bazel/test_external/long_command_line/include/long_command_line_file09.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file09.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f9();

--- a/bazel/test_external/long_command_line/include/long_command_line_file10.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file10.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f10();

--- a/bazel/test_external/long_command_line/include/long_command_line_file11.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file11.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f11();

--- a/bazel/test_external/long_command_line/include/long_command_line_file12.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file12.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f12();

--- a/bazel/test_external/long_command_line/include/long_command_line_file13.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file13.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f13();

--- a/bazel/test_external/long_command_line/include/long_command_line_file14.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file14.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f14();

--- a/bazel/test_external/long_command_line/include/long_command_line_file15.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file15.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f15();

--- a/bazel/test_external/long_command_line/include/long_command_line_file16.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file16.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f16();

--- a/bazel/test_external/long_command_line/include/long_command_line_file17.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file17.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f17();

--- a/bazel/test_external/long_command_line/include/long_command_line_file18.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file18.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f18();

--- a/bazel/test_external/long_command_line/include/long_command_line_file19.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file19.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f19();

--- a/bazel/test_external/long_command_line/include/long_command_line_file20.hh
+++ b/bazel/test_external/long_command_line/include/long_command_line_file20.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+void f20();

--- a/bazel/test_external/long_command_line/long_command_line.cc
+++ b/bazel/test_external/long_command_line/long_command_line.cc
@@ -1,0 +1,43 @@
+#include "long_command_line_file01.hh"
+#include "long_command_line_file02.hh"
+#include "long_command_line_file03.hh"
+#include "long_command_line_file04.hh"
+#include "long_command_line_file05.hh"
+#include "long_command_line_file06.hh"
+#include "long_command_line_file07.hh"
+#include "long_command_line_file08.hh"
+#include "long_command_line_file09.hh"
+#include "long_command_line_file10.hh"
+#include "long_command_line_file11.hh"
+#include "long_command_line_file12.hh"
+#include "long_command_line_file13.hh"
+#include "long_command_line_file14.hh"
+#include "long_command_line_file15.hh"
+#include "long_command_line_file16.hh"
+#include "long_command_line_file17.hh"
+#include "long_command_line_file18.hh"
+#include "long_command_line_file19.hh"
+#include "long_command_line_file20.hh"
+
+int main() {
+  f1();
+  f2();
+  f3();
+  f4();
+  f5();
+  f6();
+  f7();
+  f8();
+  f9();
+  f10();
+  f11();
+  f12();
+  f13();
+  f14();
+  f15();
+  f16();
+  f17();
+  f18();
+  f19();
+  f20();
+}

--- a/bazel/test_external/long_command_line/long_command_line_file01.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file01.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file01.hh"
+
+#include <iostream>
+
+void f1() { std::cout << "hello from f1()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file02.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file02.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file02.hh"
+
+#include <iostream>
+
+void f2() { std::cout << "hello from f2()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file03.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file03.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file03.hh"
+
+#include <iostream>
+
+void f3() { std::cout << "hello from f3()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file04.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file04.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file04.hh"
+
+#include <iostream>
+
+void f4() { std::cout << "hello from f4()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file05.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file05.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file05.hh"
+
+#include <iostream>
+
+void f5() { std::cout << "hello from f5()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file06.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file06.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file06.hh"
+
+#include <iostream>
+
+void f6() { std::cout << "hello from f6()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file07.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file07.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file07.hh"
+
+#include <iostream>
+
+void f7() { std::cout << "hello from f7()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file08.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file08.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file08.hh"
+
+#include <iostream>
+
+void f8() { std::cout << "hello from f8()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file09.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file09.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file09.hh"
+
+#include <iostream>
+
+void f9() { std::cout << "hello from f9()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file10.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file10.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file10.hh"
+
+#include <iostream>
+
+void f10() { std::cout << "hello from f10()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file11.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file11.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file11.hh"
+
+#include <iostream>
+
+void f11() { std::cout << "hello from f11()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file12.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file12.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file12.hh"
+
+#include <iostream>
+
+void f12() { std::cout << "hello from f12()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file13.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file13.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file13.hh"
+
+#include <iostream>
+
+void f13() { std::cout << "hello from f13()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file14.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file14.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file14.hh"
+
+#include <iostream>
+
+void f14() { std::cout << "hello from f14()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file15.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file15.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file15.hh"
+
+#include <iostream>
+
+void f15() { std::cout << "hello from f15()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file16.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file16.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file16.hh"
+
+#include <iostream>
+
+void f16() { std::cout << "hello from f16()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file17.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file17.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file17.hh"
+
+#include <iostream>
+
+void f17() { std::cout << "hello from f17()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file18.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file18.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file18.hh"
+
+#include <iostream>
+
+void f18() { std::cout << "hello from f18()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file19.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file19.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file19.hh"
+
+#include <iostream>
+
+void f19() { std::cout << "hello from f19()\n"; }

--- a/bazel/test_external/long_command_line/long_command_line_file20.cc
+++ b/bazel/test_external/long_command_line/long_command_line_file20.cc
@@ -1,0 +1,5 @@
+#include "long_command_line_file20.hh"
+
+#include <iostream>
+
+void f20() { std::cout << "hello from f20()\n"; }

--- a/test/test_bazel.ps1
+++ b/test/test_bazel.ps1
@@ -13,6 +13,9 @@ Set-Location test_external
 bazel build //:hello-world-wasm
 if (-not $?) { Exit $LastExitCode }
 
+bazel build //long_command_line:long_command_line_wasm
+if (-not $?) { Exit $LastExitCode }
+
 bazel build //:hello-embind-wasm --compilation_mode dbg # debug
 if (-not $?) { Exit $LastExitCode }
 

--- a/test/test_bazel.sh
+++ b/test/test_bazel.sh
@@ -26,6 +26,7 @@ bazel build //hello-world:hello-world-wasm-simd
 
 cd test_external
 bazel build //:hello-world-wasm
+bazel build //long_command_line:long_command_line_wasm
 bazel build //:hello-embind-wasm --compilation_mode dbg # debug
 
 # Test use of the closure compiler

--- a/test/test_bazel_mac.sh
+++ b/test/test_bazel_mac.sh
@@ -25,4 +25,5 @@ bazel build //hello-world:hello-world-wasm
 bazel build //hello-world:hello-world-wasm-simd
 
 cd test_external
+bazel build //long_command_line:long_command_line_wasm
 bazel build //:hello-world-wasm


### PR DESCRIPTION
* fixes issues on windows when dealing with many dependencies causing a
  'command line too long' error
