### PR TITLE
[bazel] add tarball as an optional output

### DIFF
--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -128,12 +128,15 @@ def _wasm_cc_binary_impl(ctx):
         executable = ctx.executable._wasm_binary_extractor,
     )
 
-    return DefaultInfo(
-        files = depset(ctx.outputs.outputs),
-        # This is needed since rules like web_test usually have a data
-        # dependency on this target.
-        data_runfiles = ctx.runfiles(transitive_files = depset(ctx.outputs.outputs)),
-    )
+    return [
+        DefaultInfo(
+            files = depset(ctx.outputs.outputs),
+            # This is needed since rules like web_test usually have a data
+            # dependency on this target.
+            data_runfiles = ctx.runfiles(transitive_files = depset(ctx.outputs.outputs)),
+        ),
+        OutputGroupInfo(_wasm_tar = cc_target.files),
+    ]
 
 def _wasm_cc_binary_legacy_impl(ctx):
     cc_target = ctx.attr.cc_target[0]
@@ -162,13 +165,16 @@ def _wasm_cc_binary_legacy_impl(ctx):
         executable = ctx.executable._wasm_binary_extractor,
     )
 
-    return DefaultInfo(
-        executable = ctx.outputs.wasm,
-        files = depset(outputs),
-        # This is needed since rules like web_test usually have a data
-        # dependency on this target.
-        data_runfiles = ctx.runfiles(transitive_files = depset(outputs)),
-    )
+    return [
+        DefaultInfo(
+            executable = ctx.outputs.wasm,
+            files = depset(outputs),
+            # This is needed since rules like web_test usually have a data
+            # dependency on this target.
+            data_runfiles = ctx.runfiles(transitive_files = depset(outputs)),
+        ),
+        OutputGroupInfo(_wasm_tar = cc_target.files),
+    ]
 
 _wasm_cc_binary = rule(
     implementation = _wasm_cc_binary_impl,


### PR DESCRIPTION
Usage would be something like:
```
filegroup(
    name = "hello-world-tarball",
    srcs = [":hello-world-wasm"],
    output_group = "_wasm_tar",
)
```

Fixes #1382