### PR TITLE
bazel: bump rules_nodejs and migrate to rules_js

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -23,12 +23,12 @@ def deps():
     maybe(
         http_archive,
         name = "rules_nodejs",
-        sha256 = "08337d4fffc78f7fe648a93be12ea2fc4e8eb9795a4e6aa48595b66b34555626",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.0/rules_nodejs-core-5.8.0.tar.gz"],
+        sha256 = "3e8369256ad63197959d2253c473a9dcc57c2841d176190e59b91d25d4fe9e67",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.1/rules_nodejs-v6.1.1.tar.gz"],
     )
     maybe(
         http_archive,
-        name = "build_bazel_rules_nodejs",
-        sha256 = "dcc55f810142b6cf46a44d0180a5a7fb923c04a5061e2e8d8eb05ccccc60864b",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.0/rules_nodejs-5.8.0.tar.gz"],
+        name = "aspect_rules_js",
+        sha256 = "7085e915cdba6f2dc0ce93bef59f5d040a539b510b840456b6ac7ccc2bee7886",
+        urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.0-rc1/rules_js-v2.0.0-rc1.tar.gz"],
     )

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "npm_install")
+load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
+load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock")
 load(":revisions.bzl", "EMSCRIPTEN_TAGS")
 
 def _parse_version(v):
@@ -173,36 +174,36 @@ def emscripten_deps(emscripten_version = "latest"):
         )
 
     if "emscripten_npm_linux" not in excludes:
-        npm_install(
+        npm_translate_lock(
             name = "emscripten_npm_linux",
-            package_json = "@emscripten_bin_linux//:emscripten/package.json",
-            package_lock_json = "@emscripten_bin_linux//:emscripten/package-lock.json",
+            data = ["@emscripten_bin_linux//:emscripten/package.json"],
+            npm_package_lock = "@emscripten_bin_linux//:emscripten/package-lock.json",
         )
 
     if "emscripten_npm_linux_arm64" not in excludes:
-        npm_install(
+        npm_translate_lock(
             name = "emscripten_npm_linux_arm64",
-            package_json = "@emscripten_bin_linux_arm64//:emscripten/package.json",
-            package_lock_json = "@emscripten_bin_linux_arm64//:emscripten/package-lock.json",
+            data = ["@emscripten_bin_linux_arm64//:emscripten/package.json"],
+            npm_package_lock = "@emscripten_bin_linux_arm64//:emscripten/package-lock.json",
         )
 
     if "emscripten_npm_mac" not in excludes:
-        npm_install(
+        npm_translate_lock(
             name = "emscripten_npm_mac",
-            package_json = "@emscripten_bin_mac//:emscripten/package.json",
-            package_lock_json = "@emscripten_bin_mac//:emscripten/package-lock.json",
+            data = ["@emscripten_bin_mac//:emscripten/package.json"],
+            npm_package_lock = "@emscripten_bin_mac//:emscripten/package-lock.json",
         )
 
     if "emscripten_npm_mac_arm64" not in excludes:
-        npm_install(
+        npm_translate_lock(
             name = "emscripten_npm_mac",
-            package_json = "@emscripten_bin_mac_arm64//:emscripten/package.json",
-            package_lock_json = "@emscripten_bin_mac_arm64//:emscripten/package-lock.json",
+            data = ["@emscripten_bin_mac_arm64//:emscripten/package.json"],
+            npm_package_lock = "@emscripten_bin_mac_arm64//:emscripten/package-lock.json",
         )
 
     if "emscripten_npm_win" not in excludes:
-        npm_install(
+        npm_translate_lock(
             name = "emscripten_npm_win",
-            package_json = "@emscripten_bin_win//:emscripten/package.json",
-            package_lock_json = "@emscripten_bin_win//:emscripten/package-lock.json",
+            data = ["@emscripten_bin_win//:emscripten/package.json"],
+            npm_package_lock = "@emscripten_bin_win//:emscripten/package-lock.json",
         )

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -118,7 +118,7 @@ def emscripten_deps(emscripten_version = "latest"):
     excludes = native.existing_rules().keys()
     if "nodejs_toolchains" not in excludes:
         # Node 16 is the first version that supports darwin_arm64
-        node_repositories(
+        nodejs_register_toolchains(
             node_version = "16.6.2",
         )
 


### PR DESCRIPTION
Bazel's Node.js dependency comes from [rules_nodejs](https://github.com/bazelbuild/rules_nodejs/). Previously, bazel/deps.bzl was using rules_nodejs 5.8.0, released in 2022 and only supported Node.js toolchains up to 18.12.1. 

This PR bumps rules_nodejs to latest 6.1.1. It also replaces build_bazel_rules_nodejs with [rules_js](https://github.com/aspect-build/rules_js), since `npm_install` that bazel/emscripten_deps.bzl used was deprecated. The README of rules_nodejs now recommends migrating to rules_js for everything other than the Node.js toolchain: (https://github.com/bazelbuild/rules_nodejs/commit/371e8cab15f9db444217703144b2eb71d0e13235)

#### Impetus

Our repo builds with Bazel and uses Emscripten and Node.js. Tried to upgrade Node.js 18 to Node.js 20 and saw that emsdk didn't support rules_nodejs 6+ in the same workspace.