### PR TITLE
[Bazel] Add feature to support WASM Relaxed SIMD

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -434,6 +434,11 @@ def _impl(ctx):
             name = "wasm_simd",
             requires = [feature_set(features = ["llvm_backend"])],
         ),
+        # Adds relaxed-simd support, only available with the llvm backend.
+        feature(
+            name = "wasm_relaxed_simd",
+            requires = [feature_set(features = ["llvm_backend"])],
+        ),
         feature(
             name = "precise_long_double_printf",
             enabled = True,
@@ -559,6 +564,11 @@ def _impl(ctx):
             actions = all_compile_actions + all_link_actions,
             flags = ["-msimd128"],
             features = ["wasm_simd"],
+        ),
+        flag_set(
+            actions = all_compile_actions + all_link_actions,
+            flags = ["-msimd128", "-mrelaxed-simd"],
+            features = ["wasm_relaxed_simd"],
         ),
         flag_set(
             actions = all_link_actions,


### PR DESCRIPTION
[WASM Relaxed SIMD](https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md) has been supported by LLVM and used in the XNNPACK acceleration library in bazel build, see [reference](https://github.com/google/XNNPACK/blob/master/build_config/BUILD.bazel#L169).

Add this feature in bazel toolchain so that it can be recoginized in config similarly to the WASM SIMD feature.
