### PR TITLE
Remove setting of SSL_CERT_FILE from emsdk launcher script

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -9,10 +9,8 @@
 # First look for python bundled in Emsdk
 if [ -z "$EMSDK_PYTHON" ]; then
   PYTHON3="$(dirname "$0")/python/3.9.2-1_64bit/bin/python3"
-  PYTHON3_CERT_FILE="$(dirname "$0")/python/3.9.2-1_64bit/lib/python3.9/site-packages/certifi/cacert.pem"
   if [ ! -f "$PYTHON3" ]; then
     PYTHON3="$(dirname "$0")/python/3.7.4-2_64bit/bin/python3"
-    PYTHON3_CERT_FILE="$(dirname "$0")/python/3.7.4-2_64bit/lib/python3.7/site-packages/certifi/cacert.pem"
   fi
   if [ -f "$PYTHON3" ]; then
     EMSDK_PYTHON="$PYTHON3"
@@ -22,11 +20,6 @@ if [ -z "$EMSDK_PYTHON" ]; then
     # https://github.com/emscripten-core/emsdk/issues/598
     unset PYTHONHOME
     unset PYTHONPATH
-
-    # This is needed for MacOS.  Without this, the urlopen
-    # code will try to use /usr/local/etc/openssl/cert.pem
-    # which may or may not exist on the system.
-    export SSL_CERT_FILE="$PYTHON3_CERT_FILE"
   fi
 fi
 


### PR DESCRIPTION
Since we use curl now (#1355) this should no longer be needed.