### PR TITLE
[Bazel] Let audio workout bootstrap js file be generated.

### DIFF
--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -90,7 +90,8 @@ extensions = [
     '.data',
     '.js.symbols',
     '.wasm.debug.wasm',
-    '.html'
+    '.html',
+    '.aw.js'
 ]
 
 for ext in extensions:

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -70,6 +70,7 @@ _ALLOW_OUTPUT_EXTNAMES = [
     ".js.symbols",
     ".wasm.debug.wasm",
     ".html",
+    ".aw.js",
 ]
 
 _WASM_BINARY_COMMON_ATTRS = {
@@ -151,6 +152,7 @@ def _wasm_cc_binary_legacy_impl(ctx):
         ctx.outputs.symbols,
         ctx.outputs.dwarf,
         ctx.outputs.html,
+        ctx.outputs.audio_worklet,
     ]
 
     args = ctx.actions.args()
@@ -201,6 +203,7 @@ def _wasm_binary_legacy_outputs(name, cc_target):
         "symbols": "{}/{}.js.symbols".format(name, basename),
         "dwarf": "{}/{}.wasm.debug.wasm".format(name, basename),
         "html": "{}/{}.html".format(name, basename),
+        "audio_worklet": "{}/{}.aw.js".format(name, basename)
     }
 
     return outputs


### PR DESCRIPTION
The allowed extension list in `link_wrapper.py` and in `wasm_cc_library.bzl` have been updated in order to support files with the `.aw.js` extensions that are generated when users set `-sAUDIO_WORKLET` compiler/linker flag.

Related issues:
- #1399 