### PR TITLE
Sets wasm_warning_as_error disabled by default.

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -445,7 +445,7 @@ def _impl(ctx):
         ),
         feature(
             name = "wasm_warnings_as_errors",
-            enabled = True,
+            enabled = False,
         ),
 
         # ASan and UBSan. See also:


### PR DESCRIPTION
This removes `-Werror` set by default, thus conforming with default bazel cc toolchain.

Part of:
- #1400 