### PR TITLE
Ensure temporary files have proper unique names for bazel builds.

### DIFF
--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -139,7 +139,7 @@ if os.path.exists(wasm_base + '.debug.wasm') and os.path.exists(wasm_base):
     final_bytes.extend((base_name + '.wasm.debug.wasm').encode())
 
     # Write our length + filename bytes to a temp file.
-    with open('debugsection.tmp', 'wb+') as f:
+    with open(base_name + '_debugsection.tmp', 'wb+') as f:
       f.write(final_bytes)
       f.close()
 
@@ -152,7 +152,7 @@ if os.path.exists(wasm_base + '.debug.wasm') and os.path.exists(wasm_base):
     subprocess.check_call([
         llvm_objcopy,
         wasm_base,
-        '--add-section=external_debug_info=debugsection.tmp'])
+        '--add-section=external_debug_info=' + base_name + '_debugsection.tmp'])
 
 # Make sure we have at least one output file.
 if not len(files):
@@ -160,8 +160,8 @@ if not len(files):
   sys.exit(1)
 
 # cc_binary must output exactly one file; put all the output files in a tarball.
-cmd = ['tar', 'cf', 'tmp.tar'] + files
+cmd = ['tar', 'cf', base_name + '.tar'] + files
 subprocess.check_call(cmd, cwd=outdir)
-os.replace(os.path.join(outdir, 'tmp.tar'), output_file)
+os.replace(os.path.join(outdir, base_name + '.tar'), output_file)
 
 sys.exit(0)


### PR DESCRIPTION
This attempts to fix #1386.