### PR TITLE
[Bazel] Use py_binary for emcc

### DIFF
--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -12,6 +12,14 @@ filegroup(
     ],
 )
 
+py_binary(
+    name = "emcc_compile",
+    main = "emscripten/emcc.py",
+    srcs = [
+        "@emscripten_bin_linux//:emscripten/emcc.py",
+    ],
+)
+
 filegroup(
     name = "compiler_files",
     srcs = [
@@ -19,6 +27,7 @@ filegroup(
         "emcc.bat",
         "@emsdk//:compiler_files",
         ":common_files",
+        ":emcc_compile"
     ],
 )
 
@@ -66,6 +75,7 @@ emscripten_cc_toolchain_config_rule(
         "@bazel_tools//src/conditions:host_windows": "bat",
         "//conditions:default": "sh",
     }),
+    emcc = ":emcc_compile",
 )
 
 cc_toolchain(

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -81,7 +81,7 @@ def _impl(ctx):
     ################################################################
     # Tools
     ################################################################
-    clang_tool = tool(path = emcc_script)
+    clang_tool = tool(tool = ctx.executable.emcc)
     clif_match_tool = tool(path = "dummy_clif_matcher")
     link_tool = tool(path = emcc_link_script)
     archive_tool = tool(path = emar_script)
@@ -1135,6 +1135,7 @@ emscripten_cc_toolchain_config_rule = rule(
         "em_config": attr.label(mandatory = True, allow_single_file = True),
         "emscripten_binaries": attr.label(mandatory = True, cfg = "exec"),
         "script_extension": attr.string(mandatory = True, values = ["sh", "bat"]),
+        "emcc": attr.label(mandatory = True, executable = True, allow_files = True, cfg = "exec"),
     },
     provides = [CcToolchainConfigInfo],
 )


### PR DESCRIPTION
This PR was an investigation into clean up the Emscripten toolchain in Bazel using `py_binary` to wrap and run `emcc` and `emar` etc. This would have been nice since I think it would have allowed us to drop all the sh/bat scripts (and OS detection logic around it) that just call the Python interpreter anyway. The motivation for this is #1420 and I was hoping that by wrapping `emcc` with `py_binary` that the paths/modules/libraries would have been a bit more robust to whatever is going wrong in this issue.

Unfortunately I hit the roadblock described in this [SO question](https://stackoverflow.com/questions/78703242/how-do-i-provide-a-py-binarys-runfiles-to-a-c-toolchain-in-bazel) that cannot be worked around without a hack. The main blocker is https://github.com/bazelbuild/bazel/issues/17629, however, if there is interest in this approach, we could conditionally apply a genrule on Linux and Mac to add in the missing shebang as suggested in https://github.com/bazelbuild/bazel/issues/17629#issuecomment-2207375102.

What do you think @sbc100 and @walkingeyerobot? Do you think this is worth pursuing further? Incidentally, this PR would make #1333 redundant in my opinion.
