### PR TITLE
fix: improve Fish shell support (and Cshell)

### DIFF
--- a/emsdk_env.fish
+++ b/emsdk_env.fish
@@ -3,6 +3,8 @@
 #Now, when you want to use the SDK, run this alias first to set up
 #your environment.
 
+set -gx EMSDK_FISH 1
+
 set -l script (status -f)
 set -l dir (dirname $script)
 


### PR DESCRIPTION
I faced the same issue mentioned in #1299, this PR fixes the issue by taking in account specific `set` and `unset` syntax for Fish shell.

The post install instruction (i.e : `./emsdk activate latest`) provides wrong instructions in Fish shell and Cshell cases. 
This should be fixed by this PR too, although the code is a bit redundant and it could be more cleaner. 

The [website instruction](https://emscripten.org/docs/getting_started/downloads.html#installation-instructions-using-the-emsdk-recommended)  have the same issue, but I guess user with specific shell will be able to manage. 