### PR TITLE
Add a github actions workflow to create a release PR

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,7 +10,6 @@ on:
         required: true
         type: string
 
-
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
@@ -26,5 +25,3 @@ jobs:
           title: Release ${{ env.RELEASE_VERSION }}
           commit-message: Release ${{ env.RELEASE_VERSION }}
           delete-branch: true
-
-

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,30 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      lto-sha:
+        required: true
+        type: string
+      nonlto-sha:
+        required: true
+        type: string
+
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Run create_release.py
+        run: python3 scripts/create_release.py ${{ inputs.lto-sha }} ${{ inputs.nonlto-sha }} --action
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: Release ${{ env.RELEASE_VERSION }}
+          commit-message: Release ${{ env.RELEASE_VERSION }}
+          delete-branch: true
+
+

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -31,10 +31,13 @@ def main(args):
 
   new_version = '.'.join(str(part) for part in new_version)
   asserts_hash = None
+  is_github_runner = False
   if args:
     new_hash = args[0]
     if len(args) > 1:
       asserts_hash = args[1]
+    if len(args) > 2 and args[2] == '--action':
+      is_github_runner = True
   else:
     new_hash = emsdk.get_emscripten_releases_tot()
   print('Creating new release: %s -> %s' % (new_version, new_hash))
@@ -59,16 +62,21 @@ def main(args):
 
   branch_name = 'version_' + new_version
 
-  # Create a new git branch
-  subprocess.check_call(['git', 'checkout', '-b', branch_name, 'origin/main'], cwd=root_dir)
+  if not is_github_runner: # Local use
+    # Create a new git branch
+    subprocess.check_call(['git', 'checkout', '-b', branch_name, 'origin/main'], cwd=root_dir)
 
-  # Create auto-generated changes to the new git branch
-  subprocess.check_call(['git', 'add', '-u', '.'], cwd=root_dir)
-  subprocess.check_call(['git', 'commit', '-m', new_version], cwd=root_dir)
-  print('New release created in branch: `%s`' % branch_name)
+    # Create auto-generated changes to the new git branch
+    subprocess.check_call(['git', 'add', '-u', '.'], cwd=root_dir)
+    subprocess.check_call(['git', 'commit', '-m', new_version], cwd=root_dir)
+    print('New release created in branch: `%s`' % branch_name)
 
-  # Push new branch to origin
-  subprocess.check_call(['git', 'push', 'origin', branch_name], cwd=root_dir)
+    # Push new branch to origin
+    subprocess.check_call(['git', 'push', 'origin', branch_name], cwd=root_dir)
+  else: # For GitHub Actions workflows
+    with open(os.environ['GITHUB_ENV'], 'a') as f:
+      f.write(f'RELEASE_VERSION={new_version}')
+
   return 0
 
 

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -62,7 +62,10 @@ def main(args):
 
   branch_name = 'version_' + new_version
 
-  if not is_github_runner: # Local use
+  if is_github_runner: # For GitHub Actions workflows
+    with open(os.environ['GITHUB_ENV'], 'a') as f:
+      f.write(f'RELEASE_VERSION={new_version}')
+  else: # Local use
     # Create a new git branch
     subprocess.check_call(['git', 'checkout', '-b', branch_name, 'origin/main'], cwd=root_dir)
 
@@ -73,9 +76,6 @@ def main(args):
 
     # Push new branch to origin
     subprocess.check_call(['git', 'push', 'origin', branch_name], cwd=root_dir)
-  else: # For GitHub Actions workflows
-    with open(os.environ['GITHUB_ENV'], 'a') as f:
-      f.write(f'RELEASE_VERSION={new_version}')
 
   return 0
 


### PR DESCRIPTION
The action runs the existing create_release.py script in a new mode created for github actions. Rather than using local git commands, it uses a public action for creating a PR in the repository. The action can be triggered from the website or via the CLI tool, for example

gh workflow run create-release.yml -R emscripten-core/emsdk -F lto-sha=abc123 -F nonlto-sha=234567