### PR TITLE
Add Actions workflow to automatically create release tags

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -32,5 +32,5 @@ jobs:
                   sha: context.sha
                 })
               } else {
-               console.log(`Commit message: ${message} did not match pattern`)
+                console.log(`Commit message: ${message} did not match pattern`)
               }

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,36 @@
+# When a release commit created by create-release.yml is landed, create the
+# corresponding tag.
+name: Create release tag
+
+on:
+  push:
+    paths: [ emscripten-releases-tags.json, .github/workflows/tag-release.yml ]
+  workflow_dispatch:
+
+jobs:
+    tag-release:
+      # Only activate for commits created by the create-release.yml workflow.
+      # The assumption is that when manual changes happen, we want to handle
+      # tagging manually too.
+      if: github.event.head_commit.author.username == 'github-actions[bot]'
+      runs-on: ubuntu-latest
+      steps:
+        - name: Match message and create tag
+          uses: actions/github-script@v7
+          with:
+            script: |
+              const message = `${{ github.event.head_commit.message }}`
+              const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
+              const match = message.match(regex)
+              if (match) {
+                const release = match[1]
+                console.log(`Matched release ${release}`)
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `refs/tags/${release}`,
+                  sha: context.sha
+                })
+              } else {
+               console.log(`Commit message: ${message} did not match pattern`)
+              }


### PR DESCRIPTION
For commits created by the new create-release.yml workflow, we can add the corresponding release tag. This only runs for changes to the tag JSON file (and the workflow itself) and only acts on changes created by the automation (so that it won't interfere if we want to do things manually).