### PR TITLE
Automatically dispatch emscripten release tag action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,5 +23,10 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           title: Release ${{ env.RELEASE_VERSION }}
-          commit-message: Release ${{ env.RELEASE_VERSION }}
+          commit-message: |
+            Release ${{ env.RELEASE_VERSION }}
+
+            With emscripten-releases revisions:
+              ${{ inputs.lto-sha }} (LTO)
+              ${{ inputs.nonlto-sha }} (asserts)
           delete-branch: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,7 +25,7 @@ jobs:
           title: Release ${{ env.RELEASE_VERSION }}
           commit-message: |
             Release ${{ env.RELEASE_VERSION }}
-
+          body: |
             With emscripten-releases revisions:
               ${{ inputs.lto-sha }} (LTO)
               ${{ inputs.nonlto-sha }} (asserts)

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,6 +27,6 @@ jobs:
             Release ${{ env.RELEASE_VERSION }}
           body: |
             With emscripten-releases revisions:
-              ${{ inputs.lto-sha }} (LTO)
-              ${{ inputs.nonlto-sha }} (asserts)
+              https://chromium.googlesource.com/emscripten-releases/+/${{ inputs.lto-sha }} (LTO)
+              https://chromium.googlesource.com/emscripten-releases/+/${{ inputs.nonlto-sha }} (asserts)
           delete-branch: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -21,17 +21,28 @@ jobs:
               const message = 'Release 1.1.2' //`${{ github.event.head_commit.message }}`
               const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
               const match = message.match(regex)
-              console.log(context.repo.owner);
-              console.log(context.repo.repo);
               if (match) {
                 const release = match[1]
                 console.log(`Matched release ${release}`)
+                try {
                 await github.rest.git.createRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   ref: `refs/tags/${release}`,
                   sha: context.sha
                 })
+                } catch (e) { console.log(`createRef failed: ${e}`) }
               } else {
                 console.log(`Commit message: ${message} did not match pattern`)
               }
+        - name: Dispatch emscripten workflow
+          uses: actions/github-script@v7
+          with:
+            script: |
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: 'emscripten',
+                workflow_id: tag-release.yml,
+                ref: main,
+                intpus: { release-sha: b7ca27c4313b8282e1023d90a31f323f1d16ac83 }
+              })

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -5,6 +5,7 @@ name: Create release tag
 on:
   push:
     paths: [ emscripten-releases-tags.json, .github/workflows/tag-release.yml ]
+    # TODO: restrict to main branch
   workflow_dispatch:
 
 jobs:
@@ -36,6 +37,8 @@ jobs:
               } else {
                 console.log(`Commit message: ${message} did not match pattern`)
               }
+        - name: Find emscripten revision
+          run: python3 scripts/get_emscripten_revision_info.py
         - name: Dispatch emscripten workflow
           uses: actions/github-script@v7 # TODO: make conditional on regex match
           with:
@@ -46,5 +49,5 @@ jobs:
                 repo: 'emscripten',
                 workflow_id: 'tag-release.yml',
                 ref: 'main',
-                inputs: { 'release-sha': 'b7ca27c4313b8282e1023d90a31f323f1d16ac83' }
+                inputs: { 'release-sha': '${{ env.EMSCRIPTEN_HASH }}' }
               })

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check for release commit and create tag
     runs-on: ubuntu-latest
     outputs:
-      is_release: ${{ steps.create-tag.outputs.is_release }}
+      is_release: ${{ steps.create-tag.outputs.result }}
     steps:
       - name: Match message and create tag
         id: create-tag
@@ -27,6 +27,7 @@ jobs:
             const message = 'Release 1.1.2'; //`${{ github.event.head_commit.message }}`
             const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/;
             const match = message.match(regex);
+            let is_release = false;
             if (match) {
               const release = match[1];
               console.log(`Matched release ${release}`);
@@ -37,12 +38,12 @@ jobs:
                 ref: `refs/tags/${release}`,
                 sha: context.sha
               });
-              core.setOutput('is_release=true');
+              is_release = true;
               } catch (e) { console.log(`createRef failed: ${e}`) }
             } else {
               console.log(`Commit message: ${message} did not match pattern`);
-              core.setOutput('is_release=false');
               }
+            return is_release;
 
   dispatch-emscripten-tag:
     name: Dispatch workflow to tag emscripten repo

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -43,6 +43,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: 'emscripten',
                 workflow_id: 'tag-release.yml',
-                ref: main,
+                ref: 'main',
                 intpus: { 'release-sha': 'b7ca27c4313b8282e1023d90a31f323f1d16ac83' }
               })

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -16,35 +16,39 @@ jobs:
     name: Check for release commit and create tag
     runs-on: ubuntu-latest
     outputs:
-      is_release:
+      is_release: ${{ steps.create-tag.outputs.is_release }}
     steps:
       - name: Match message and create tag
+        id: create-tag
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TEST_TOKEN }}
           script: |
-            const message = 'Release 1.1.2' //`${{ github.event.head_commit.message }}`
-            const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
-            const match = message.match(regex)
+            const message = 'Release 1.1.2'; //`${{ github.event.head_commit.message }}`
+            const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/;
+            const match = message.match(regex);
             if (match) {
-              const release = match[1]
-              console.log(`Matched release ${release}`)
+              const release = match[1];
+              console.log(`Matched release ${release}`);
               try {
               await github.rest.git.createRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: `refs/tags/${release}`,
                 sha: context.sha
-              })
+              });
+              core.setOutput('is_release=true');
               } catch (e) { console.log(`createRef failed: ${e}`) }
             } else {
-              console.log(`Commit message: ${message} did not match pattern`)
+              console.log(`Commit message: ${message} did not match pattern`);
+              core.setOutput('is_release=false');
               }
 
   dispatch-emscripten-tag:
     name: Dispatch workflow to tag emscripten repo
     runs-on: ubuntu-latest
     needs: tag-release
+    if: ${{ needs.tag-release.outputs.is_release == 'true' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -61,4 +65,4 @@ jobs:
               workflow_id: 'tag-release.yml',
               ref: 'main',
               inputs: { 'release-sha': '${{ env.EMSCRIPTEN_HASH }}' }
-            })
+            });

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,47 +9,56 @@ on:
   workflow_dispatch:
 
 jobs:
-    tag-release:
-      # Only activate for commits created by the create-release.yml workflow.
-      # The assumption is that when manual changes happen, we want to handle
-      # tagging manually too.
-      runs-on: ubuntu-latest
-      steps:
-        - name: Match message and create tag
-          uses: actions/github-script@v7
-          with:
-            github-token: ${{ secrets.TEST_TOKEN }}
-            script: |
-              const message = 'Release 1.1.2' //`${{ github.event.head_commit.message }}`
-              const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
-              const match = message.match(regex)
-              if (match) {
-                const release = match[1]
-                console.log(`Matched release ${release}`)
-                try {
-                await github.rest.git.createRef({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ref: `refs/tags/${release}`,
-                  sha: context.sha
-                })
-                } catch (e) { console.log(`createRef failed: ${e}`) }
-              } else {
-                console.log(`Commit message: ${message} did not match pattern`)
-              }
-        - name: Checkout repo
-          uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-        - name: Find emscripten revision
-          run: python3 scripts/get_emscripten_revision_info.py
-        - name: Dispatch emscripten workflow
-          uses: actions/github-script@v7 # TODO: make conditional on regex match
-          with:
-            github-token: ${{ secrets.TEST_TOKEN }}
-            script: |
-              await github.rest.actions.createWorkflowDispatch({
+  tag-release:
+    # Only activate for commits created by the create-release.yml workflow.
+    # The assumption is that when manual changes happen, we want to handle
+    # tagging manually too.
+    name: Check for release commit and create tag
+    runs-on: ubuntu-latest
+    outputs:
+      is_release:
+    steps:
+      - name: Match message and create tag
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.TEST_TOKEN }}
+          script: |
+            const message = 'Release 1.1.2' //`${{ github.event.head_commit.message }}`
+            const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
+            const match = message.match(regex)
+            if (match) {
+              const release = match[1]
+              console.log(`Matched release ${release}`)
+              try {
+              await github.rest.git.createRef({
                 owner: context.repo.owner,
-                repo: 'emscripten',
-                workflow_id: 'tag-release.yml',
-                ref: 'main',
-                inputs: { 'release-sha': '${{ env.EMSCRIPTEN_HASH }}' }
+                repo: context.repo.repo,
+                ref: `refs/tags/${release}`,
+                sha: context.sha
               })
+              } catch (e) { console.log(`createRef failed: ${e}`) }
+            } else {
+              console.log(`Commit message: ${message} did not match pattern`)
+              }
+
+  dispatch-emscripten-tag:
+    name: Dispatch workflow to tag emscripten repo
+    runs-on: ubuntu-latest
+    needs: tag-release
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Find emscripten revision
+        run: python3 scripts/get_emscripten_revision_info.py
+      - name: Dispatch emscripten workflow
+        uses: actions/github-script@v7 # TODO: make conditional on regex match
+        with:
+          github-token: ${{ secrets.TEST_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'emscripten',
+              workflow_id: 'tag-release.yml',
+              ref: 'main',
+              inputs: { 'release-sha': '${{ env.EMSCRIPTEN_HASH }}' }
+            })

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,14 +12,13 @@ jobs:
       # Only activate for commits created by the create-release.yml workflow.
       # The assumption is that when manual changes happen, we want to handle
       # tagging manually too.
-      if: github.event.head_commit.author.username == 'github-actions[bot]'
       runs-on: ubuntu-latest
       steps:
         - name: Match message and create tag
           uses: actions/github-script@v7
           with:
             script: |
-              const message = `${{ github.event.head_commit.message }}`
+              const message = 'Release 1.1.1' //`${{ github.event.head_commit.message }}`
               const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
               const match = message.match(regex)
               if (match) {

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -42,7 +42,7 @@ jobs:
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
                 repo: 'emscripten',
-                workflow_id: tag-release.yml,
+                workflow_id: 'tag-release.yml',
                 ref: main,
-                intpus: { release-sha: b7ca27c4313b8282e1023d90a31f323f1d16ac83 }
+                intpus: { 'release-sha': 'b7ca27c4313b8282e1023d90a31f323f1d16ac83' }
               })

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,8 +4,11 @@ name: Create release tag
 
 on:
   push:
-    paths: [ emscripten-releases-tags.json, .github/workflows/tag-release.yml ]
-    # TODO: restrict to main branch
+    paths:
+      - emscripten-releases-tags.json
+      - .github/workflows/tag-release.yml
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -23,15 +26,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TEST_TOKEN }}
+          # A commit with the message of the form 'Release X.Y.Z' is expected
+          # to have been created by create_release.py and update the latest
+          # release in emscripten-releases-tags.json
           script: |
-            const message = 'Release 1.1.2'; //`${{ github.event.head_commit.message }}`
+            const message = `${{ github.event.head_commit.message }}`
             const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/;
             const match = message.match(regex);
             let is_release = false;
             if (match) {
               const release = match[1];
               console.log(`Matched release ${release}`);
-              try {
               await github.rest.git.createRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -39,10 +44,9 @@ jobs:
                 sha: context.sha
               });
               is_release = true;
-              } catch (e) { console.log(`createRef failed: ${e}`) }
             } else {
               console.log(`Commit message: ${message} did not match pattern`);
-              }
+            }
             return is_release;
 
   dispatch-emscripten-tag:
@@ -54,9 +58,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Find emscripten revision
+        # get_emscripten_revision_info.py sets env.EMSCRIPTEN_HASH to the
+        # emscripten hash associated with the latest release in
+        # emscripten-releases-tags.json
         run: python3 scripts/get_emscripten_revision_info.py
       - name: Dispatch emscripten workflow
-        uses: actions/github-script@v7 # TODO: make conditional on regex match
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TEST_TOKEN }}
           script: |

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -21,6 +21,8 @@ jobs:
               const message = 'Release 1.1.1' //`${{ github.event.head_commit.message }}`
               const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
               const match = message.match(regex)
+              console.log(context.repo.owner);
+              console.log(context.repo.repo);
               if (match) {
                 const release = match[1]
                 console.log(`Matched release ${release}`)

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -17,6 +17,7 @@ jobs:
         - name: Match message and create tag
           uses: actions/github-script@v7
           with:
+            github-token: ${{ secrets.TEST_TOKEN }}
             script: |
               const message = 'Release 1.1.2' //`${{ github.event.head_commit.message }}`
               const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
@@ -38,6 +39,7 @@ jobs:
         - name: Dispatch emscripten workflow
           uses: actions/github-script@v7
           with:
+            github-token: ${{ secrets.TEST_TOKEN }}
             script: |
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -46,5 +46,5 @@ jobs:
                 repo: 'emscripten',
                 workflow_id: 'tag-release.yml',
                 ref: 'main',
-                intpus: { 'release-sha': 'b7ca27c4313b8282e1023d90a31f323f1d16ac83' }
+                inputs: { 'release-sha': 'b7ca27c4313b8282e1023d90a31f323f1d16ac83' }
               })

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -37,6 +37,8 @@ jobs:
               } else {
                 console.log(`Commit message: ${message} did not match pattern`)
               }
+        - name: Checkout repo
+          uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         - name: Find emscripten revision
           run: python3 scripts/get_emscripten_revision_info.py
         - name: Dispatch emscripten workflow

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -45,7 +45,7 @@ jobs:
               });
               is_release = true;
             } else {
-              console.log(`Commit message: ${message} did not match pattern`);
+              console.log(`Commit message: '${message}' did not match pattern`);
             }
             return is_release;
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -17,6 +17,7 @@ jobs:
     # The assumption is that when manual changes happen, we want to handle
     # tagging manually too.
     name: Check for release commit and create tag
+    if: github.event.head_commit.author.username == 'github-actions[bot]'
     runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.create-tag.outputs.result }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,7 +18,7 @@ jobs:
           uses: actions/github-script@v7
           with:
             script: |
-              const message = 'Release 1.1.1' //`${{ github.event.head_commit.message }}`
+              const message = 'Release 1.1.2' //`${{ github.event.head_commit.message }}`
               const regex = /Release ([0-9]+.[0-9]+.[0-9]+)/
               const match = message.match(regex)
               console.log(context.repo.owner);

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -37,7 +37,7 @@ jobs:
                 console.log(`Commit message: ${message} did not match pattern`)
               }
         - name: Dispatch emscripten workflow
-          uses: actions/github-script@v7
+          uses: actions/github-script@v7 # TODO: make conditional on regex match
           with:
             github-token: ${{ secrets.TEST_TOKEN }}
             script: |

--- a/scripts/get_emscripten_revision_info.py
+++ b/scripts/get_emscripten_revision_info.py
@@ -28,7 +28,7 @@ def get_latest_emscripten(tagfile):
 if __name__ == '__main__':
     emscripten_hash = get_latest_emscripten(TAGFILE)
     print('Emscripten revision ' + emscripten_hash)
-    if 'GITHUB_ENV' in os.environ':
+    if 'GITHUB_ENV' in os.environ:
             with open(os.environ['GITHUB_ENV'], 'a') as f:
                 f.write(f'EMSCRIPTEN_HASH={emscripten_hash}')
             sys.exit(0)

--- a/scripts/get_emscripten_revision_info.py
+++ b/scripts/get_emscripten_revision_info.py
@@ -34,8 +34,8 @@ if __name__ == '__main__':
     emscripten_hash = get_latest_emscripten(TAGFILE)
     print('Emscripten revision ' + emscripten_hash)
     if 'GITHUB_ENV' in os.environ:
-            with open(os.environ['GITHUB_ENV'], 'a') as f:
-                f.write(f'EMSCRIPTEN_HASH={emscripten_hash}')
-            sys.exit(0)
+        with open(os.environ['GITHUB_ENV'], 'a') as f:
+            f.write(f'EMSCRIPTEN_HASH={emscripten_hash}')
+        sys.exit(0)
     print('Not a GitHub Action')
     sys.exit(1)

--- a/scripts/get_emscripten_revision_info.py
+++ b/scripts/get_emscripten_revision_info.py
@@ -17,8 +17,13 @@ def get_latest_hash(tagfile):
 def get_latest_emscripten(tagfile):
     latest = get_latest_hash(tagfile)
     if not os.path.isdir('emscripten-releases'):
-        subprocess.run(['git', 'clone', EMSCRIPTEN_RELEASES_GIT, '--depth', '100'], check=True)
-    info = subprocess.run(['emscripten-releases/src/release-info.py', 'emscripten-releases', latest],
+        subprocess.run(['git', 'clone', EMSCRIPTEN_RELEASES_GIT, '--depth',
+                        '100'], check=True)
+    # This will fail if the 'latest' revision is not within the most recent
+    # 100 commits; but that shouldn't happen because this script is intended
+    # to be run right after a release is added.
+    info = subprocess.run(['emscripten-releases/src/release-info.py',
+                           'emscripten-releases', latest],
                           stdout=subprocess.PIPE, check=True, text=True).stdout
     for line in info.split('\n'):
         tokens = line.split()

--- a/scripts/get_emscripten_revision_info.py
+++ b/scripts/get_emscripten_revision_info.py
@@ -18,7 +18,7 @@ def get_latest_emscripten(tagfile):
     latest = get_latest_hash(tagfile)
     if not os.path.isdir('emscripten-releases'):
         subprocess.run(['git', 'clone', EMSCRIPTEN_RELEASES_GIT, '--depth', '100'], check=True)
-    info = subprocess.run(['emscripten-releases/src/release-info.py', 'emscripten-releases', latest, '-d'],
+    info = subprocess.run(['emscripten-releases/src/release-info.py', 'emscripten-releases', latest],
                           stdout=subprocess.PIPE, check=True, text=True).stdout
     for line in info.split('\n'):
         tokens = line.split()

--- a/scripts/get_emscripten_revision_info.py
+++ b/scripts/get_emscripten_revision_info.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import sys
+
+EMSCRIPTEN_RELEASES_GIT = 'https://chromium.googlesource.com/emscripten-releases'
+TAGFILE = 'emscripten-releases-tags.json'
+
+def get_latest_hash(tagfile):
+    with open(tagfile) as f:
+        versions = json.load(f)
+        latest = versions['aliases']['latest']
+        return versions['releases'][latest]
+
+def get_latest_emscripten(tagfile):
+    latest = get_latest_hash(tagfile)
+    if not os.path.isdir('emscripten-releases'):
+        subprocess.run(['git', 'clone', EMSCRIPTEN_RELEASES_GIT, '--depth', '100'], check=True)
+    info = subprocess.run(['emscripten-releases/src/release-info.py', 'emscripten-releases', latest, '-d'],
+                          capture_output=True, check=True, text=True).stdout
+    for line in info.split('\n'):
+        tokens = line.split()
+        if len(tokens) and tokens[0] == 'emscripten':
+            return tokens[2]
+
+if __name__ == '__main__':
+    emscripten_hash = get_latest_emscripten(TAGFILE)
+    print('Emscripten revision ' + emscripten_hash)
+    if 'GITHUB_ENV' in os.environ':
+            with open(os.environ['GITHUB_ENV'], 'a') as f:
+                f.write(f'EMSCRIPTEN_HASH={emscripten_hash}')
+            sys.exit(0)
+    print('Not a GitHub Action')
+    sys.exit(1)

--- a/scripts/get_emscripten_revision_info.py
+++ b/scripts/get_emscripten_revision_info.py
@@ -19,7 +19,7 @@ def get_latest_emscripten(tagfile):
     if not os.path.isdir('emscripten-releases'):
         subprocess.run(['git', 'clone', EMSCRIPTEN_RELEASES_GIT, '--depth', '100'], check=True)
     info = subprocess.run(['emscripten-releases/src/release-info.py', 'emscripten-releases', latest, '-d'],
-                          capture_output=True, check=True, text=True).stdout
+                          stdout=subprocess.PIPE, check=True, text=True).stdout
     for line in info.split('\n'):
         tokens = line.split()
         if len(tokens) and tokens[0] == 'emscripten':


### PR DESCRIPTION
This PR add several features to release automation:

1. The existing tag-release job has an output that indicates whether the triggering commit 
    is a release (i.e. whether it matches the regex)
2. The new followup job runs a new script which fetches the recent emscripten-releases
    revisions, reads the DEPS file from the 'latest' release in emscripten-releases-tags.json
    to find the corresponding emscripten revision and writes it into the environment
2. The final step reads the emscripten revision from the environment and creates a
    workflow_dispatch event to run the tag-release.yml job on the emscripten repo