### PR TITLE
Include psutil module in the python build to enable emrun to track when browser process finishes.

### DIFF
--- a/scripts/update_python.py
+++ b/scripts/update_python.py
@@ -148,12 +148,16 @@ def build_python():
 
     install_dir = os.path.join(src_dir, 'install')
 
-    # Install requests module.  This is needed in particualr on macOS to ensure
+    # Install requests module.  This is needed in particular on macOS to ensure
     # SSL certificates are available (certifi in installed and used by requests).
     pybin = os.path.join(src_dir, 'install', 'usr', 'local', 'bin', 'python3')
     pip = os.path.join(src_dir, 'install', 'usr', 'local', 'bin', 'pip3')
     check_call([pybin, '-m', 'ensurepip', '--upgrade'])
     check_call([pybin, pip, 'install', 'requests'])
+
+    # Install psutil module. This is needed by emrun to track when browser
+    # process quits.
+    check_call([pybin, pip, 'install', 'psutil'])
 
     dirname = 'python-%s-%s' % (version, revision)
     if os.path.isdir(dirname):


### PR DESCRIPTION
Without this, emrun web server will be left running after user code quits the page abnormally without calling `exit()` (e.g. due to a page awwsnap crash), and there are multiple processes in use by the browser.

emrun has a graceful fallback to weaker browser process detection when psutil is not available, so this is easy to miss if not running emrun with --verbose: https://github.com/emscripten-core/emscripten/blob/814ec05f74eac9025c0442f51fa09bd8d02f8b43/emrun.py#L330-L339