### PR TITLE
Remove temp zip after uncompressing in update_python.py

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2714,7 +2714,7 @@ def main(args):
     errlog("Missing command; Type 'emsdk help' to get a list of commands.")
     return 1
 
-  debug_print('esmdk.py running under `%s`' % sys.executable)
+  debug_print('emsdk.py running under `%s`' % sys.executable)
   cmd = args.pop(0)
 
   if cmd in ('help', '--help', '-h'):


### PR DESCRIPTION
Remove temp zip after uncompressing in update_python.py to avoid confusing it with the output artifact zip. Adjust comments.