### PR TITLE
Update Node to 20.18.0 LTS and add support for Windows on ARM64 to Node packages.

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -107,6 +107,56 @@
 
 
   {
+    "id": "node",
+    "version": "20.18.0",
+    "bitness": 32,
+    "arch": "x86",
+    "windows_url": "node-v20.18.0-win-x86.zip",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "20.18.0",
+    "arch": "arm",
+    "bitness": 32,
+    "linux_url": "node-v20.18.0-linux-armv7l.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "20.18.0",
+    "bitness": 64,
+    "arch": "x86_64",
+    "macos_url": "node-v20.18.0-darwin-x64.tar.gz",
+    "windows_url": "node-v20.18.0-win-x64.zip",
+    "linux_url": "node-v20.18.0-linux-x64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "20.18.0",
+    "arch": "arm64",
+    "bitness": 64,
+    "windows_url": "node-v20.18.0-win-arm64.zip",
+    "macos_url": "node-v20.18.0-darwin-arm64.tar.gz",
+    "linux_url": "node-v20.18.0-linux-arm64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+
+
+  {
     "id": "python",
     "version": "3.9.2-nuget",
     "bitness": 64,
@@ -318,19 +368,19 @@
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-18.20.3-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.9.2-nuget-64bit", "llvm-git-main-64bit", "node-20.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-18.20.3-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-20.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-18.20.3-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-20.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {

--- a/scripts/update_node.py
+++ b/scripts/update_node.py
@@ -16,13 +16,14 @@ import subprocess
 import os
 import shutil
 
-version = '18.20.3'
-base = 'https://nodejs.org/dist/latest-v18.x/'
+version = '20.18.0'
+base = 'https://nodejs.org/dist/v20.18.0/'
 upload_base = 'gs://webassembly/emscripten-releases-builds/deps/'
 
 suffixes = [
     '-win-x86.zip',
     '-win-x64.zip',
+    '-win-arm64.zip',
     '-darwin-x64.tar.gz',
     '-darwin-arm64.tar.gz',
     '-linux-x64.tar.xz',


### PR DESCRIPTION
Earlier Node 18.20.3 LTS did not yet support Windows on ARM64 builds.

Node 20.18.0 LTS is released on https://nodejs.org/en/blog/release/v20.18.0.

This update currently only affects the "compiled from source" builds, and not the Google precompiled releases.