### PR TITLE
Update release tagging workflow to handle external triggering

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -17,7 +17,8 @@ jobs:
     # The assumption is that when manual changes happen, we want to handle
     # tagging manually too.
     name: Check for release commit and create tag
-    if: github.event.head_commit.author.username == 'github-actions[bot]'
+    # The author is emscripten-bot when triggered from Chromium CI, and github-actions when manually triggered.
+    if: ${ github.event.head_commit.author.username == 'github-actions[bot]' || github.event.head_commit.author.username == 'emscripten-bot' }
     runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.create-tag.outputs.result }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,7 +18,7 @@ jobs:
     # tagging manually too.
     name: Check for release commit and create tag
     # The author is emscripten-bot when triggered from Chromium CI, and github-actions when manually triggered.
-    if: ${ github.event.head_commit.author.username == 'github-actions[bot]' || github.event.head_commit.author.username == 'emscripten-bot' }
+    if: ${{ github.event.head_commit.author.username == 'github-actions[bot]' || github.event.head_commit.author.username == 'emscripten-bot' }}
     runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.create-tag.outputs.result }}


### PR DESCRIPTION
When triggered from Chromium CI, the credential is for the emscripten-bot account.