### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -54,7 +54,7 @@ filegroup(
 
 filegroup(name = "empty")
 
-# dlmalloc.bc is implictly added by the emscripten toolchain
+# dlmalloc.bc is implicitly added by the emscripten toolchain
 cc_library(name = "malloc")
 
 emscripten_cc_toolchain_config_rule(

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,7 @@ RUN echo "## Update and install packages" \
     && apt-get -qq -y update \
     # Somewhere in here apt sets up tzdata which asks for your time zone and blocks
     # waiting for the answer which you can't give as docker build doesn't read from
-    # the terninal. The env vars set here avoid the interactive prompt and set the TZ.
+    # the terminal. The env vars set here avoid the interactive prompt and set the TZ.
     && DEBIAN_FRONTEND="noninteractive" TZ="America/San_Francisco" apt-get -qq install -y --no-install-recommends \
         sudo \
         libxml2 \

--- a/emsdk.py
+++ b/emsdk.py
@@ -1456,7 +1456,7 @@ def get_required_path(active_tools):
       # the tools path to the users path if a program by that name is found
       # in the existing PATH.  This allows us to, for example, add our version
       # node to the users PATH if, and only if, they don't already have a
-      # another version of node in thier PATH.
+      # another version of node in their PATH.
       if hasattr(tool, 'activated_path_skip'):
         current_path = which(tool.activated_path_skip)
         # We found an executable by this name in the current PATH, but we

--- a/scripts/update_bazel_workspace.py
+++ b/scripts/update_bazel_workspace.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# This script will update emsdk/bazel/revisons.bzl to the latest version of
+# This script will update emsdk/bazel/revisions.bzl to the latest version of
 # emscripten. It reads emsdk/emscripten-releases-tags.json to get the latest
 # version number. Then, it downloads the prebuilts for that version and computes
 # the sha256sum for the archive. It then puts all this information into the

--- a/scripts/update_node.py
+++ b/scripts/update_node.py
@@ -8,7 +8,7 @@
 http://storage.google.com/webassembly.
 
 For the windows version we also alter the directory layout to add the 'bin'
-direcotry.
+directory.
 """
 
 import urllib.request

--- a/test/test.bat
+++ b/test/test.bat
@@ -1,4 +1,4 @@
-:: equivilent of test.sh as windows bat file
+:: equivalent of test.sh as windows bat file
 set PATH=%PATH%;%PYTHON_BIN%
 CALL emsdk install latest
 CALL emsdk activate latest

--- a/test/test.py
+++ b/test/test.py
@@ -195,7 +195,7 @@ int main() {
     check_call(upstream_emcc + ' hello_world.c')
 
   def test_closure(self):
-    # Specificlly test with `--closure` so we know that node_modules is working
+    # Specifically test with `--closure` so we know that node_modules is working
     check_call(upstream_emcc + ' hello_world.c --closure=1')
 
   def test_specific_version(self):


### PR DESCRIPTION
# https://pypi.org/project/codespell
% `codespell`
```
./emsdk.py:1459: thier ==> their
./test/test.bat:1: equivilent ==> equivalent
./test/test.py:198: Specificlly ==> Specifically
./scripts/update_bazel_workspace.py:2: revisons ==> revisions
./scripts/update_node.py:11: direcotry ==> directory
./bazel/emscripten_toolchain/BUILD.bazel:57: implictly ==> implicitly
./docker/Dockerfile:87: terninal ==> terminal
```