### PR TITLE
Allow overriding version number in create_release.py

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Run create_release.py
-        run: python3 scripts/create_release.py ${{ inputs.lto-sha }} ${{ inputs.nonlto-sha }} --action
+        run: python3 scripts/create_release.py -r ${{ inputs.lto-sha }} -a ${{ inputs.nonlto-sha }} --action
       - name: Create PR
         id: cpr
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Run create_release.py
-        run: python3 scripts/create_release.py -r ${{ inputs.lto-sha }} -a ${{ inputs.nonlto-sha }} --action
+        run: python3 scripts/create_release.py -r ${{ inputs.lto-sha }} -a ${{ inputs.nonlto-sha }} --gh-action
       - name: Create PR
         id: cpr
         uses: peter-evans/create-pull-request@v6

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -30,7 +30,7 @@ def main():
   parser.add_argument('-r', '--release-hash')
   parser.add_argument('-a', '--asserts-hash')
   parser.add_argument('-v', '--new-version')
-  parser.add_argument('--action', action='store_true')
+  parser.add_argument('--gh-action', action='store_true')
   options = parser.parse_args()
 
   release_info = emsdk.load_releases_info()
@@ -42,14 +42,11 @@ def main():
     new_version = '.'.join(str(part) for part in new_version)
 
   asserts_hash = None
-  is_github_runner = False
   if options.release_hash:
     new_hash = options.release_hash
     asserts_hash = options.asserts_hash
   else:
     new_hash = emsdk.get_emscripten_releases_tot()
-  if options.action:
-      is_github_runner = True
 
   print('Creating new release: %s -> %s' % (new_version, new_hash))
   release_info['releases'][new_version] = new_hash
@@ -73,7 +70,7 @@ def main():
 
   branch_name = 'version_' + new_version
 
-  if is_github_runner:  # For GitHub Actions workflows
+  if options.gh_action:  # For GitHub Actions workflows
     with open(os.environ['GITHUB_ENV'], 'a') as f:
       f.write(f'RELEASE_VERSION={new_version}')
   else:  # Local use

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
 import os
 import re
@@ -20,26 +21,36 @@ def version_key(version_string):
   return key
 
 
-def main(args):
+def main():
   if subprocess.check_output(['git', 'status', '--porcelain'], cwd=root_dir).strip():
     print('tree is not clean')
     sys.exit(1)
 
-  release_info = emsdk.load_releases_info()
-  new_version = version_key(release_info['aliases']['latest'])[0]
-  new_version[-1] += 1
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-r', '--release-hash')
+  parser.add_argument('-a', '--asserts-hash')
+  parser.add_argument('-v', '--new-version')
+  parser.add_argument('--action', action='store_true')
+  options = parser.parse_args()
 
-  new_version = '.'.join(str(part) for part in new_version)
+  release_info = emsdk.load_releases_info()
+  if options.new_version:
+    new_version = options.new_version
+  else:
+    new_version = version_key(release_info['aliases']['latest'])[0]
+    new_version[-1] += 1
+    new_version = '.'.join(str(part) for part in new_version)
+
   asserts_hash = None
   is_github_runner = False
-  if args:
-    new_hash = args[0]
-    if len(args) > 1:
-      asserts_hash = args[1]
-    if len(args) > 2 and args[2] == '--action':
-      is_github_runner = True
+  if options.release_hash:
+    new_hash = options.release_hash
+    asserts_hash = options.asserts_hash
   else:
     new_hash = emsdk.get_emscripten_releases_tot()
+  if options.action:
+      is_github_runner = True
+
   print('Creating new release: %s -> %s' % (new_version, new_hash))
   release_info['releases'][new_version] = new_hash
   if asserts_hash:
@@ -81,4 +92,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-  sys.exit(main(sys.argv[1:]))
+  sys.exit(main())


### PR DESCRIPTION
This changes the CLI syntax for create_relase.py to be more compatible with
argparse, but we don't run it often manually anyway.
