### PR TITLE
[Bazel] Support for feature debug fission in emsdk-bazel-toolchain #1479

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -78,6 +78,18 @@ alias(
     }),
 )
 
+alias(
+    name = "dwp_files",
+    actual = select({
+        ":linux": "@emscripten_bin_linux//:dwp_files",
+        ":linux_arm64": "@emscripten_bin_linux_arm64//:dwp_files",
+        ":macos": "@emscripten_bin_mac//:dwp_files",
+        ":macos_arm64": "@emscripten_bin_mac_arm64//:dwp_files",
+        ":windows": "@emscripten_bin_win//:dwp_files",
+        "//conditions:default": ":empty",
+    }),
+)
+
 platform(
     name = "platform_wasm",
     constraint_values = [

--- a/bazel/emscripten_deps.bzl
+++ b/bazel/emscripten_deps.bzl
@@ -96,6 +96,13 @@ filegroup(
         ],
     ),
 )
+
+filegroup(
+    name = "dwp_files",
+    srcs = [
+        "bin/llvm-dwp{bin_extension}",
+    ],
+)
 """
 
 def emscripten_deps(emscripten_version = "latest"):

--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -44,11 +44,24 @@ filegroup(
 )
 
 filegroup(
+    name = "dwp_files",
+    srcs = [
+        "emdwp-emscripten_bin_linux_arm64.sh",
+        "emdwp-emscripten_bin_linux.sh",
+        "emdwp-emscripten_bin_mac_arm64.sh",
+        "emdwp-emscripten_bin_mac.sh",
+        "emdwp-emscripten_bin_win.bat",
+        "@emsdk//:dwp_files",
+    ],
+)
+
+filegroup(
     name = "all_files",
     srcs = [
         ":ar_files",
         ":compiler_files",
         ":linker_files",
+        ":dwp_files",
     ],
 )
 
@@ -75,7 +88,7 @@ cc_toolchain(
     ar_files = ":ar_files",
     as_files = ":empty",
     compiler_files = ":compiler_files",
-    dwp_files = ":empty",
+    dwp_files = ":dwp_files",
     linker_files = ":linker_files",
     objcopy_files = ":empty",
     strip_files = ":empty",

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec external/emscripten_bin_linux/bin/llvm-dwp "$@"

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
+#
+#  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
+#  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
+#  For more info, see PR discussion and bezel issue:
+#  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
+#  - https://github.com/bazelbuild/bazel/issues/25336
+#
 
 exec external/emscripten_bin_linux/bin/llvm-dwp "$@"

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux.sh
@@ -2,7 +2,7 @@
 #
 #  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
 #  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
-#  For more info, see PR discussion and bezel issue:
+#  For more info, see PR discussion and bazel issue:
 #  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
 #  - https://github.com/bazelbuild/bazel/issues/25336
 #

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux_arm64.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux_arm64.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec external/emscripten_bin_linux_arm64/bin/llvm-dwp "$@"

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux_arm64.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux_arm64.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
+#
+#  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
+#  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
+#  For more info, see PR discussion and bezel issue:
+#  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
+#  - https://github.com/bazelbuild/bazel/issues/25336
+#
 
 exec external/emscripten_bin_linux_arm64/bin/llvm-dwp "$@"

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux_arm64.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_linux_arm64.sh
@@ -2,7 +2,7 @@
 #
 #  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
 #  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
-#  For more info, see PR discussion and bezel issue:
+#  For more info, see PR discussion and bazel issue:
 #  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
 #  - https://github.com/bazelbuild/bazel/issues/25336
 #

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec external/emscripten_bin_mac/bin/llvm-dwp "$@"

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
+#
+#  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
+#  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
+#  For more info, see PR discussion and bezel issue:
+#  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
+#  - https://github.com/bazelbuild/bazel/issues/25336
+#
 
 exec external/emscripten_bin_mac/bin/llvm-dwp "$@"

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac.sh
@@ -2,7 +2,7 @@
 #
 #  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
 #  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
-#  For more info, see PR discussion and bezel issue:
+#  For more info, see PR discussion and bazel issue:
 #  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
 #  - https://github.com/bazelbuild/bazel/issues/25336
 #

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac_arm64.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac_arm64.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec external/emscripten_bin_mac_arm64/bin/llvm-dwp "$@"

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac_arm64.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac_arm64.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
+#
+#  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
+#  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
+#  For more info, see PR discussion and bezel issue:
+#  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
+#  - https://github.com/bazelbuild/bazel/issues/25336
+#
 
 exec external/emscripten_bin_mac_arm64/bin/llvm-dwp "$@"

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac_arm64.sh
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_mac_arm64.sh
@@ -2,7 +2,7 @@
 #
 #  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
 #  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
-#  For more info, see PR discussion and bezel issue:
+#  For more info, see PR discussion and bazel issue:
 #  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
 #  - https://github.com/bazelbuild/bazel/issues/25336
 #

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_win.bat
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_win.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+call external\emscripten_bin_win\bin\llvm-dwp %*

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_win.bat
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_win.bat
@@ -1,7 +1,7 @@
 ::
 ::  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
 ::  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
-::  For more info, see PR discussion and bezel issue:
+::  For more info, see PR discussion and bazel issue:
 ::  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
 ::  - https://github.com/bazelbuild/bazel/issues/25336
 ::

--- a/bazel/emscripten_toolchain/emdwp-emscripten_bin_win.bat
+++ b/bazel/emscripten_toolchain/emdwp-emscripten_bin_win.bat
@@ -1,3 +1,10 @@
+::
+::  This script differs in form from emcc.{py,bat}/…, because bazel are limited/bugged in the way of executing dwp tool.
+::  Bazel dwp action configuration does not pass environment variables, so we cannot use them in this script.
+::  For more info, see PR discussion and bezel issue:
+::  - https://github.com/emscripten-core/emsdk/pull/1531#discussion_r1962090650
+::  - https://github.com/bazelbuild/bazel/issues/25336
+::
 @ECHO OFF
 
 call external\emscripten_bin_win\bin\llvm-dwp %*

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -72,12 +72,14 @@ def _impl(ctx):
 
     emscripten_dir = ctx.attr.emscripten_binaries.label.workspace_root
     nodejs_path = ctx.file.nodejs_bin.path
+    emscripten_name = ctx.attr.emscripten_binaries.label.repo_name
 
     builtin_sysroot = emscripten_dir + "/emscripten/cache/sysroot"
 
     emcc_script = "emcc.%s" % ctx.attr.script_extension
     emcc_link_script = "emcc_link.%s" % ctx.attr.script_extension
     emar_script = "emar.%s" % ctx.attr.script_extension
+    emdwp_script = "emdwp-%s.%s" % (emscripten_name, ctx.attr.script_extension)
 
     ################################################################
     # Tools
@@ -99,6 +101,7 @@ def _impl(ctx):
         tool_path(name = "nm", path = "NOT_USED"),
         tool_path(name = "objdump", path = "/bin/false"),
         tool_path(name = "strip", path = "NOT_USED"),
+        tool_path(name = "dwp", path = emdwp_script),
     ]
 
     ################################################################
@@ -460,6 +463,49 @@ def _impl(ctx):
         feature(
             name = "wasm_standalone",
         ),
+        # Support for debug fission. In short, debugging fission should:
+        #   * reduce linking time, RAM usage and disk usage  
+        #   * speed up incremental builds
+        #   * speed up debugger work (reduce startup and breakpoint time)
+        # (to use this, follow the --fission=yes flag)
+        # https://developer.chrome.com/blog/faster-wasm-debugging
+        # https://bazel.build/docs/user-manual#fission
+        feature(
+            name = "per_object_debug_info",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = ["-g", "-gsplit-dwarf", "-gdwarf-5", "-gpubnames"],
+                            expand_if_available = "per_object_debug_info_file",
+                        ),
+                    ],
+                ),
+            ],
+            enabled = True,
+        ),
+        feature(
+            name = "fission_support",
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = [
+                        flag_group(
+                            flags = ["-sWASM_BIGINT"], # WASM_BIGINT required to support dwarf-5
+                            expand_if_available = "is_using_fission",
+                        ),
+                    ],
+                ),
+            ],
+            enabled = True,
+        )
     ]
 
     crosstool_default_flag_sets = [

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -72,7 +72,7 @@ def _impl(ctx):
 
     emscripten_dir = ctx.attr.emscripten_binaries.label.workspace_root
     nodejs_path = ctx.file.nodejs_bin.path
-    emscripten_name = ctx.attr.emscripten_binaries.label.repo_name
+    emscripten_name = ctx.attr.emscripten_binaries.label.workspace_name
 
     builtin_sysroot = emscripten_dir + "/emscripten/cache/sysroot"
 

--- a/bazel/emscripten_toolchain/wasm_binary.py
+++ b/bazel/emscripten_toolchain/wasm_binary.py
@@ -36,7 +36,7 @@ def main():
 
   if args.dwp_file:
     for idx, output in enumerate(args.outputs):
-      if output.endswith(".dwp"): # also update extension 'binary.dwp' to 'binary.wasm.dwp'
+      if output.endswith(".dwp"):  # also update extension 'binary.dwp' to 'binary.wasm.dwp'
         shutil.copy2(args.dwp_file, output)
         args.outputs.pop(idx)
         break

--- a/bazel/emscripten_toolchain/wasm_binary.py
+++ b/bazel/emscripten_toolchain/wasm_binary.py
@@ -14,7 +14,7 @@ WebAssembly binary into a larger web application.
 import argparse
 import os
 import tarfile
-
+import shutil
 
 def ensure(f):
   if not os.path.exists(f):
@@ -26,11 +26,20 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--archive', help='The archive to extract from.')
   parser.add_argument('--outputs', help='Comma separated list of files that should be extracted from the archive. Only the extname has to match a file in the archive.')
+  parser.add_argument('--dwp_file', help='Optional dwp input file, generated when fission flags set.')
   parser.add_argument('--allow_empty_outputs', help='If an output listed in --outputs does not exist, create it anyways.', action='store_true')
   args = parser.parse_args()
 
   args.archive = os.path.normpath(args.archive)
   args.outputs = args.outputs.split(",")
+  args.dwp_file = os.path.normpath(args.dwp_file) if args.dwp_file else None
+
+  if args.dwp_file:
+    for idx, output in enumerate(args.outputs):
+      if output.endswith(".dwp"): # also update extension 'binary.dwp' to 'binary.wasm.dwp'
+        shutil.copy2(args.dwp_file, output)
+        args.outputs.pop(idx)
+        break
 
   tar = tarfile.open(args.archive)
 

--- a/bazel/emscripten_toolchain/wasm_binary.py
+++ b/bazel/emscripten_toolchain/wasm_binary.py
@@ -16,6 +16,7 @@ import os
 import tarfile
 import shutil
 
+
 def ensure(f):
   if not os.path.exists(f):
     with open(f, 'w'):


### PR DESCRIPTION
Support for debug fission. In short, debugging fission should:
* reduce linking time, RAM usage and disk usage  
* speed up incremental builds
* speed up debugger work (reduce startup and breakpoint time)

To use this, follow the `--fission=yes` flag.

References:
* https://developer.chrome.com/blog/faster-wasm-debugging
* https://bazel.build/docs/user-manual#fission
* https://yurydelendik.github.io/webassembly-dwarf/
* https://www.tweag.io/blog/2023-11-23-debug-fission/#case-study-bazel