### PR TITLE
Do not mark cache generation as local

### DIFF
--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -83,7 +83,6 @@ _emscripten_cache = repository_rule(
         "configuration": attr.string_list(),
         "targets": attr.string_list(),
     },
-    local = True
 )
 
 def register_emscripten_toolchains(cache = {}):


### PR DESCRIPTION
local=True marks a repository rule to unconditionally re-execute anytime bazel re-evaluates the workspace (almost every invocation) It works well for processes that execute in <10ms, not large ones like the embuilder cache generation.

I have tested this locally and it seems to work fine, but I'll be honest that I don't understand the nuances of repository rules that well, nor do I know much of anything about emscripten or the circumstances in which the cache ought to be rebuilt.

I checked the `external/@emscripten_cache.marker` file that Bazel uses to store the cache key for if it needs to re-evaluate, and changing any of the options passed into register_emscripten_toolchains resulted in the cache key changing, and it correctly resulted in the cache being regenerated.

The big question I don't have the context to answer: are there files on disk other than these two that need to be watched for changes, so the repository rule should change if they change:
```
FILE:@@emscripten_bin_linux//BUILD.bazel
FILE:@@emsdk//emscripten_toolchain/default_config
```