### PR TITLE
Update Node.js to LTS 22.16.0.

### DIFF
--- a/bazel/MODULE.bazel
+++ b/bazel/MODULE.bazel
@@ -16,7 +16,7 @@ python.toolchain(
 )
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-node.toolchain(node_version = "22.16.0")
+node.toolchain(node_version = "20.18.0")
 use_repo(node, "nodejs")
 
 emscripten_deps = use_extension(

--- a/bazel/MODULE.bazel.lock
+++ b/bazel/MODULE.bazel.lock
@@ -897,7 +897,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -910,7 +910,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -923,7 +923,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -936,7 +936,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -949,7 +949,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -962,7 +962,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -975,7 +975,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "windows_amd64"
             }

--- a/bazel/test_external/MODULE.bazel.lock
+++ b/bazel/test_external/MODULE.bazel.lock
@@ -897,7 +897,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -910,7 +910,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -923,7 +923,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -936,7 +936,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -949,7 +949,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -962,7 +962,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -975,7 +975,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "windows_amd64"
             }

--- a/bazel/test_secondary_lto_cache/MODULE.bazel.lock
+++ b/bazel/test_secondary_lto_cache/MODULE.bazel.lock
@@ -911,7 +911,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -924,7 +924,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -937,7 +937,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -950,7 +950,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -963,7 +963,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -976,7 +976,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -989,7 +989,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.16.0",
+              "node_version": "20.18.0",
               "include_headers": false,
               "platform": "windows_amd64"
             }


### PR DESCRIPTION
This matches the minimum OS requirements set of macOS 11.0 and Windows 10:

https://github.com/nodejs/node/blob/v22.x/BUILDING.md#platform-list
