### PR TITLE
Fix python search path in emsdk launcher scripts

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -8,9 +8,9 @@
 
 # First look for python bundled in Emsdk
 if [ -z "$EMSDK_PYTHON" ]; then
-  PYTHON3="$(dirname "$0")/python/3.13.3-0_64bit/bin/python3"
+  PYTHON3="$(dirname "$0")/python/3.13.3_64bit/bin/python3"
   if [ ! -f "$PYTHON3" ]; then
-    PYTHON3="$(dirname "$0")/python/3.9.2-1_64bit/bin/python3"
+    PYTHON3="$(dirname "$0")/python/3.9.2_64bit/bin/python3"
   fi
   if [ -f "$PYTHON3" ]; then
     EMSDK_PYTHON="$PYTHON3"

--- a/emsdk.bat
+++ b/emsdk.bat
@@ -8,15 +8,15 @@ setlocal
 :: PYTHONHOME or PYTHONPATH
 :: https://github.com/emscripten-core/emsdk/issues/598
 
-if exist "%~dp0python\3.13.3-0_64bit\python.exe" (
-  set EMSDK_PY="%~dp0python\3.13.3-0_64bit\python.exe"
+if exist "%~dp0python\3.13.3_64bit\python.exe" (
+  set EMSDK_PY="%~dp0python\3.13.3_64bit\python.exe"
   set PYTHONHOME=
   set PYTHONPATH=
   goto end
 )
 
-if exist "%~dp0python\3.9.2-1_64bit\python.exe" (
-  set EMSDK_PY="%~dp0python\3.9.2-1_64bit\python.exe"
+if exist "%~dp0python\3.9.2_64bit\python.exe" (
+  set EMSDK_PY="%~dp0python\3.9.2_64bit\python.exe"
   set PYTHONHOME=
   set PYTHONPATH=
   goto end


### PR DESCRIPTION
The `-0` and `-1` suffixes here are not part of the install path which only based on the `id` and `version` of the tool. e.g:

```
  {
    "id": "python",
    "version": "3.9.2",
    "bitness": 64,
    "arch": "x86_64",
    "windows_url": "python-3.9.2-1-embed-amd64+pywin32.zip",
    "activated_cfg": "PYTHON='%installation_dir%/python.exe'",
    "activated_env": "EMSDK_PYTHON=%installation_dir%/python.exe"
  },
```

Here we have a `-1` in the archive name, but that is not included in the version which is used to construct the install path.

Fixes: #1570