### PR TITLE
Allow switching between overrides

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -862,8 +862,8 @@ def git_pull(repo_path, branch_or_tag, remote_name='origin'):
     if target_is_tag:
       ret = run([GIT(), 'checkout', '--recurse-submodules', '--quiet', branch_or_tag], repo_path)
     else:
-      local_branch_prefix = ('remote_name' + '_') if remote_name != 'origin' else ''
-      ret = run([GIT(), 'checkout', '--recurse-submodules', '--quiet', '-B', 'local_branch_prefix' + 'branch_or_tag',
+      local_branch_prefix = (remote_name + '_') if remote_name != 'origin' else ''
+      ret = run([GIT(), 'checkout', '--recurse-submodules', '--quiet', '-B', local_branch_prefix + branch_or_tag,
                  '--track', remote_name + '/' + branch_or_tag], repo_path)
     if ret != 0:
       return False


### PR DESCRIPTION
Previously, if one used e.g. command

```
emsdk install --override-repository emscripten-main-64bit@https://github.com/juj/emscripten/tree/my_own_emscripten_branch emscripten-main-64bit
```

then the overridden installation would create a git clone from `juj/emscripten`, and that clone would be located under the default remote name `origin`.

This would prevent being able to switch between overrides on subsequent `emsdk install` commands. I.e. it would then not be possible to later do a default

```
emsdk install emscripten-main-64bit
```

command without an override, since the remote name `origin` would point to `juj/emscripten` instead of `emscripten-core/emscripten`.

This PR changes the naming scheme of `git clone`s when `--override-repository` is used, to name the clones with remote names from the override, so in the above case, the clone would appear under remote name `juj` and not `origin`.

This enables flipping between multiple `emsdk install` commands in the same checkout, without needing to nuke the installed directory in between.

This enables me to run experiments like github.com/emscripten-core/emscripten/pull/25025 locally on my CI, without needing to merge them upstream to become available.