### PR TITLE
Nightly Node.js and Big Endian cross compilation Node.js

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -207,13 +207,13 @@
   {
     "id": "node-big-endian-crosscompile",
     "version": "22.16.0",
-    "arch": "x64",
+    "arch": "x86_64",
     "bitness": 64,
     "linux_url": "https://nodejs.org/download/release/v22.16.0/node-v22.16.0-linux-s390x.tar.gz",
     "activated_path": "%installation_dir%/bin",
     "activated_path_skip": "node",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
-    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+    "activated_cfg": "NODE_JS=['qemu-s390x', '-L', '/usr/s390x-linux-gnu/', '%installation_dir%/bin/node']",
+    "activated_env": "EMSDK_NODE=qemu-s390x -L /usr/s390x-linux-gnu/ %installation_dir%/bin/node"
   },
   {
     "id": "node",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -204,6 +204,30 @@
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
+  {
+    "id": "node-big-endian-crosscompile",
+    "version": "22.16.0",
+    "arch": "x64",
+    "bitness": 64,
+    "linux_url": "https://nodejs.org/download/release/v22.16.0/node-v22.16.0-linux-s390x.tar.gz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "nightly",
+    "bitness": 64,
+    "install_path": "node/%latest_downloaded_node_nightly_dir%",
+    "custom_install_script": "build_node_nightly",
+    "activated_path": "node/%latest_downloaded_node_nightly_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%",
+    "url": "https://nodejs.org/download/nightly/%version%/node-%version%-%os%-%arch%.%zip_suffix%",
+    "git_branch": "nightly"
+  },
 
 
   {


### PR DESCRIPTION
This PR adds support for

`./emsdk install node-nightly-64bit`

which finds the latest nightly node.js version and installs that. It is a moving target, so the next day when a new nightly is produced, reissuing `./emsdk install node-nightly-64bit` will install the newer published version.

Also, this PR adds a fixed 22.18.0 version for the cross compilation s390x Node.js target as well. On an x64 Linux system, this allows running

./emsdk install node-big-endian-crosscompile-22.16.0-64bit`

to install the big endian Node.js. This greatly simplifies the steps at https://github.com/emscripten-core/emscripten/compare/main...juj:emscripten:bigendian_test_suite#diff-c36b90121be240017fa490a1c00e63e47fa3235f5c1be0593e2b7502d017c778R9985-R10000 and enables a trivial way to switch between LE and BE Node.js versions for testing.

CC @slavek-kucera