### PR TITLE
Add support for a new command 'emsdk deactivate'

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2835,6 +2835,9 @@ def main(args):
                                   --override-repository emscripten-main@https://github.com/<fork>/emscripten/tree/<refspec>
 
 
+   emsdk deactivate tool/sdk    - Removes the given tool or SDK from the current set of activated tools.
+
+
    emsdk uninstall <tool/sdk>   - Removes the given tool or SDK from disk.''')
 
     if WINDOWS:
@@ -3104,7 +3107,7 @@ def main(args):
   elif cmd == 'update-tags':
     errlog('`update-tags` is not longer needed.  To install the latest tot release just run `install tot`')
     return 0
-  elif cmd == 'activate':
+  elif cmd == 'activate' or cmd =='deactivate':
     if arg_permanent:
       print('Registering active Emscripten environment permanently')
       print('')
@@ -3116,7 +3119,14 @@ def main(args):
         tool = find_sdk(arg)
         if tool is None:
           error_on_missing_tool(arg)
-      tools_to_activate += [tool]
+
+      if cmd == 'activate':
+        tools_to_activate += [tool]
+      elif tool in tools_to_activate:
+        print('Deactivating tool ' + str(tool) + '.')
+        tools_to_activate.remove(tool)
+      else:
+        print('Tool "' + arg + '" was not active, no need to deactivate.')
     if not tools_to_activate:
       errlog('No tools/SDKs specified to activate! Usage:\n   emsdk activate tool/sdk1 [tool/sdk2] [...]')
       return 1


### PR DESCRIPTION
Add support for a new command 'emsdk deactivate' that can be used to remove a tool from the active list.

Since the big endian cross compile Node.js is added to `NODE_JS_TEST` instead of `NODE_JS`, there needs to be a way to deactivate it for regular runs.

This PR adds a `emsdk deactivate` command to enable doing that.