### PR TITLE
Add Node.js 24.7.0 support.

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -499,19 +499,19 @@
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-24.7.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-24.7.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-24.7.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
@@ -523,14 +523,14 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-24.7.0-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-22.16.0-64bit", "releases-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-24.7.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -538,7 +538,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-24.7.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "arm64",
     "custom_install_script": "emscripten_npm_install"
@@ -546,7 +546,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-24.7.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   }

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -214,6 +214,44 @@
     "activated_path_skip": "node",
     "activated_cfg": "NODE_JS_TEST=['qemu-s390x', '-L', '/usr/s390x-linux-gnu/', '%installation_dir%/bin/node']"
   },
+
+  {
+    "id": "node",
+    "version": "24.7.0",
+    "bitness": 64,
+    "arch": "x86_64",
+    "windows_url": "node-v24.7.0-win-x64.zip",
+    "macos_url": "node-v24.7.0-darwin-x64.tar.gz",
+    "linux_url": "node-v24.7.0-linux-x64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node",
+    "version": "24.7.0",
+    "arch": "arm64",
+    "bitness": 64,
+    "windows_url": "node-v24.7.0-win-arm64.zip",
+    "macos_url": "node-v24.7.0-darwin-arm64.tar.gz",
+    "linux_url": "node-v24.7.0-linux-arm64.tar.xz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
+  {
+    "id": "node-big-endian-crosscompile",
+    "version": "24.7.0",
+    "arch": "x86_64",
+    "bitness": 64,
+    "linux_url": "node-v24.7.0-linux-s390x.tar.gz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS_TEST=['qemu-s390x', '-L', '/usr/s390x-linux-gnu/', '%installation_dir%/bin/node']"
+  },
+
   {
     "id": "node",
     "version": "nightly",
@@ -461,19 +499,19 @@
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-24.7.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "win"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-24.7.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-24.7.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
@@ -485,14 +523,14 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-22.16.0-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-24.7.0-64bit", "releases-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "emscripten_npm_install"
   },
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-24.7.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -500,7 +538,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-24.7.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "arm64",
     "custom_install_script": "emscripten_npm_install"
@@ -508,7 +546,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-24.7.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "win",
     "custom_install_script": "emscripten_npm_install"
   }

--- a/scripts/update_node.py
+++ b/scripts/update_node.py
@@ -18,6 +18,10 @@ import os
 import shutil
 from zip import unzip_cmd, zip_cmd
 
+# When adjusting this version, visit
+# https://github.com/nodejs/node/blob/v24.x/BUILDING.md#platform-list
+# to verify minimum supported OS versions. Replace "v24.x" in the URL
+# with the version field.
 version = '24.7.0'
 base = f'https://nodejs.org/dist/v{version}/'
 upload_base = 'gs://webassembly/emscripten-releases-builds/deps/'

--- a/scripts/update_node.py
+++ b/scripts/update_node.py
@@ -18,12 +18,11 @@ import os
 import shutil
 from zip import unzip_cmd, zip_cmd
 
-version = '22.16.0'
+version = '24.7.0'
 base = f'https://nodejs.org/dist/v{version}/'
 upload_base = 'gs://webassembly/emscripten-releases-builds/deps/'
 
 suffixes = [
-    '-win-x86.zip',
     '-win-x64.zip',
     '-win-arm64.zip',
     '-darwin-x64.tar.gz',
@@ -31,6 +30,7 @@ suffixes = [
     '-linux-x64.tar.xz',
     '-linux-arm64.tar.xz',
     '-linux-armv7l.tar.xz',
+    '-linux-s390x.tar.gz'
 ]
 
 for suffix in suffixes:

--- a/scripts/update_node.py
+++ b/scripts/update_node.py
@@ -29,8 +29,7 @@ suffixes = [
     '-darwin-arm64.tar.gz',
     '-linux-x64.tar.xz',
     '-linux-arm64.tar.xz',
-    '-linux-armv7l.tar.xz',
-    '-linux-s390x.tar.gz'
+    '-linux-s390x.tar.gz',
 ]
 
 for suffix in suffixes:


### PR DESCRIPTION
This PR updates Node.js from earlier 22.16.0 to newer 24.7.0.

Remove armv7l and 32-bit Windows, https://github.com/nodejs/nodejs.org/issues/8123