### PR TITLE
Use default python in PATH for circleci windows bot. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,22 +138,17 @@ jobs:
       name: win/server-2019
       shell: bash.exe
     environment:
-      # We need python installed before we can test anytyhing.
-      # There seems to be undocument copy of python installed here. Hopefully
-      # if this disappears there will be another way of getting a re-installed
-      # version.
-      PYTHON_BIN: "C:\\Python27amd64"
       PYTHONUNBUFFERED: "1"
       EMSDK_NOTTY: "1"
     steps:
       - checkout
-      - run:
-          name: Add python to bash path
-          command: echo "export PATH=\"$PATH:/c/python27amd64/\"" >> $BASH_ENV
+      - run: where python
+
       - run:
           name: Install latest
           shell: cmd.exe
           command: test\test.bat
+
       - run:
           name: test.py
           command: |

--- a/test/test.bat
+++ b/test/test.bat
@@ -1,5 +1,4 @@
 :: equivalent of test.sh as windows bat file
-set PATH=%PATH%;%PYTHON_BIN%
 CALL emsdk install latest
 CALL emsdk activate latest
 CALL emsdk_env.bat


### PR DESCRIPTION
`C:\Python312\python.exe` is already in the path by default.

We no longer need to set this special path or environment variable.  In fact this code was doing nothing since it was adding the end of the PATH so the system python was already coming first.

