### PR TITLE
[bazel] Replace deprecated '-g4' flag with '-g3'

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -408,7 +408,7 @@ def _impl(ctx):
             implies = ["profiling"],
         ),
 
-        # Turns on full debug info (-gsource-map).
+        # Turns on full debug info (-g3).
         feature(name = "full_debug_info"),
 
         # Enables the use of "Emscripten" Pthread implementation.
@@ -667,7 +667,7 @@ def _impl(ctx):
             actions = all_compile_actions +
                       all_link_actions,
             flags = [
-                "-gsource-map",
+                "-g3",
                 "-fsanitize=undefined",
                 "-O1",
                 "-DUNDEFINED_BEHAVIOR_SANITIZER=1",
@@ -692,7 +692,7 @@ def _impl(ctx):
         flag_set(
             actions = all_compile_actions +
                       all_link_actions,
-            flags = ["-gsource-map"],
+            flags = ["-g3"],
             features = ["full_debug_info"],
         ),
         flag_set(


### PR DESCRIPTION
- this avoids deprecated flag warnings from emscripten when building with full_debug_info or wasm_ubsan features enabled