### PR TITLE
[ci] Bump xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ executors:
       # brew itself which takes more than 4 minutes.
       HOMEBREW_NO_AUTO_UPDATE: "1"
     macos:
-      xcode: "13.4.1"
+      # Corresponds to macOS 12.6.1
+      # See https://circleci.com/docs/guides/execution-managed/using-macos/#supported-xcode-versions
+      xcode: "14.0.1"
     resource_class: macos.m1.medium.gen1
   linux_arm64:
     machine:


### PR DESCRIPTION
13.4.1 is scheduled for deprecation:
https://circleci.com/changelog/deprecation-of-eol-xcode-versions/

Note that the underlying macOS version is still 12.6.1