### PR TITLE
Add installation of certifi to Python.

### DIFF
--- a/scripts/update_python.py
+++ b/scripts/update_python.py
@@ -39,6 +39,7 @@ major_minor_version = '.'.join(version.split('.')[:2])  # e.g. '3.9.2' -> '3.9'
 # when a version of Python needs to be redownloaded.
 revision = '0'
 
+CERTIFI = 'certifi==2025.10.5'
 PSUTIL = 'psutil==7.0.0'
 
 upload_base = 'gs://webassembly/emscripten-releases-builds/deps/'
@@ -75,6 +76,7 @@ def make_python_patch():
     python_exe = os.path.join(src_dir, 'python.exe')
     check_call([python_exe, '-m', 'ensurepip', '--upgrade'])
     check_call([python_exe, '-m', 'pip', 'install', 'pywin32==310', '--no-warn-script-location'])
+    check_call([python_exe, '-m', 'pip', 'install', CERTIFI])
     check_call([python_exe, '-m', 'pip', 'install', PSUTIL])
 
     check_call(zip_cmd() + [os.path.join('..', '..', out_filename), '.'], cwd=src_dir)


### PR DESCRIPTION
Add installation of certifi to Python. On old macOS versions (macOS Monterey 12.7.6, macOS Ventura 13.7.8), needed Python certificates aren't available otherwise, and emsdk.py will be unable to perform any HTTP downloads via python.
