### PR TITLE
Fix mozdownload of native ARM64 Firefox on Windows-on-ARM.

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1282,6 +1282,8 @@ def download_firefox(tool):
   platform = None
   if LINUX and 'arm' in ARCH:
     platform = 'linux-arm64'
+  if WINDOWS and 'arm' in ARCH:
+    platform = 'win64-aarch64'
 
   if tool.version == 'nightly':
     scraper = FactoryScraper('daily', extension=extension, locale='en-US', platform=platform)


### PR DESCRIPTION
Before mozdownload was downloading x64 artifacts and running them through the Windows Prism emulation.