### PR TITLE
Update CI to run on Ubuntu 22.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   ubuntu:
     docker:
-      - image: buildpack-deps:focal
+      - image: buildpack-deps:jammy
   mac_arm64:
     environment:
       EMSDK_NOTTY: "1"


### PR DESCRIPTION
This allows us compile binaryen from source during CI, which was broken recently.
See https://github.com/WebAssembly/binaryen/issues/8067 and  https://github.com/WebAssembly/binaryen/pull/8071