### PR TITLE
Correctly tag latest built docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
           name: push image
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            make -C ./docker version=${CIRCLE_TAG} alias=${CIRCLE_TAG}-x64 only_alias=true push
+            make -C ./docker version=${CIRCLE_TAG} tag=${CIRCLE_TAG}-x64 push
 
   publish-docker-image-arm64:
     executor: linux_arm64
@@ -254,7 +254,7 @@ jobs:
           name: push image
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            make -C ./docker version=${CIRCLE_TAG} alias=${CIRCLE_TAG}-arm64 only_alias=true push
+            make -C ./docker version=${CIRCLE_TAG} tag=${CIRCLE_TAG}-arm64 push
 
   publish-docker-image-multiplatform:
     executor: linux_arm64
@@ -264,7 +264,8 @@ jobs:
           name: push image
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            make -C ./docker version=${CIRCLE_TAG} alias="latest" push-multiplatform
+            make -C ./docker version=${CIRCLE_TAG} tag=${CIRCLE_TAG} push-multiplatform
+            make -C ./docker version=${CIRCLE_TAG} tag="latest" push-multiplatform
 
   test-bazel7-linux:
     executor: ubuntu

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,8 +3,7 @@
 # Emscripten version to build: Should match the version that has been already released.
 # i.e.:  1.39.18
 version =
-alias =
-only_alias =
+tag =
 
 image_name ?= emscripten/emsdk
 
@@ -22,14 +21,13 @@ test: test_dockerimage.sh .TEST
 	docker run --rm -u `id -u`:`id -g` -w /emsdk/docker --net=host --entrypoint /bin/bash ${image_name}:${version} $<
 
 push: .TEST
-ifndef only_alias
-	docker push ${image_name}:${version}
-endif
-ifdef alias
-	docker tag ${image_name}:${version} ${image_name}:${alias}
-	docker push ${image_name}:${alias}
+ifdef tag
+	docker tag ${image_name}:${version} ${image_name}:${tag}
+	docker push ${image_name}:${tag}
 endif
 
 push-multiplatform: .TEST
-	docker manifest create ${image_name}:${version} $(foreach platform,x64 arm64,--amend ${image_name}:${version}-$(platform))
-	docker manifest push ${image_name}:${version}
+ifdef tag
+	docker manifest create ${image_name}:${tag} $(foreach platform,x64 arm64,--amend ${image_name}:${version}-$(platform))
+	docker manifest push ${image_name}:${tag}
+endif


### PR DESCRIPTION
Additionally removes the `alias` and `only_alias` arguments and adds a single `tag` argument - this makes it clear about the tag being pushed to.

Tested on my fork: https://hub.docker.com/r/radiantly/emsdk

Fixes: #1631