### PR TITLE
Bump min macOS version to 11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ https://emscripten.org/docs/building_from_source/toolchain_what_is_needed.html.
 
 ### Mac OS X
 
-- For Intel-based Macs, macOS 10.13 or newer. For ARM64 M1 based Macs, macOS
-  11.0 or newer.
+- macOS 11.0 or newer.
 - `java`: For running closure compiler (optional).  After installing emscripten
   via emsdk, typing 'emcc --help' should pop up a OS X dialog "Java is not
   installed. To open java, you need a Java SE 6 runtime. Would you like to


### PR DESCRIPTION
We already specify 11.0 for `CMAKE_OSX_DEPLOYMENT_TARGET` in `cmake_configure`

See #1634