### PR TITLE
Fix for window very-long-filename support. NFC

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -574,14 +574,13 @@ def unzip(source_filename, dest_dir):
 
       unzip_to_dir = dest_dir
       if common_subdir:
-        debug_print(f'common_subdir: {common_subdir}')
         unzip_to_dir = os.path.join(os.path.dirname(dest_dir), 'unzip_temp')
 
       # Now do the actual decompress.
-      target_dir = fix_potentially_long_windows_pathname(unzip_to_dir)
+      unzip_to_dir = fix_potentially_long_windows_pathname(unzip_to_dir)
       for member in zf.infolist():
-        zf.extract(member, target_dir)
-        dst_filename = os.path.join(unzip_to_dir, member.filename)
+        zf.extract(member, unzip_to_dir)
+        dst_filename = os.path.join(unzip_to_dir, os.path.normpath(member.filename))
 
         # See: https://stackoverflow.com/questions/42326428/zipfile-in-python-file-permission
         unix_attributes = member.external_attr >> 16


### PR DESCRIPTION
We have a function called `fix_potentially_long_windows_pathname` which is used when unzipping archives under windows.

Without this the unzip process will fail if the total filename length ever exceeds 256.   This change adds a test for installing deep in the filesystem (where pathnames exceed 256) and fixes a bug in this code which was causing the test to fail.

The fact that this code had this bug for god-known-how-long means I think nobody was depending on it, so we could probably just remove it, but maybe better to fix it and add this test?