### PR TITLE
Fix windows test failure. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
     steps:
       - checkout
       - run: where python
-
+      - run: pip install pip-system-certs
       - run:
           name: Install latest
           shell: cmd.exe


### PR DESCRIPTION
This fixes the `CERTIFICATE_VERIFY_FAILED` failure we've been seeing on windows recently running the `test_update_no_git` test.

The test runs `emsdk update` without a git checkout which tries to fetch https://github.com/emscripten-core/emsdk/archive/HEAD.zip, which was generating the `CERTIFICATE_VERIFY_FAILED`.