### PR TITLE
Re-enable test_binaryen_from_source on mac. NFC

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -274,8 +274,6 @@ int main() {
     run_emsdk('activate sdk-tag-1.38.33-64bit')
 
   def test_binaryen_from_source(self):
-    if MACOS:
-      self.skipTest("https://github.com/WebAssembly/binaryen/issues/4299")
     if WINDOWS:
       self.skipTest("https://github.com/emscripten-core/emsdk/issues/1624")
     print('test binaryen source build')


### PR DESCRIPTION
https://github.com/WebAssembly/binaryen/issues/4299 has been fixed.