### PR TITLE
Fix test_binaryen_from_source on windows. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,10 @@ jobs:
       - run: where python
       - run: pip install pip-system-certs
       - run:
+          name: Install packages
+          command: choco install -y cmake.portable ninja pkgconfiglite
+
+      - run:
           name: Install latest
           shell: cmd.exe
           command: test\test.bat

--- a/test/test.py
+++ b/test/test.py
@@ -275,9 +275,9 @@ int main() {
 
   def test_binaryen_from_source(self):
     if WINDOWS:
-      self.skipTest("https://github.com/emscripten-core/emsdk/issues/1624")
-    print('test binaryen source build')
-    run_emsdk(['install', '--build=Release', '--generator=Unix Makefiles', 'binaryen-main-64bit'])
+      # It takes over 30 mins to build binaryen using Visual Studio in CI
+      self.skipTest('test is too slow under windows')
+    run_emsdk(['install', '--build=Release', 'binaryen-main-64bit'])
 
   def test_no_32bit(self):
     print('test 32-bit error')


### PR DESCRIPTION
This fixes the build, but I left it disabled because it takes
over 30 minutes to build.

Fixes: #1624