### PR TITLE
Fix Bazel 9.x compatibility issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,8 +357,7 @@ workflows:
               bazel_version: 
                 - "7.x"
                 - "8.x"
-              # https://github.com/emscripten-core/emsdk/issues/1642
-              # - "9.x"
+                - "9.x"
   test-bazel-mac-arm64:
     jobs:
       - test-bazel-mac-arm64:
@@ -379,5 +378,4 @@ workflows:
               bazel_version: 
                 - "7.7.1"
                 - "8.5.1"
-              # https://github.com/emscripten-core/emsdk/issues/1642  
-              # - "9.0.0"
+                - "9.0.0"

--- a/bazel/MODULE.bazel.lock
+++ b/bazel/MODULE.bazel.lock
@@ -189,7 +189,7 @@
     },
     "//:emscripten_deps.bzl%emscripten_deps": {
       "general": {
-        "bzlTransitiveDigest": "l13dpT30uo2JkUyTZcaXwreRsEt2lTQVOStOPWoZeaI=",
+        "bzlTransitiveDigest": "y6S20gbXD2Z1xg129G+ZN5voikh9/LZq7ibv7boVv2k=",
         "usagesDigest": "GRrT6scRlV2QxKUQntVM6GS5Ax0NopJWqNOSEDLPMbk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -15,7 +15,7 @@ load(
     "with_feature_set",
     _flag_set = "flag_set",
 )
-load("@rules_cc//cc:defs.bzl", "CcToolchainConfigInfo")
+load("@rules_cc//cc:defs.bzl", "CcToolchainConfigInfo", "cc_common")
 
 def flag_set(flags = None, features = None, not_features = None, **kwargs):
     """Extension to flag_set which allows for a "simple" form.

--- a/bazel/remote_emscripten_repository.bzl
+++ b/bazel/remote_emscripten_repository.bzl
@@ -2,7 +2,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 load("//emscripten_toolchain:toolchain.bzl", "emscripten_cc_toolchain_config_rule")
 load(":emscripten_build_file.bzl", "EMSCRIPTEN_BUILD_FILE_CONTENT_TEMPLATE")
-load(":revisions.bzl", "EMSCRIPTEN_TAGS")
 
 def remote_emscripten_repository(
         name,


### PR DESCRIPTION
#### Description 

Enable bazel 9 for linux and windows

The job for bazel 9 and macos arm64 has been excluded because it fails

Related to #1642