### PR TITLE
[Bazel] Remove dependency on system python on Windows too

### DIFF
--- a/bazel/emscripten_toolchain/emar.bat
+++ b/bazel/emscripten_toolchain/emar.bat
@@ -2,4 +2,4 @@
 
 call %~dp0\env.bat
 
-py -3 %EMSCRIPTEN%\emar.py %*
+"%EMSDK_PYTHON%" %EMSCRIPTEN%\emar.py %*

--- a/bazel/emscripten_toolchain/emcc.bat
+++ b/bazel/emscripten_toolchain/emcc.bat
@@ -2,4 +2,4 @@
 
 call %~dp0\env.bat
 
-py -3 %EMSCRIPTEN%\emcc.py %*
+"%EMSDK_PYTHON%" %EMSCRIPTEN%\emcc.py %*

--- a/bazel/emscripten_toolchain/emcc_link.bat
+++ b/bazel/emscripten_toolchain/emcc_link.bat
@@ -2,4 +2,4 @@
 
 call %~dp0\env.bat
 
-py -3 %~dp0\link_wrapper.py %*
+"%EMSDK_PYTHON%" %~dp0\link_wrapper.py %*


### PR DESCRIPTION
This is a followup of #1676.

Just a heads up with those changes (and the ones from #1676), things will not work anymore for projects that don't use an hermetic python toolchain because the interpreter will not be found.

Using the system python is not a great idea anyway, but I just wanted to mention that because that forced our hand in adopting the hermetic toolchain (we were planing on doing it at a later date), and I don't know if this had been considered in #1676.