### PR TITLE
[Bazel] Replace the use of @bazel_tools//src/conditions:host_windows

### DIFF
--- a/bazel/emscripten_toolchain/BUILD.bazel
+++ b/bazel/emscripten_toolchain/BUILD.bazel
@@ -2,11 +2,21 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("//:emscripten_deps.bzl", "emscripten_repo_name")
 load("//:remote_emscripten_repository.bzl", "create_toolchains", "emscripten_toolchain_name")
+load(":platform_info.bzl", "platform_info")
 
 package(default_visibility = ["//visibility:public"])
 
 # dlmalloc.bc is implicitly added by the emscripten toolchain
 cc_library(name = "malloc")
+
+platform_info(
+    name = "platform_info",
+    script_extension = select({
+        "@platforms//os:windows": ".bat",
+        "//conditions:default": ".sh",
+    }),
+    visibility = [":__subpackages__"],
+)
 
 create_toolchains(
     name = emscripten_toolchain_name("linux"),

--- a/bazel/emscripten_toolchain/platform_info.bzl
+++ b/bazel/emscripten_toolchain/platform_info.bzl
@@ -1,0 +1,22 @@
+"""Defines a provider and rule for platform information.
+"""
+
+PlatformInfo = provider(
+    doc = "Provides some info about a platform",
+    fields = {
+        "script_extension": "The script extension for the platform, e.g. '.sh' or '.bat'",
+    },
+)
+
+platform_info = rule(
+    implementation = lambda ctx: PlatformInfo(
+        script_extension = ctx.attr.script_extension,
+    ),
+    attrs = {
+        "script_extension": attr.string(
+            mandatory = True,
+            values = [".sh", ".bat"],
+            doc = "The script extension for the platform, e.g. '.sh' or '.bat'",
+        ),
+    },
+)

--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -16,6 +16,7 @@ load(
     _flag_set = "flag_set",
 )
 load("@rules_cc//cc:defs.bzl", "CcToolchainConfigInfo", "cc_common")
+load(":platform_info.bzl", "PlatformInfo", "platform_info")
 
 def flag_set(flags = None, features = None, not_features = None, **kwargs):
     """Extension to flag_set which allows for a "simple" form.
@@ -56,6 +57,8 @@ CROSSTOOL_DEFAULT_WARNINGS = [
 ]
 
 def _impl(ctx):
+    platform_info = ctx.attr._exec_platform_info[PlatformInfo]
+
     target_cpu = ctx.attr.cpu
     toolchain_identifier = "emscripten-" + target_cpu
     target_system_name = target_cpu + "-unknown-emscripten"
@@ -82,9 +85,9 @@ def _impl(ctx):
 
     builtin_sysroot = emscripten_dir + "/emscripten/cache/sysroot"
 
-    emcc_script = "emcc.%s" % ctx.attr.script_extension
-    emcc_link_script = "emcc_link.%s" % ctx.attr.script_extension
-    emar_script = "emar.%s" % ctx.attr.script_extension
+    emcc_script = "emcc" + platform_info.script_extension
+    emcc_link_script = "emcc_link" + platform_info.script_extension
+    emar_script = "emar" + platform_info.script_extension
 
     ################################################################
     # Tools
@@ -1162,7 +1165,11 @@ emscripten_cc_toolchain_config_rule = rule(
         "em_config": attr.label(mandatory = True, allow_single_file = True),
         "emscripten_binaries": attr.label(mandatory = True, cfg = "exec"),
         "nodejs_bin": attr.label(mandatory = True, allow_single_file = True),
-        "script_extension": attr.string(mandatory = True, values = ["sh", "bat"]),
+        "_exec_platform_info": attr.label(
+            providers = [PlatformInfo],
+            default = Label(":platform_info"),
+            cfg = "exec",
+        ),
     },
     provides = [CcToolchainConfigInfo],
     toolchains = [
@@ -1177,7 +1184,6 @@ def _python_interpreter_files_impl(ctx):
         )
 
     return DefaultInfo(files = python_exec_runtime.files)
-
 
 emscripten_python_interpreter_files = rule(
     implementation = _python_interpreter_files_impl,

--- a/bazel/remote_emscripten_repository.bzl
+++ b/bazel/remote_emscripten_repository.bzl
@@ -116,10 +116,6 @@ def create_toolchains(name, repo_name, exec_compatible_with):
         em_config = "@emscripten_cache//:emscripten_config",
         emscripten_binaries = repo_compiler_files_target,
         nodejs_bin = "@nodejs//:node",
-        script_extension = select({
-            "@bazel_tools//src/conditions:host_windows": "bat",
-            "//conditions:default": "sh",
-        }),
     )
 
     cc_toolchain(


### PR DESCRIPTION
This is a followup of #1682.

This has been deprecated and will be removed in Bazel 10.

This implementation of the platform information retrieval is similar to what is done in Skylib (see https://github.com/bazelbuild/bazel-skylib/blob/56a2abbaf131332835ab2721a258ea3c763a7178/rules/private/copy_file_private.bzl#L117) however this does not use the experimental platform API.

- We define a provider that gives the script extension for a given platform and a rule to instantiate it.
- We define a target with the `platform_info` rule that selects the correct settings based on constraints from `@platform`.
- During toolchain config creation we inject that target **using the `exec` config**.
- We can then retrieve the platform information in the toolchain config (namely the script extension here).

Note that the platform information could have given a simple `is_windows` flag, but I chose this implementation because it matches the previous one more closely.

Note also that it was not possible to keep the `script_extension` attribute as string, because the `cfg` field is not supported on string attributes.