### PR TITLE
Add EMSDK_USE_CURL environment variable to force use of curl

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -720,11 +720,11 @@ def download_file(url, dstpath, download_even_if_exists=False,
   mkdir_p(os.path.dirname(file_name))
 
   try:
-    # Use curl on macOS to avoid CERTIFICATE_VERIFY_FAILED issue with
-    # python's urllib:
+    # Use curl on macOS or when EMSDK_USE_CURL is set to avoid
+    # CERTIFICATE_VERIFY_FAILED issue with python's urllib:
     # https://stackoverflow.com/questions/40684543/how-to-make-python-use-ca-certificates-from-mac-os-truststore
     # Unlike on linux or windows, curl is always available on macOS systems.
-    if MACOS:
+    if MACOS or 'EMSDK_USE_CURL' in os.environ:
       download_with_curl(url, file_name)
     else:
       download_with_urllib(url, file_name)


### PR DESCRIPTION
Corporate environments may force use of a custom CA. `emsdk` uses urllib on all platforms and curl on macos. However, urllib does not have a single universal variable similar to the recently introduced `NODE_USE_SYSTEM_CA` in nodejs that can be set to make it use system CA rather than the included certificate store.

There is an option to use custom CA with urllib by setting some environment variables but there are 2 problems with it. 
1. It requires a dependency to get the certificate store. (This can also be hardcoded if I know the platform)
2. I _think_ I cannot use multiple certificates this way because the environment variables seem to accept a  path to a single file.

It's easier to install curl and use that. 