### PR TITLE
Remove unused LLVM_ENABLE_TERMINFO option llvm build

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1154,7 +1154,7 @@ def build_llvm(tool):
            '-DLLVM_ENABLE_ASSERTIONS=' + ('ON' if enable_assertions else 'OFF'),
            # Disable optional LLVM dependencies, these can cause unwanted .so dependencies
            # that prevent distributing the generated compiler for end users.
-           '-DLLVM_ENABLE_LIBXML2=OFF', '-DLLVM_ENABLE_TERMINFO=OFF', '-DLLDB_ENABLE_LIBEDIT=OFF',
+           '-DLLVM_ENABLE_LIBXML2=OFF', '-DLLDB_ENABLE_LIBEDIT=OFF',
            '-DLLVM_ENABLE_LIBEDIT=OFF', '-DLLVM_ENABLE_LIBPFM=OFF']
   # LLVM build system bug: compiler-rt does not build on Windows. It insists on performing a CMake install step that writes to C:\Program Files. Attempting
   # to reroute that to build_root directory then fails on an error


### PR DESCRIPTION
In this old PR (see this comment https://github.com/emscripten-core/emsdk/pull/1519#issuecomment-4322705279) it was determined that LLVM_ENABLE_TERMINFO could likely be removed since it couldn't be found in the LLVM repo anymore. This PR removes this option.