### PR TITLE
Update Github ci actions to latest versions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run create_release.py
         run: python3 scripts/create_release.py -r ${{ inputs.lto-sha }} -a ${{ inputs.nonlto-sha }} --gh-action
       - name: Create PR
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
           title: Release ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Match message and create tag
         id: create-tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
           # A commit with the message of the form 'Release X.Y.Z' is expected
@@ -58,14 +58,14 @@ jobs:
     if: ${{ needs.tag-release.outputs.is_release == 'true' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Find emscripten revision
         # get_emscripten_revision_info.py sets env.EMSCRIPTEN_HASH to the
         # emscripten hash associated with the latest release in
         # emscripten-releases-tags.json
         run: python3 scripts/get_emscripten_revision_info.py
       - name: Dispatch emscripten workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
           script: |


### PR DESCRIPTION
The actions being used in the Github ci are outdated. These cis are obviously not broken, but thought it might be worth doing. I've been told its best to use a hash instead of a general version to make it use an immutable version. I have added a comment next to each one to make it more obvious as to what version the action is pinned to.