### PR TITLE
[bazel] Remove `linkshared = True` from bazel/test_external/long_command_line

### DIFF
--- a/bazel/test_external/long_command_line/BUILD.bazel
+++ b/bazel/test_external/long_command_line/BUILD.bazel
@@ -48,7 +48,6 @@ _TEST_TARGET_SUFFIXES = [
 cc_binary(
     name = "long_command_line",
     srcs = ["long_command_line.cc"],
-    linkshared = True,
     deps = [":{}_{}".format(target, suffix) for target in _TEST_TARGETS for suffix in _TEST_TARGET_SUFFIXES],
 )
 


### PR DESCRIPTION
I'm not sure why this was originally added as part of  #1373, but its breaking with our transition to using true dynamic linking because bazel currently does not know how to include PIC versions of the standard libraries. 

See #1714