### PR TITLE
Remove explicit .bat extension from emcc. NFC

### DIFF
--- a/test/test.bat
+++ b/test/test.bat
@@ -3,4 +3,4 @@ CALL emsdk install latest
 CALL emsdk activate latest
 CALL emsdk_env.bat
 CALL python -c "import sys; print(sys.executable)"
-CALL emcc.bat -v
+CALL emcc -v


### PR DESCRIPTION
This version should work with both `.bat` and the new `.exe`.