### PR TITLE
[bazel] Remove use of deprecated `-s USE_PTHREADS=1` flag

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -569,12 +569,6 @@ def _impl(ctx):
             features = ["crosstool_cpu_asmjs"],
         ),
         flag_set(
-            actions = all_compile_actions +
-                      all_link_actions,
-            flags = ["-sUSE_PTHREADS"],
-            features = ["use_pthreads"],
-        ),
-        flag_set(
             actions = all_link_actions,
             flags = ["-sEXIT_RUNTIME"],
             features = ["exit_runtime"],


### PR DESCRIPTION
This will silence linker warnings when building binaries with enabled threads.