### PR TITLE
[bazel] Remove EMCC_WASM_BACKEND

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -1093,14 +1093,6 @@ def _impl(ctx):
                 ),
             ],
         ),
-        # Use llvm backend.  Off by default, enabled via --features=llvm_backend
-        env_set(
-            actions = all_compile_actions +
-                      all_link_actions +
-                      [ACTION_NAMES.cpp_link_static_library],
-            env_entries = [env_entry(key = "EMCC_WASM_BACKEND", value = "1")],
-            with_features = [with_feature_set(features = ["llvm_backend"])],
-        ),
         # Debug compile and link. Off by default, enabled via --features=emcc_debug
         env_set(
             actions = all_compile_actions,


### PR DESCRIPTION
This environment variable has not existed for a long time now.