### PR TITLE
[bazel] remove the `llvm_backend` feature

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -433,11 +433,6 @@ def _impl(ctx):
         # Primarily for toolchain maintainers:
         feature(name = "emcc_debug"),
         feature(name = "emcc_debug_link"),
-        feature(
-            name = "llvm_backend",
-            requires = [feature_set(features = ["crosstool_cpu_wasm"])],
-            enabled = True,
-        ),
 
         # Remove once flag is flipped.
         # See https://github.com/bazelbuild/bazel/issues/7687
@@ -448,12 +443,10 @@ def _impl(ctx):
         # Adds simd support, only available with the llvm backend.
         feature(
             name = "wasm_simd",
-            requires = [feature_set(features = ["llvm_backend"])],
         ),
         # Adds relaxed-simd support, only available with the llvm backend.
         feature(
             name = "wasm_relaxed_simd",
-            requires = [feature_set(features = ["llvm_backend"])],
         ),
         feature(
             name = "precise_long_double_printf",
@@ -576,7 +569,7 @@ def _impl(ctx):
         flag_set(
             actions = all_compile_actions + all_link_actions,
             flags = ["-pthread"],
-            features = ["llvm_backend", "use_pthreads"],
+            features = ["use_pthreads"],
         ),
         flag_set(
             actions = all_compile_actions + all_link_actions,

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -17,11 +17,6 @@ def _wasm_transition_impl(settings, attr):
     if attr.exit_runtime == True:
         features.append("exit_runtime")
 
-    if attr.backend == "llvm":
-        features.append("llvm_backend")
-    elif attr.backend == "emscripten":
-        features.append("-llvm_backend")
-
     if attr.simd:
         features.append("wasm_simd")
 
@@ -72,10 +67,6 @@ _ALLOW_OUTPUT_EXTNAMES = [
 ]
 
 _WASM_BINARY_COMMON_ATTRS = {
-    "backend": attr.string(
-        default = "_default",
-        values = ["_default", "emscripten", "llvm"],
-    ),
     "cc_target": attr.label(
         cfg = _wasm_transition,
         mandatory = True,


### PR DESCRIPTION
- this no longer needs to be a feature as it's always implied. Non-LLVM backends are not supported anymore.