### PR TITLE
[bazel] add support for enabling relaxed SIMD in wasm_cc_binary

### DIFF
--- a/bazel/emscripten_toolchain/toolchain.bzl
+++ b/bazel/emscripten_toolchain/toolchain.bzl
@@ -440,13 +440,14 @@ def _impl(ctx):
             name = "do_not_split_linking_cmdline",
         ),
 
-        # Adds simd support, only available with the llvm backend.
+        # Adds simd support
         feature(
             name = "wasm_simd",
         ),
-        # Adds relaxed-simd support, only available with the llvm backend.
+        # Adds relaxed-simd support
         feature(
             name = "wasm_relaxed_simd",
+            implies = ["wasm_simd"],
         ),
         feature(
             name = "precise_long_double_printf",

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -19,9 +19,8 @@ def _wasm_transition_impl(settings, attr):
 
     if attr.simd:
         features.append("wasm_simd")
-
-    if attr.relaxed_simd:
-        features.append("wasm_relaxed_simd")
+        if attr.simd == "relaxed_simd":
+            features.append("wasm_relaxed_simd")
 
     platform = "@emsdk//:platform_wasm"
     if attr.standalone:
@@ -81,11 +80,10 @@ _WASM_BINARY_COMMON_ATTRS = {
         default = "_default",
         values = ["_default", "emscripten", "off"],
     ),
-    "simd": attr.bool(
-        default = False,
-    ),
-    "relaxed_simd": attr.bool(
-        default = False,
+    "simd": attr.string(
+        default = "off",
+        values = ["off", "simd128", "relaxed_simd"],
+        doc = "Enable SIMD support via emscripten.",
     ),
     "standalone": attr.bool(
         default = False,

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -20,6 +20,9 @@ def _wasm_transition_impl(settings, attr):
     if attr.simd:
         features.append("wasm_simd")
 
+    if attr.relaxed_simd:
+        features.append("wasm_relaxed_simd")
+
     platform = "@emsdk//:platform_wasm"
     if attr.standalone:
         platform = "@emsdk//:platform_wasi"
@@ -79,6 +82,9 @@ _WASM_BINARY_COMMON_ATTRS = {
         values = ["_default", "emscripten", "off"],
     ),
     "simd": attr.bool(
+        default = False,
+    ),
+    "relaxed_simd": attr.bool(
         default = False,
     ),
     "standalone": attr.bool(

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -17,7 +17,7 @@ def _wasm_transition_impl(settings, attr):
     if attr.exit_runtime == True:
         features.append("exit_runtime")
 
-    if attr.simd:
+    if attr.simd != "off":
         features.append("wasm_simd")
         if attr.simd == "relaxed_simd":
             features.append("wasm_relaxed_simd")

--- a/bazel/hello-world/BUILD
+++ b/bazel/hello-world/BUILD
@@ -21,3 +21,10 @@ wasm_cc_binary(
     cc_target = ":hello-world-simd",
     simd = True,
 )
+
+wasm_cc_binary(
+    name = "hello-world-wasm-relaxed-simd",
+    cc_target = ":hello-world-simd",
+    simd = True,
+    relaxed_simd = True,
+)

--- a/bazel/hello-world/BUILD
+++ b/bazel/hello-world/BUILD
@@ -19,12 +19,11 @@ wasm_cc_binary(
 wasm_cc_binary(
     name = "hello-world-wasm-simd",
     cc_target = ":hello-world-simd",
-    simd = True,
+    simd = "simd128",
 )
 
 wasm_cc_binary(
     name = "hello-world-wasm-relaxed-simd",
     cc_target = ":hello-world-simd",
-    simd = True,
-    relaxed_simd = True,
+    simd = "relaxed_simd",
 )

--- a/bazel/hello-world/hello-world-simd.cc
+++ b/bazel/hello-world/hello-world-simd.cc
@@ -8,3 +8,42 @@ void multiply_arrays(int* out, int* in_a, int* in_b, int size) {
     wasm_v128_store(&out[i], prod);
   }
 }
+
+#ifdef __wasm_relaxed_simd__
+
+float dot_product_accumulate(const float* A, const float* B, int len, float initial_sum) {
+    int i = 0;
+
+    // Initialize accumulator vector with the initial sum spread across all lanes
+    // We will sum these lanes at the end.
+    v128_t acc = wasm_f32x4_splat(initial_sum);
+
+    // Main loop: process 4 elements at a time
+    // Requires len to be at least 4. If len < 4, the loop is skipped.
+    for (; i + 4 <= len; i += 4) {
+        // Load 4 floats from A and B
+        v128_t va = wasm_v128_load(&A[i]);
+        v128_t vb = wasm_v128_load(&B[i]);
+
+        // Fused Multiply-Add: acc = (va * vb) + acc
+        // Uses relaxed rounding for performance
+        acc = __builtin_wasm_relaxed_madd_f32x4(va, vb, acc);
+    }
+
+    // Horizontal add: sum the 4 lanes of the accumulator
+    // acc = {s0, s1, s2, s3}
+    // sum = s0 + s1 + s2 + s3
+    v128_t sum1 = wasm_f32x4_add(acc, wasm_i32x4_shuffle(acc, acc, 1, 0, 3, 2)); // {s0+s1, s0+s1, s2+s3, s2+s3}
+    v128_t sum2 = wasm_f32x4_add(sum1, wasm_i32x4_shuffle(sum1, sum1, 2, 3, 0, 1)); // {total, total, total, total}
+
+    float result = wasm_f32x4_extract_lane(sum2, 0);
+
+    // Handle remaining elements (tail loop)
+    for (; i < len; i++) {
+        result += A[i] * B[i];
+    }
+
+    return result;
+}
+
+#endif

--- a/test/test_bazel.ps1
+++ b/test/test_bazel.ps1
@@ -8,6 +8,9 @@ if (-not $?) { Exit $LastExitCode }
 bazel build //hello-world:hello-world-wasm-simd
 if (-not $?) { Exit $LastExitCode }
 
+bazel build //hello-world:hello-world-wasm-relaxed-simd
+if (-not $?) { Exit $LastExitCode }
+
 Set-Location test_external
 
 bazel build //:hello-world-wasm

--- a/test/test_bazel.sh
+++ b/test/test_bazel.sh
@@ -22,6 +22,7 @@ cd bazel
 
 bazel build //hello-world:hello-world-wasm
 bazel build //hello-world:hello-world-wasm-simd
+bazel build //hello-world:hello-world-wasm-relaxed-simd
 
 pushd test_external
 bazel build //:hello-world-wasm

--- a/test/test_bazel_mac.sh
+++ b/test/test_bazel_mac.sh
@@ -21,6 +21,7 @@ grep ${VER} bazel/MODULE.bazel || (echo ${FAILMSG} && false)
 cd bazel
 bazel build //hello-world:hello-world-wasm
 bazel build //hello-world:hello-world-wasm-simd
+bazel build //hello-world:hello-world-wasm-relaxed-simd
 
 cd test_external
 bazel build //long_command_line:long_command_line_wasm


### PR DESCRIPTION
It would probably be more elegant to reuse the existing `simd` attribute and change it's type from boolean into string enum (similar like it's for `threads`), but that would be a breaking change so I decided to add additional boolean acknowlidging that `simd=False`, `relaxed_simd=True` makes no sense and will also enable `simd` as `relaxed_simd` implies `simd`.

If you are comfortable with me breaking the API, I'd be happy to do it (see [how I did it in my wrapper](https://github.com/DoDoENT/bazel-playground/pull/62/changes#diff-f8403d920861efa3471626c055b696f82cf2e5d20c5f584a991576fcc6178a05))