### PR TITLE
Drop testing for bazel 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,6 @@ workflows:
           matrix:
             parameters:
               bazel_version: 
-                - "7.x"
                 - "8.x"
                 - "9.x"
   test-bazel-mac-arm64:
@@ -372,7 +371,6 @@ workflows:
           matrix:
             parameters:
               bazel_version: 
-                - "7.x"
                 - "8.x"
                 - "9.x"
   test-bazel-windows:
@@ -383,6 +381,5 @@ workflows:
               # For some reason version resolution with "x.x" does not work on Windows,
               # so we have to specify full versions.
               bazel_version: 
-                - "7.7.1"
                 - "8.5.1"
                 - "9.0.0"

--- a/bazel/emscripten_cache.bzl
+++ b/bazel/emscripten_cache.bzl
@@ -86,10 +86,7 @@ def _emscripten_cache_repository_impl(repository_ctx):
 
         # Use the prebuilt cache
         use_builtin_cache = False
-
-        # Bazel 7 does not have the repo_metadata API, so prebuilt cache on Bazel 7 will not be marked as reproducible. This is not ideal, but it is a limitation of Bazel 7.
-        if hasattr(repository_ctx, "repo_metadata"):
-            repo_metadata = repository_ctx.repo_metadata(reproducible = True)
+        repo_metadata = repository_ctx.repo_metadata(reproducible = True)
 
     elif repository_ctx.attr.targets or repository_ctx.attr.configuration:
         root, script_ext = get_root_and_script_ext(repository_ctx)


### PR DESCRIPTION
The CI for bazel 7 + linux is failing for unknown reasons so maybe its time to simply drop support for this old version.