### PR TITLE
Remove the ninja build-from-source

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1155,41 +1155,6 @@ def build_llvm(tool):
   return success
 
 
-def build_ninja(tool):
-  debug_print(f'build_ninja({tool})')
-  root = os.path.normpath(tool.installation_path())
-  src_root = os.path.join(root, 'src')
-  success = git_clone_checkout_and_pull(tool.url, src_root, tool.git_branch)
-  if not success:
-    return False
-
-  build_dir = llvm_build_dir(tool)
-  build_root = os.path.join(root, build_dir)
-
-  build_type = decide_cmake_build_type(tool)
-
-  # Configure
-  cmake_generator, args = get_generator_and_config_args(tool)
-
-  cmakelists_dir = os.path.join(src_root)
-
-  success = cmake_configure_and_build(cmake_generator, build_root, cmakelists_dir, build_type, args)
-
-  if success:
-    bin_dir = os.path.join(root, 'bin')
-    mkdir_p(bin_dir)
-    exe_paths = [os.path.join(build_root, 'Release', 'ninja'), os.path.join(build_root, 'ninja')]
-    for e in exe_paths:
-      for s in ['.exe', '']:
-        ninja = e + s
-        if os.path.isfile(ninja):
-          dst = os.path.join(bin_dir, 'ninja' + s)
-          shutil.copyfile(ninja, dst)
-          os.chmod(dst, os.stat(dst).st_mode | stat.S_IEXEC)
-
-  return success
-
-
 def build_ccache(tool):
   debug_print(f'build_ccache({tool})')
   root = os.path.normpath(tool.installation_path())
@@ -2128,7 +2093,6 @@ class Tool:
 
     custom_install_scripts = {
       'build_llvm': build_llvm,
-      'build_ninja': build_ninja,
       'build_ccache': build_ccache,
       'download_node_nightly': download_node_nightly,
       'download_firefox': download_firefox,
@@ -2149,7 +2113,7 @@ class Tool:
     if self.custom_install_script:
       if self.custom_install_script == 'emscripten_install':
         success = emscripten_install(self)
-      elif self.custom_install_script in {'build_llvm', 'build_ninja', 'build_ccache', 'download_node_nightly', 'download_firefox'}:
+      elif self.custom_install_script in {'build_llvm', 'build_ccache', 'download_node_nightly', 'download_firefox'}:
         # 'build_llvm' is a special one that does the download on its
         # own, others do the download manually.
         pass

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -644,22 +644,12 @@
     "id": "ninja",
     "version": "1.13.2",
     "bitness": 64,
+    "url_windows": "ninja-1.13.2-winarm64.zip",
+    "url_linux": "ninja-1.13.2-linux-aarch64.zip",
     "url_macos": "ninja-1.13.2-mac.zip",
-    "os": "macos",
     "arch": "arm64",
     "activated_cfg": "NINJA_ROOT='%installation_dir%'",
     "activated_path": "%installation_dir%"
-  },
-  {
-    "id": "ninja",
-    "version": "git-release",
-    "bitness": 64,
-    "url": "https://github.com/ninja-build/ninja.git",
-    "git_branch": "release",
-    "activated_cfg": "NINJA=%installation_dir%/bin",
-    "activated_path": "%installation_dir%/bin",
-    "cmake_build_type": "Release",
-    "custom_install_script": "build_ninja"
   },
   {
     "id": "ccache",


### PR DESCRIPTION
Now that we have ninja binaries available for install (See #1105), I don't think we need to be able to build it from source anymore.

We can treat ninja more like node and/or python and just depend on the binary version of it.

Also, add missing arm64 binaries for ninja for windows and linux, making this binary available on all three OSes on both architectures.