### PR TITLE
Remove redundant assignment in win_set_environment_variable. NFC

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -383,7 +383,7 @@ def win_set_environment_variable(key, value, system, user):
       else:
         cmd = ['REG', 'DELETE', 'HKCU\\Environment', '/V', key, '/f']
       debug_print(str(cmd))
-      value = subprocess.call(cmd, stdout=subprocess.PIPE)
+      subprocess.call(cmd, stdout=subprocess.PIPE)
     except Exception:
       return False
     return True


### PR DESCRIPTION
The assignment of the return code of the process to the local value variable here doesn't make sense and also doesn't do anything.

This code can be traced all the way back to 2ed7a605a9 but IIUC that assignment was meaning less even then.