### PR TITLE
Remove redundant check in `make_build`. NFC

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -964,17 +964,11 @@ def make_build(build_root, build_type):
     make += ['--', '-j', str(CPU_CORES)]
 
   # Build
-  try:
-    print('Running build: ' + str(make))
-    ret = subprocess.check_call(make, cwd=build_root, env=build_env())
-    if ret != 0:
-      errlog(f'Build failed with exit code {ret}!')
-      errlog('Working directory: ' + build_root)
-      return False
-  except Exception as e:
-    errlog('Build failed due to exception!')
+  print('Running build: ' + str(make))
+  ret = subprocess.call(make, cwd=build_root, env=build_env())
+  if ret != 0:
+    errlog(f'Build failed with exit code {ret}!')
     errlog('Working directory: ' + build_root)
-    errlog(str(e))
     return False
 
   return True


### PR DESCRIPTION
The code here seemed to be confused about `call` vs `check_call` When manually checking the return code we use much use `call` rather than `check_call` (the later will throw rather then return non-zero code).

With `call` the only exception that can be thrown would be if the executable (cmake) is not found, but `find_cmake` would already have hard-exited above if it was not found.