### PR TITLE
Update Node.js to v24.19.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,7 @@ COPY --from=stage_build /emsdk /emsdk
 # using `--entrypoint /bin/bash` in CLI).
 # This corresponds to the env variables set during: `source ./emsdk_env.sh`
 ENV EMSDK=/emsdk
-ENV PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/node/22.16.0_64bit/bin:${PATH}"
+ENV PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/node/24.19.0_64bit/bin:${PATH}"
 
 # ------------------------------------------------------------------------------
 

--- a/emsdk.py
+++ b/emsdk.py
@@ -1416,15 +1416,15 @@ def find_latest_installed_tool(name):
 
 def get_node_env():
   node_tool = find_latest_installed_tool('node')
-  if not node_tool:
+  if node_tool:
+    node_path = node_tool.expand_vars(node_tool.activated_path)
+  else:
     npm_fallback = shutil.which('npm')
     if not npm_fallback:
       errlog('Failed to find npm command')
       errlog('npm is required for Emscripten setup. Please install node.js first')
       return None, None
     node_path = os.path.dirname(npm_fallback)
-  else:
-    node_path = os.path.join(node_tool.installation_path(), 'bin')
 
   env = os.environ.copy()
   env["PATH"] = node_path + os.pathsep + env["PATH"]

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -217,36 +217,42 @@
 
   {
     "id": "node",
-    "version": "24.7.0",
+    "version": "24.19.0",
     "bitness": 64,
     "arch": "x86_64",
-    "url_windows": "node-v24.7.0-win-x64.zip",
-    "url_macos": "node-v24.7.0-darwin-x64.tar.gz",
-    "url_linux": "node-v24.7.0-linux-x64.tar.xz",
+    "url_windows": "node-v24.19.0-win-x64.zip",
+    "url_macos": "node-v24.19.0-darwin-x64.tar.gz",
+    "url_linux": "node-v24.19.0-linux-x64.tar.xz",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_windows": "%installation_dir%",
     "activated_path_skip": "node",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
-    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node'",
+    "activated_cfg_windows": "NODE_JS='%installation_dir%/node.exe'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node",
+    "activated_env_windows": "EMSDK_NODE=%installation_dir%/node.exe"
   },
   {
     "id": "node",
-    "version": "24.7.0",
+    "version": "24.19.0",
     "arch": "arm64",
     "bitness": 64,
-    "url_windows": "node-v24.7.0-win-arm64.zip",
-    "url_macos": "node-v24.7.0-darwin-arm64.tar.gz",
-    "url_linux": "node-v24.7.0-linux-arm64.tar.xz",
+    "url_windows": "node-v24.19.0-win-arm64.zip",
+    "url_macos": "node-v24.19.0-darwin-arm64.tar.gz",
+    "url_linux": "node-v24.19.0-linux-arm64.tar.xz",
     "activated_path": "%installation_dir%/bin",
+    "activated_path_windows": "%installation_dir%",
     "activated_path_skip": "node",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
-    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node'",
+    "activated_cfg_windows": "NODE_JS='%installation_dir%/node.exe'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node",
+    "activated_env_windows": "EMSDK_NODE=%installation_dir%/node.exe"
   },
   {
     "id": "node-big-endian-crosscompile",
-    "version": "24.7.0",
+    "version": "24.19.0",
     "arch": "x86_64",
     "bitness": 64,
-    "url_linux": "node-v24.7.0-linux-s390x.tar.gz",
+    "url_linux": "node-v24.19.0-linux-s390x.tar.gz",
     "activated_path": "%installation_dir%/bin",
     "activated_path_skip": "node",
     "activated_cfg": "NODE_JS_TEST=['qemu-s390x', '-L', '/usr/s390x-linux-gnu/', '%installation_dir%/bin/node']"
@@ -672,19 +678,19 @@
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-24.19.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "windows"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["python-3.13.3-64bit", "llvm-git-main-64bit", "node-24.19.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos"
   },
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["llvm-git-main-64bit", "node-22.16.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "uses": ["llvm-git-main-64bit", "node-24.19.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },
   {
@@ -696,14 +702,14 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-22.16.0-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-24.19.0-64bit", "releases-%releases-tag%-64bit"],
     "os": "linux",
     "custom_install_script": "sdk_post_install"
   },
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-24.19.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "sdk_post_install"
@@ -711,7 +717,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-24.19.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "arm64",
     "custom_install_script": "sdk_post_install"
@@ -719,7 +725,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-22.16.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-24.19.0-64bit", "python-3.13.3-64bit", "releases-%releases-tag%-64bit"],
     "os": "windows",
     "custom_install_script": "sdk_post_install"
   }

--- a/scripts/update_node.py
+++ b/scripts/update_node.py
@@ -6,24 +6,18 @@
 
 """Updates the node binaries that we cache store at
 http://storage.google.com/webassembly.
-
-For the windows version we also alter the directory layout to add the 'bin'
-directory.
 """
 
+import argparse
 import os
-import shutil
 import subprocess
-import sys
 import urllib.request
-
-from zip import unzip_cmd, zip_cmd
 
 # When adjusting this version, visit
 # https://github.com/nodejs/node/blob/v24.x/BUILDING.md#platform-list
 # to verify minimum supported OS versions. Replace "v24.x" in the URL
 # with the version field.
-version = '24.7.0'
+version = '24.19.0'
 base = f'https://nodejs.org/dist/v{version}/'
 upload_base = 'gs://webassembly/emscripten-releases-builds/deps/'
 
@@ -37,26 +31,26 @@ suffixes = [
     '-linux-s390x.tar.gz',
 ]
 
-for suffix in suffixes:
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--upload', action='store_true', help='Upload binaries to Google Cloud Storage')
+  args = parser.parse_args()
+
+  for suffix in suffixes:
     filename = 'node-v%s%s' % (version, suffix)
     download_url = base + filename
     print('Downloading: ' + download_url)
     urllib.request.urlretrieve(download_url, filename)
 
-    if '-win-' in suffix:
-      subprocess.check_call([*unzip_cmd(), filename])
-      dirname = os.path.splitext(os.path.basename(filename))[0]
-      shutil.move(dirname, 'bin')
-      os.mkdir(dirname)
-      shutil.move('bin', dirname)
-      os.remove(filename)
-      subprocess.check_call([*zip_cmd(), filename, dirname])
-      shutil.rmtree(dirname)
-
-    if '--upload' in sys.argv:
+    if args.upload:
       upload_url = upload_base + filename
       print('Uploading: ' + upload_url)
       cmd = ['gsutil', 'cp', '-n', filename, upload_url]
       print(' '.join(cmd))
       subprocess.check_call(cmd)
       os.remove(filename)
+
+
+if __name__ == '__main__':
+  main()

--- a/test/test.py
+++ b/test/test.py
@@ -265,9 +265,9 @@ int main() {
 
     # Test the normal tools like node don't re-download on re-install
     print('another install must re-download')
-    checked_call_with_output(emsdk + ' uninstall node-22.16.0-64bit')
-    checked_call_with_output(emsdk + ' install node-22.16.0-64bit', expected='Downloading:', unexpected='already installed')
-    checked_call_with_output(emsdk + ' install node-22.16.0-64bit', unexpected='Downloading:', expected='already installed')
+    checked_call_with_output(emsdk + ' uninstall node-24.19.0-64bit')
+    checked_call_with_output(emsdk + ' install node-24.19.0-64bit', expected='Downloading:', unexpected='already installed')
+    checked_call_with_output(emsdk + ' install node-24.19.0-64bit', unexpected='Downloading:', expected='already installed')
 
   def test_tot_upstream(self):
     print('test update-tags')


### PR DESCRIPTION
Update the version of Node.js shipped with emsdk to the latest LTS.

One additional change here is that since #1761 we can now have a different activated_path for windows to other platforms.  This allows us to use the upstream node archives without modifying the windows versions (they ship node.exe at the top level and not under `bin/`).

Fixes: #1758