### PR TITLE
[emsdk] Assert tool dependencies exist in dependencies methods

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2207,17 +2207,17 @@ class Tool:
 
     for dep in self.deps:
       tool = find_tool(dep)
-      if tool:
-        deps += [tool]
+      assert tool, f"dependency '{dep}' of '{self}' not found"
+      deps += [tool]
     return deps
 
   def recursive_dependencies(self):
     deps = []
     for dep in self.deps:
       tool = find_tool(dep)
-      if tool:
-        deps += [tool]
-        deps += tool.recursive_dependencies()
+      assert tool, f"dependency '{dep}' of '{self}' not found"
+      deps += [tool]
+      deps += tool.recursive_dependencies()
     return deps
 
 


### PR DESCRIPTION
Replace `if tool:` check with an assertion in `dependencies()` and `recursive_dependencies()`. Since `self.deps` is filtered per-OS during manifest loading, any tool listed in `self.deps` is expected to exist.