### PR TITLE
[bazel] Use em++.py in link_wrapper.py for C++ linking

### DIFF
--- a/bazel/emscripten_build_file.bzl
+++ b/bazel/emscripten_build_file.bzl
@@ -29,6 +29,7 @@ filegroup(
     name = "emcc_common",
     srcs = [
         "emscripten/emcc.py",
+        "emscripten/em++.py",
         "emscripten/embuilder.py",
         "emscripten/emscripten-version.txt",
         "emscripten/cache/sysroot_install.stamp",

--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -37,7 +37,7 @@ if any(' ' in a for a in param_file_args):
       f.write('\n')
   sys.argv[1] = '@' + new_param_filename
 
-emcc_py = os.path.join(os.environ['EMSCRIPTEN'], 'emcc.py')
+emcc_py = os.path.join(os.environ['EMSCRIPTEN'], 'em++.py')
 rtn = subprocess.call([sys.executable, emcc_py, *sys.argv[1:]])
 if rtn != 0:
   sys.exit(1)

--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -37,8 +37,8 @@ if any(' ' in a for a in param_file_args):
       f.write('\n')
   sys.argv[1] = '@' + new_param_filename
 
-emcc_py = os.path.join(os.environ['EMSCRIPTEN'], 'em++.py')
-rtn = subprocess.call([sys.executable, emcc_py, *sys.argv[1:]])
+emxx_py = os.path.join(os.environ['EMSCRIPTEN'], 'em++.py')
+rtn = subprocess.call([sys.executable, emxx_py, *sys.argv[1:]])
 if rtn != 0:
   sys.exit(1)
 
@@ -153,7 +153,7 @@ if os.path.exists(wasm_base + '.debug.wasm') and os.path.exists(wasm_base):
 
 # Make sure we have at least one output file.
 if not files:
-  print('emcc.py did not appear to output any known files!')
+  print('em++.py did not appear to output any known files!')
   sys.exit(1)
 
 # cc_binary must output exactly one file; put all the output files in a tarball.


### PR DESCRIPTION
Use em++.py instead of emcc.py in Bazel's `link_wrapper.py`. In recent versions of Emscripten, emcc no longer links as C++ by default.    See  https://github.com/emscripten-core/emscripten/pull/27469.

Since Bazel uses this link wrapper for C++ executable/library linking, invoking em++.py ensures C++ standard library symbols are properly resolved.