### PR TITLE
[docker] Install typescript instead of tsc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,10 +50,10 @@ RUN echo "## Aggressive optimization: Remove debug symbols" \
     && find ${EMSDK}/upstream/bin -type f -exec strip -s {} + || true \
     && echo "## Done"
 
-RUN echo "## Installing tsc" \
+RUN echo "## Installing typescript" \
     && cd ${EMSDK} && . ./emsdk_env.sh \
     && cd ${EMSDK}/upstream/emscripten \
-    && npm install tsc \
+    && npm install typescript \
     && echo "## Done"
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
In #1371, `npm install tsc` was added to `docker/Dockerfile`. However, `tsc` on npm is a placeholder package rather than TypeScript itself. Installing `typescript` provides the `tsc` compiler binary needed for `emcc --emit-tsd`.

See: #1371