### PR TITLE
Remove Tool.__repr__. NFC

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -1862,9 +1862,6 @@ class Tool:
   def __str__(self):
     return self.name
 
-  def __repr__(self):
-    return self.name
-
   def expand_vars(self, str):
     if '%installation_dir%' in str:
       str = str.replace('%installation_dir%', sdk_path(self.installation_dir()))


### PR DESCRIPTION
We already have `__str__` override the works for printing and formatting a single Tool.  I don't think there is any reason override `__repr__` in addition.