### PR TITLE
[bazel] Fix support for .symbols extension in link_wrapper

### DIFF
--- a/bazel/emscripten_toolchain/link_wrapper.py
+++ b/bazel/emscripten_toolchain/link_wrapper.py
@@ -84,7 +84,7 @@ extensions = [
     '.wasm',
     '.wasm.map',
     '.data',
-    '.js.symbols',
+    '.symbols',
     '.wasm.debug.wasm',
     '.html',
     '.ts',

--- a/bazel/emscripten_toolchain/wasm_cc_binary.bzl
+++ b/bazel/emscripten_toolchain/wasm_cc_binary.bzl
@@ -61,7 +61,7 @@ _ALLOW_OUTPUT_EXTNAMES = [
     ".wasm",
     ".wasm.map",
     ".data",
-    ".js.symbols",
+    ".symbols",
     ".wasm.debug.wasm",
     ".html",
     ".ts",
@@ -186,7 +186,7 @@ def _wasm_binary_legacy_outputs(name, cc_target):
         "wasm": "{}/{}.wasm".format(name, basename),
         "map": "{}/{}.wasm.map".format(name, basename),
         "data": "{}/{}.data".format(name, basename),
-        "symbols": "{}/{}.js.symbols".format(name, basename),
+        "symbols": "{}/{}.symbols".format(name, basename),
         "dwarf": "{}/{}.wasm.debug.wasm".format(name, basename),
         "html": "{}/{}.html".format(name, basename),
     }

--- a/bazel/test_external/BUILD
+++ b/bazel/test_external/BUILD
@@ -4,6 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "hello-world",
     srcs = ["hello-world.cc"],
+    linkopts = ["--emit-symbol-map"],
 )
 
 wasm_cc_binary(
@@ -12,6 +13,7 @@ wasm_cc_binary(
     outputs = [
         "hello-world.js",
         "hello-world.wasm",
+        "hello-world.symbols",
     ],
 )
 

--- a/test/test_bazel.sh
+++ b/test/test_bazel.sh
@@ -26,6 +26,7 @@ bazel build //hello-world:hello-world-wasm-relaxed-simd
 
 pushd test_external
 bazel build //:hello-world-wasm
+test -f bazel-bin/hello-world.symbols
 bazel build //long_command_line:long_command_line_wasm
 bazel build //:hello-embind-wasm --compilation_mode dbg # debug
 


### PR DESCRIPTION
Update link_wrapper.py and wasm_cc_binary.bzl to look for and allow .symbols output extension instead of .js.symbols, matching emcc's output naming scheme for symbol maps.

Fixes: #1092