### PR TITLE
Fix PowerShell scripts to support StrictMode

### DIFF
--- a/emsdk.ps1
+++ b/emsdk.ps1
@@ -1,4 +1,4 @@
-Set-StrictMode -Version latest
+Set-StrictMode -Version 3.0
 
 $ScriptDirectory = Split-Path -parent $PSCommandPath
 

--- a/emsdk.ps1
+++ b/emsdk.ps1
@@ -1,4 +1,8 @@
+Set-StrictMode -Version latest
+
 $ScriptDirectory = Split-Path -parent $PSCommandPath
+
+$EMSDK_PY = $null
 
 $PythonLocations = $(
     "python\3.13.3_64bit\python.exe",
@@ -32,9 +36,9 @@ $ExitCode = $LASTEXITCODE
 # to set up the environment variables
 if ($ExitCode -eq 0 -and (Test-Path $ScriptDirectory/emsdk_set_env.ps1)) {
     & $ScriptDirectory/emsdk_set_env.ps1
-    Remove-Item $ScriptDirectory/emsdk_set_env.ps1
+    Remove-Item $ScriptDirectory/emsdk_set_env.ps1 -ErrorAction SilentlyContinue
 }
 
-Remove-Item Env:\EMSDK_POWERSHELL
+Remove-Item Env:\EMSDK_POWERSHELL -ErrorAction SilentlyContinue
 
 exit $ExitCode

--- a/emsdk.py
+++ b/emsdk.py
@@ -2764,7 +2764,7 @@ def construct_env(tools_to_activate, system, user):
 
 def unset_env(key):
   if POWERSHELL:
-    return 'Remove-Item env:%s\n' % key
+    return 'Remove-Item env:%s -ErrorAction SilentlyContinue\n' % key
   if CMD:
     return 'set %s=\n' % key
   if CSH:

--- a/emsdk_env.ps1
+++ b/emsdk_env.ps1
@@ -1,2 +1,4 @@
+Set-StrictMode -Version latest
+
 $ScriptDirectory = Split-Path -parent $PSCommandPath
 & "$ScriptDirectory/emsdk.ps1" construct_env

--- a/emsdk_env.ps1
+++ b/emsdk_env.ps1
@@ -1,4 +1,4 @@
-Set-StrictMode -Version latest
+Set-StrictMode -Version 3.0
 
 $ScriptDirectory = Split-Path -parent $PSCommandPath
 & "$ScriptDirectory/emsdk.ps1" construct_env

--- a/test/test_activation.ps1
+++ b/test/test_activation.ps1
@@ -2,7 +2,7 @@
 # and checks if the environment variables and PATH are correctly updated. Set $env:SYSTEM_FLAG and $env:PERMANENT_FLAG to test each.
 # If no flag is provided the process/shell values are tested. See the CI file for an example.
 
-Set-StrictMode -Version latest
+Set-StrictMode -Version 3.0
 
 refreshenv
 

--- a/test/test_activation.ps1
+++ b/test/test_activation.ps1
@@ -2,6 +2,8 @@
 # and checks if the environment variables and PATH are correctly updated. Set $env:SYSTEM_FLAG and $env:PERMANENT_FLAG to test each.
 # If no flag is provided the process/shell values are tested. See the CI file for an example.
 
+Set-StrictMode -Version latest
+
 refreshenv
 
 $repo_root = [System.IO.Path]::GetDirectoryName((resolve-path "$PSScriptRoot"))

--- a/test/test_bazel.ps1
+++ b/test/test_bazel.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version latest
 
 Set-Location bazel
 

--- a/test/test_bazel.ps1
+++ b/test/test_bazel.ps1
@@ -1,5 +1,5 @@
 $ErrorActionPreference = 'Stop'
-Set-StrictMode -Version latest
+Set-StrictMode -Version 3.0
 
 Set-Location bazel
 

--- a/test/test_path_preservation.ps1
+++ b/test/test_path_preservation.ps1
@@ -2,6 +2,8 @@
 # and checks if parts of PATH are lost or overwritten. Set $env:SYSTEM_FLAG and $env:PERMANENT_FLAG to test each.
 # If no flag is provided the process/shell values are tested. See the CI file for an example.
 
+Set-StrictMode -Version latest
+
 refreshenv
 
 $repo_root = [System.IO.Path]::GetDirectoryName((resolve-path "$PSScriptRoot"))

--- a/test/test_path_preservation.ps1
+++ b/test/test_path_preservation.ps1
@@ -2,7 +2,7 @@
 # and checks if parts of PATH are lost or overwritten. Set $env:SYSTEM_FLAG and $env:PERMANENT_FLAG to test each.
 # If no flag is provided the process/shell values are tested. See the CI file for an example.
 
-Set-StrictMode -Version latest
+Set-StrictMode -Version 3.0
 
 refreshenv
 


### PR DESCRIPTION
Add `Set-StrictMode -Version latest` to PowerShell scripts. Initialize `$EMSDK_PY` to `$null` and use `-ErrorAction SilentlyContinue` when removing environment variables so execution under strict mode does not fail on uninitialized variables or missing env items.

Fixes: #1337